### PR TITLE
Bollard v0.2.0 archive API

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,17 +41,7 @@ jobs:
       - checkout
       - setup_remote_docker
       - run: docker build -t bollard .
-      - run: docker run -d --restart always --name registry -p 5000:5000 registry:2
-      - run: docker pull hello-world:linux
-      - run: docker pull fnichol/uhttpd
-      - run: docker pull alpine
-      - run: docker tag hello-world:linux localhost:5000/hello-world:linux
-      - run: docker tag fnichol/uhttpd localhost:5000/fnichol/uhttpd
-      - run: docker tag alpine localhost:5000/alpine
-      - run: docker push localhost:5000/hello-world:linux
-      - run: docker push localhost:5000/fnichol/uhttpd
-      - run: docker push localhost:5000/alpine
-      - run: docker run -e REGISTRY_HTTP_ADDR=localhost:5000 -v /var/run/docker.sock:/var/run/docker.sock -ti --rm bollard cargo test -- --test-threads 1
+      - run: dockerfiles/bin/run_integration_tests.sh
   test_doc:
     docker:
       - image: docker:18.09.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,43 +22,43 @@ test_http = []
 test_tls = []
 
 [dependencies]
-failure = "0.1.2"
-hyper = { version = "0.12.17" }
-hyper-tls = "0.3.0"
-openssl = { version = "0.10.11", optional = true }
-hyper-openssl = { version = "0.6.1", optional = true }
-serde = "1.0"
-serde_derive = "1.0"
-serde_json = "1.0"
-url = "1.2.2"
-http = "0.1.10"
-native-tls = "0.2.1"
-futures = "0.1.24"
-tokio = "0.1.11"
-tokio-reactor = "0.1.4"
-hex = "0.3.2"
-tokio-io = "0.1.8"
-bytes = "0.4.9"
-mio = "0.6.15"
-tokio-codec = "0.1.0"
-chrono = { version = "0.4.6", features = ["serde"] }
-arrayvec = "0.4.7"
-dirs = "1.0.4"
-log = "0.4.6"
-env_logger = "0.6.0"
-tokio-timer = "0.2.8"
+arrayvec = "0.4.10"
 base64 = "0.10.0"
+bytes = "0.4.11"
+chrono = { version = "0.4.6", features = ["serde"] }
+dirs = "1.0.4"
+env_logger = "0.6.0"
+failure = "0.1.5"
+futures = "0.1.25"
+hex = "0.3.2"
+http = "0.1.15"
+hyper = { version = "0.12.23" }
+hyper-openssl = { version = "0.7.0", optional = true }
+hyper-tls = "0.3.1"
+log = "0.4.6"
+mio = "0.6.16"
+native-tls = "0.2.2"
+openssl = { version = "0.10.16", optional = true }
+serde = "1.0.85"
+serde_derive = "1.0.85"
+serde_json = "1.0.37"
+tokio = "0.1.11"
+tokio-codec = "0.1.1"
+tokio-io = "0.1.11"
+tokio-reactor = "0.1.8"
+tokio-timer = "0.2.9"
+url = "1.7.2"
 
 [dev-dependencies]
-yup-hyper-mock = "3.14.0"
-tokio-threadpool = "0.1.7"
-tokio-executor = "0.1.5"
-tar = "0.4.20"
+tokio-executor = "0.1.6"
+tokio-threadpool = "0.1.11"
 flate2 = "1.0"
+tar = "0.4.20"
+yup-hyper-mock = "3.14.0"
 
 [target.'cfg(unix)'.dependencies]
 hyperlocal = "0.6.0"
 
 [target.'cfg(windows)'.dependencies]
 mio-named-pipes = "0.1.6"
-winapi = "0.3.5"
+winapi = "0.3.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,7 @@ dirs = "1.0.4"
 log = "0.4.6"
 env_logger = "0.6.0"
 tokio-timer = "0.2.8"
+base64 = "0.10.0"
 
 [dev-dependencies]
 yup-hyper-mock = "3.14.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "bollard"
 description = "An asynchronous Docker daemon API"
-version = "0.1.3"
+version = "0.2.0"
 authors = ["Graham Lee <ghmlee@ghmlee.com>",
            "Toby Lawrence <toby@nuclearfurnace.com>",
            "Eric Kidd <git@randomhacks.net>",

--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ use std::default::Default;
 docker.chain().create_image(Some(CreateImageOptions{
     from_image: "hello-world",
     ..Default::default()
-})).and_then(|(docker, _)|
+}), None).and_then(|(docker, _)|
     docker.create_container(
         None::<CreateContainerOptions<String>>,
         Config {
@@ -280,7 +280,7 @@ docker tag alpine localhost:5000/alpine
 docker push localhost:5000/hello-world:linux
 docker push localhost:5000/fnichol/uhttpd
 docker push localhost:5000/alpine
-REGISTRY_HTTP_ADDR=localhost:5000 cargo test --test-threads 1
+REGISTRY_HTTP_ADDR=localhost:5000 cargo test -- --test-threads 1
 ```
 
 License: Apache-2.0

--- a/dockerfiles/bin/run_integration_tests.sh
+++ b/dockerfiles/bin/run_integration_tests.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+#
+# Creates a htpasswd file and bootstraps a docker registry with user 'bollard'.
+# Pulls all the images needed to run the integration suite and pushes them to
+# the registry. Finally, runs the tests.
+
+export REGISTRY_PASSWORD=$(date | md5sum | cut -f1 -d\ )
+docker create -v /etc/docker/registry --name config alpine:3.4 /bin/true
+echo -n "${REGISTRY_PASSWORD}" | docker run --rm -i --entrypoint=htpasswd --volumes-from config nimmis/alpine-apache -i -B -c /etc/docker/registry/htpasswd bollard
+cat dockerfiles/registry/config.yml | docker run --rm -i --volumes-from config --entrypoint=tee alpine:3.4 /etc/docker/registry/config.yml
+docker run -d --restart always --name registry -p 5000:5000 --volumes-from config registry:2
+docker login --username bollard --password "${REGISTRY_PASSWORD}" localhost:5000
+docker pull hello-world:linux
+docker pull fnichol/uhttpd
+docker pull alpine
+docker tag hello-world:linux localhost:5000/hello-world:linux
+docker tag fnichol/uhttpd localhost:5000/fnichol/uhttpd
+docker tag alpine localhost:5000/alpine
+docker push localhost:5000/hello-world:linux
+docker push localhost:5000/fnichol/uhttpd
+docker push localhost:5000/alpine
+docker run -e RUST_LOG=bollard=debug -e REGISTRY_PASSWORD -e REGISTRY_HTTP_ADDR=localhost:5000 -v /var/run/docker.sock:/var/run/docker.sock -ti --rm bollard cargo test -- --test-threads 1

--- a/dockerfiles/registry/README
+++ b/dockerfiles/registry/README
@@ -1,0 +1,2 @@
+This configuration serves to bootstrap the docker Registry with an
+authenticated user for integration testing purposes.

--- a/dockerfiles/registry/config.yml
+++ b/dockerfiles/registry/config.yml
@@ -1,0 +1,22 @@
+version: 0.1
+log:
+  fields:
+    service: registry
+storage:
+  cache:
+    blobdescriptor: inmemory
+  filesystem:
+    rootdirectory: /var/lib/registry
+http:
+  addr: :5000
+  headers:
+    X-Content-Type-Options: [nosniff]
+health:
+  storagedriver:
+    enabled: true
+    interval: 10s
+    threshold: 3
+auth:
+  htpasswd:
+    realm: localhost:5000
+    path: /etc/docker/registry/htpasswd

--- a/examples/kafka.rs
+++ b/examples/kafka.rs
@@ -107,10 +107,13 @@ fn main() {
 
     let stream = docker1
         .chain()
-        .create_image(Some(CreateImageOptions {
-            from_image: ZOOKEEPER_IMAGE,
-            ..Default::default()
-        }))
+        .create_image(
+            Some(CreateImageOptions {
+                from_image: ZOOKEEPER_IMAGE,
+                ..Default::default()
+            }),
+            None,
+        )
         .and_then(move |(docker, _)| {
             docker.create_container(
                 Some(CreateContainerOptions { name: "zookeeper" }),
@@ -122,20 +125,26 @@ fn main() {
         })
         .map(|(docker, _)| {
             let stream1 = docker
-                .create_image(Some(CreateImageOptions {
-                    from_image: KAFKA_IMAGE,
-                    ..Default::default()
-                }))
+                .create_image(
+                    Some(CreateImageOptions {
+                        from_image: KAFKA_IMAGE,
+                        ..Default::default()
+                    }),
+                    None,
+                )
                 .map(move |(docker, _)| create_and_logs(docker, "kafka1", broker1_config))
                 .into_stream()
                 .flatten();
 
             let stream2 = docker2
                 .chain()
-                .create_image(Some(CreateImageOptions {
-                    from_image: KAFKA_IMAGE,
-                    ..Default::default()
-                }))
+                .create_image(
+                    Some(CreateImageOptions {
+                        from_image: KAFKA_IMAGE,
+                        ..Default::default()
+                    }),
+                    None,
+                )
                 .map(move |(docker, _)| create_and_logs(docker, "kafka2", broker2_config))
                 .into_stream()
                 .flatten();

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -8,6 +8,9 @@
 pub struct DockerCredentials {
     pub username: Option<String>,
     pub password: Option<String>,
+    pub auth: Option<String>,
     pub email: Option<String>,
     pub serveraddress: Option<String>,
+    pub identitytoken: Option<String>,
+    pub registrytoken: Option<String>,
 }

--- a/src/container.rs
+++ b/src/container.rs
@@ -2502,7 +2502,7 @@ where
     ///
     /// # Returns
     ///
-    ///  - ???
+    ///  - unit type `()`, wrapped in a Future.
     ///
     /// # Examples
     ///
@@ -2563,7 +2563,8 @@ where
     ///
     /// # Returns
     ///
-    ///  - a Hyper Body
+    ///  - Tar archive compressed with one of the following algorithms: identity (no compression),
+    ///    gzip, bzip2, xz. [Hyper Body](https://hyper.rs/hyper/master/hyper/struct.Body.html).
     ///
     /// # Examples
     ///
@@ -3415,7 +3416,8 @@ where
     ///
     /// # Returns
     ///
-    ///  - ???
+    ///  - A Tuple containing the original [DockerChain](struct.Docker.html) instance, and the unit
+    ///  type `()`, wrapped in a Future.
     ///
     /// # Examples
     ///
@@ -3468,7 +3470,10 @@ where
     ///
     /// # Returns
     ///
-    ///  - a Hyper Body
+    ///  - A Tuple containing the original [DockerChain](struct.Docker.html) instance, and a tar
+    ///  archive compressed with one of the following algorithms: identity (no compression), gzip,
+    ///  bzip2, xz, represented as a [Hyper
+    ///  Body](https://hyper.rs/hyper/master/hyper/struct.Body.html), wrapped in a Future.
     ///
     /// # Examples
     ///

--- a/src/image.rs
+++ b/src/image.rs
@@ -804,8 +804,7 @@ impl<'a> BuildImageQueryParams<&'a str> for BuildImageOptions<&'a str> {
                 self.cpuperiod.map(|v| ("cpuperiod", v.to_string())),
                 self.cpuquota.map(|v| ("cpuperiod", v.to_string())),
                 self.shmsize.map(|v| ("shmsize", v.to_string())),
-            ]
-            .into_iter()
+            ].into_iter()
             .flatten(),
         );
 
@@ -841,8 +840,7 @@ impl<'a> BuildImageQueryParams<&'a str> for BuildImageOptions<String> {
                 self.cpuperiod.map(|v| ("cpuperiod", v.to_string())),
                 self.cpuquota.map(|v| ("cpuperiod", v.to_string())),
                 self.shmsize.map(|v| ("shmsize", v.to_string())),
-            ]
-            .into_iter()
+            ].into_iter()
             .flatten(),
         );
 

--- a/src/image.rs
+++ b/src/image.rs
@@ -13,6 +13,7 @@ use hyper::rt::Future;
 use hyper::{Body, Method};
 use serde::Serialize;
 use serde_json;
+use base64;
 
 use super::{Docker, DockerChain};
 use auth::DockerCredentials;

--- a/src/image.rs
+++ b/src/image.rs
@@ -855,23 +855,23 @@ impl<'a> BuildImageQueryParams<&'a str> for BuildImageOptions<String> {
 #[serde(deny_unknown_fields)]
 pub struct BuildImageAuxDetail {
     #[serde(rename = "ID")]
-    id: String,
+    pub id: String,
 }
 
 /// Subtype for the [Build Image Results](struct.BuildImageResults.html) type.
 #[derive(Debug, Clone, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct BuildImageErrorDetail {
-    code: Option<u64>,
-    message: String,
+    pub code: Option<u64>,
+    pub message: String,
 }
 
 /// Subtype for the [Build Image Results](struct.BuildImageResults.html) type.
 #[derive(Debug, Clone, Copy, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct BuildImageProgressDetail {
-    current: Option<u64>,
-    total: Option<u64>,
+    pub current: Option<u64>,
+    pub total: Option<u64>,
 }
 
 /// Result type for the [Build Image API](../struct.Docker.html#method.build_image)

--- a/src/image.rs
+++ b/src/image.rs
@@ -990,7 +990,7 @@ where
     ///   ..Default::default()
     /// });
     ///
-    /// docker.create_image(options);
+    /// docker.create_image(options, None);
     ///
     /// // do some other work while the image is pulled from the docker hub...
     /// ```
@@ -1243,7 +1243,7 @@ where
     ///     ..Default::default()
     /// });
     ///
-    /// docker.remove_image("hello-world", remove_options);
+    /// docker.remove_image("hello-world", remove_options, None);
     /// ```
     pub fn remove_image<T, K, V>(
         &self,
@@ -1353,6 +1353,8 @@ where
     /// use bollard::auth::DockerCredentials;
     /// use bollard::image::PushImageOptions;
     ///
+    /// use std::default::Default;
+    ///
     /// # let docker = Docker::connect_with_http_defaults().unwrap();
     /// let push_options = Some(PushImageOptions {
     ///     tag: "v1.0.1",
@@ -1361,8 +1363,7 @@ where
     /// let credentials = Some(DockerCredentials {
     ///     username: Some("Jack".to_string()),
     ///     password: Some("myverysecretpassword".to_string()),
-    ///     email: Some("jack.smith@example.com".to_string()),
-    ///     serveraddress: Some("localhost:5000".to_string())
+    ///     ..Default::default()
     /// });
     ///
     /// docker.push_image("hello-world", push_options, credentials);
@@ -1572,7 +1573,7 @@ where
     ///   ..Default::default()
     /// });
     ///
-    /// docker.chain().create_image(options);
+    /// docker.chain().create_image(options, None);
     ///
     /// // do some other work while the image is pulled from the docker hub...
     /// ```
@@ -1678,6 +1679,8 @@ where
     /// use bollard::auth::DockerCredentials;
     /// use bollard::image::PushImageOptions;
     ///
+    /// use std::default::Default;
+    ///
     /// # let docker = Docker::connect_with_http_defaults().unwrap();
     /// let push_options = Some(PushImageOptions {
     ///     tag: "v1.0.1",
@@ -1686,8 +1689,7 @@ where
     /// let credentials = Some(DockerCredentials {
     ///     username: Some("Jack".to_string()),
     ///     password: Some("myverysecretpassword".to_string()),
-    ///     email: Some("jack.smith@example.com".to_string()),
-    ///     serveraddress: Some("localhost:5000".to_string())
+    ///     ..Default::default()
     /// });
     ///
     /// docker.push_image("hello-world", push_options, credentials);
@@ -1738,7 +1740,7 @@ where
     ///     ..Default::default()
     /// });
     ///
-    /// docker.chain().remove_image("hello-world", remove_options);
+    /// docker.chain().remove_image("hello-world", remove_options, None);
     /// ```
     pub fn remove_image<T, K, V>(
         self,
@@ -2291,7 +2293,7 @@ mod tests {
             ..Default::default()
         };
 
-        let remove_results = docker.remove_image("hello-world", Some(remove_options));
+        let remove_results = docker.remove_image("hello-world", Some(remove_options), None);
 
         let future = remove_results.map(|vec| {
             assert!(vec.into_iter().any(|result| match result {

--- a/src/image.rs
+++ b/src/image.rs
@@ -853,6 +853,7 @@ impl<'a> BuildImageQueryParams<&'a str> for BuildImageOptions<String> {
 /// Subtype for the [Build Image Results](struct.BuildImageResults.html) type.
 #[derive(Debug, Clone, Deserialize)]
 #[serde(deny_unknown_fields)]
+#[allow(missing_docs)]
 pub struct BuildImageAuxDetail {
     #[serde(rename = "ID")]
     pub id: String,
@@ -861,6 +862,7 @@ pub struct BuildImageAuxDetail {
 /// Subtype for the [Build Image Results](struct.BuildImageResults.html) type.
 #[derive(Debug, Clone, Deserialize)]
 #[serde(deny_unknown_fields)]
+#[allow(missing_docs)]
 pub struct BuildImageErrorDetail {
     pub code: Option<u64>,
     pub message: String,
@@ -869,6 +871,7 @@ pub struct BuildImageErrorDetail {
 /// Subtype for the [Build Image Results](struct.BuildImageResults.html) type.
 #[derive(Debug, Clone, Copy, Deserialize)]
 #[serde(deny_unknown_fields)]
+#[allow(missing_docs)]
 pub struct BuildImageProgressDetail {
     pub current: Option<u64>,
     pub total: Option<u64>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -396,6 +396,7 @@ extern crate hyper_openssl;
 extern crate hyperlocal;
 #[macro_use]
 extern crate log;
+extern crate base64;
 extern crate mio;
 #[cfg(windows)]
 extern crate mio_named_pipes;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -361,7 +361,7 @@
 //! docker push localhost:5000/hello-world:linux
 //! docker push localhost:5000/fnichol/uhttpd
 //! docker push localhost:5000/alpine
-//! REGISTRY_HTTP_ADDR=localhost:5000 cargo test --test-threads 1
+//! REGISTRY_HTTP_ADDR=localhost:5000 cargo test -- --test-threads 1
 //! ```
 #![deny(
     missing_docs,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -235,7 +235,7 @@
 //! docker.chain().create_image(Some(CreateImageOptions{
 //!     from_image: "hello-world",
 //!     ..Default::default()
-//! })).and_then(|(docker, _)|
+//! }), None).and_then(|(docker, _)|
 //!     docker.create_container(
 //!         None::<CreateContainerOptions<String>>,
 //!         Config {

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -7,6 +7,7 @@ use hyper::client::connect::Connect;
 use hyper::rt::{Future, Stream};
 use tokio::runtime::Runtime;
 
+use std;
 use std::collections::HashMap;
 
 use bollard::auth::DockerCredentials;

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -9,6 +9,7 @@ use tokio::runtime::Runtime;
 
 use std::collections::HashMap;
 
+use bollard::auth::DockerCredentials;
 use bollard::container::*;
 use bollard::image::*;
 use bollard::DockerChain;
@@ -75,6 +76,14 @@ macro_rules! connect_to_docker_and_run {
     }};
 }
 
+pub fn integration_test_registry_credentials() -> DockerCredentials {
+    DockerCredentials {
+        username: Some("bollard".to_string()),
+        password: std::env::var("REGISTRY_PASSWORD").ok(),
+        ..Default::default()
+    }
+}
+
 pub(crate) fn registry_http_addr() -> String {
     if ::std::env::var("DISABLE_REGISTRY").is_ok() {
         String::new()
@@ -127,10 +136,17 @@ where
     };
 
     chain
-        .create_image(Some(CreateImageOptions {
-            from_image: image(),
-            ..Default::default()
-        }))
+        .create_image(
+            Some(CreateImageOptions {
+                from_image: image(),
+                ..Default::default()
+            }),
+            if cfg!(windows) {
+                None
+            } else {
+                Some(integration_test_registry_credentials())
+            },
+        )
         .and_then(move |(docker, _)| {
             docker.create_container(
                 Some(CreateContainerOptions {
@@ -201,10 +217,17 @@ where
     };
 
     chain
-        .create_image(Some(CreateImageOptions {
-            from_image: image(),
-            ..Default::default()
-        }))
+        .create_image(
+            Some(CreateImageOptions {
+                from_image: image(),
+                ..Default::default()
+            }),
+            if cfg!(windows) {
+                None
+            } else {
+                Some(integration_test_registry_credentials())
+            },
+        )
         .and_then(move |(docker, _)| {
             docker.create_container(
                 Some(CreateContainerOptions {
@@ -297,10 +320,17 @@ where
     #[cfg(unix)]
     let chain = chain
         .and_then(move |docker| {
-            docker.create_image(Some(CreateImageOptions {
-                from_image: image(),
-                ..Default::default()
-            }))
+            docker.create_image(
+                Some(CreateImageOptions {
+                    from_image: image(),
+                    ..Default::default()
+                }),
+                if cfg!(windows) {
+                    None
+                } else {
+                    Some(integration_test_registry_credentials())
+                },
+            )
         })
         .map(|(docker, _)| docker);
 
@@ -370,10 +400,17 @@ where
     };
 
     chain
-        .create_image(Some(CreateImageOptions {
-            from_image: image(),
-            ..Default::default()
-        }))
+        .create_image(
+            Some(CreateImageOptions {
+                from_image: image(),
+                ..Default::default()
+            }),
+            if cfg!(windows) {
+                None
+            } else {
+                Some(integration_test_registry_credentials())
+            },
+        )
         .map(|(docker, result)| {
             result
                 .take(1)

--- a/tests/container_test.rs
+++ b/tests/container_test.rs
@@ -1,6 +1,5 @@
 #![type_length_limit = "2097152"]
 extern crate bollard;
-extern crate env_logger;
 extern crate failure;
 extern crate futures;
 extern crate hyper;
@@ -15,6 +14,8 @@ use bollard::Docker;
 use hyper::client::connect::Connect;
 use hyper::rt::{Future, Stream};
 use tokio::runtime::Runtime;
+
+use std::io::Write;
 
 #[macro_use]
 pub mod common;
@@ -412,6 +413,103 @@ where
     run_runtime(rt, future);
 }
 
+fn archive_container_test<C>(docker: Docker<C>)
+where
+    C: Connect + Sync + 'static,
+{
+    let rt = Runtime::new().unwrap();
+
+    let image = move || {
+        if cfg!(windows) {
+            format!("{}microsoft/nanoserver", registry_http_addr())
+        } else {
+            format!("{}alpine", registry_http_addr())
+        }
+    };
+
+    let readme = r#"Hello from Bollard!"#.as_bytes();
+
+    let mut header = tar::Header::new_gnu();
+    header.set_path("readme.txt").unwrap();
+    header.set_size(readme.len() as u64);
+    header.set_mode(0o744);
+    header.set_cksum();
+    let mut tar = tar::Builder::new(Vec::new());
+    tar.append(&header, readme).unwrap();
+
+    let uncompressed = tar.into_inner().unwrap();
+    let mut c = flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::default());
+    c.write_all(&uncompressed).unwrap();
+    let payload = c.finish().unwrap();
+
+    let cleanup = docker.clone();
+
+    let future = docker
+        .chain()
+        .create_container(
+            Some(CreateContainerOptions {
+                name: "integration_test_archive_container",
+            }),
+            Config {
+                image: Some(image()),
+                ..Default::default()
+            },
+        )
+        .and_then(|(docker, _)| {
+            docker.upload_to_container(
+                "integration_test_archive_container",
+                Some(UploadToContainerOptions {
+                    path: "/tmp",
+                    ..Default::default()
+                }),
+                payload.into(),
+            )
+        })
+        .and_then(|(docker, _)| {
+            docker.download_from_container(
+                "integration_test_archive_container",
+                Some(DownloadFromContainerOptions { path: "/tmp" }),
+            )
+        })
+        .and_then(|(_, stream)| stream.concat2())
+        .map(|chunk| {
+            let bytes = &chunk.into_bytes()[..];
+            let mut a: tar::Archive<&[u8]> = tar::Archive::new(bytes);
+
+            use std::io::Read;
+            let files: Vec<String> = a
+                .entries()
+                .unwrap()
+                .map(|file| file.unwrap())
+                .filter(|file| {
+                    let path = file.header().path().unwrap();
+                    if path == std::path::Path::new("tmp/readme.txt") {
+                        return true;
+                    }
+                    println!("{:?}", file.header().path().unwrap());
+                    false
+                })
+                .map(|mut r| {
+                    let mut s = String::new();
+                    r.read_to_string(&mut s).unwrap();
+                    s
+                })
+                .collect();
+
+            assert_eq!(1, files.len());
+
+            assert_eq!("Hello from Bollard!", files.first().unwrap());
+        })
+        .then(move |_| {
+            cleanup.remove_container(
+                "integration_test_archive_container",
+                None::<RemoveContainerOptions>,
+            )
+        });
+
+    run_runtime(rt, future);
+}
+
 #[test]
 fn integration_test_list_containers() {
     connect_to_docker_and_run!(list_containers_test);
@@ -441,7 +539,6 @@ fn integration_test_logs() {
 
 #[test]
 fn integration_test_container_changes() {
-    env_logger::init();
     connect_to_docker_and_run!(container_changes_test);
 }
 
@@ -477,4 +574,9 @@ fn integration_test_pause_container() {
 #[test]
 fn integration_test_prune_containers() {
     connect_to_docker_and_run!(prune_containers_test);
+}
+
+#[test]
+fn integration_test_archive_containers() {
+    connect_to_docker_and_run!(archive_container_test);
 }

--- a/tests/container_test.rs
+++ b/tests/container_test.rs
@@ -6,6 +6,8 @@ extern crate hyper;
 #[cfg(unix)]
 extern crate hyperlocal;
 extern crate tokio;
+extern crate flate2;
+extern crate tar;
 
 use bollard::container::*;
 use bollard::image::*;

--- a/tests/image_test.rs
+++ b/tests/image_test.rs
@@ -183,8 +183,14 @@ where
                     noprune: true,
                     ..Default::default()
                 }),
+                if cfg!(windows) {
+                    None
+                } else {
+                    Some(integration_test_registry_credentials())
+                },
             )
-        }).map(move |(docker, result)| {
+        })
+        .map(move |(docker, result)| {
             assert!(result.into_iter().any(|s| match s {
                 RemoveImageResults::RemoveImageUntagged { untagged } => untagged == image(),
                 _ => false,
@@ -290,22 +296,31 @@ where
                     }
                     assert_eq!(first.status_code, 0);
                     docker
-                }).or_else(|e| {
+                })
+                .or_else(|e| {
                     println!("{}", e.0);
                     Err(e.0)
                 })
-        }).flatten()
+        })
+        .flatten()
         .and_then(move |docker| {
             docker.remove_container(
                 "integration_test_commit_container_next",
                 None::<RemoveContainerOptions>,
             )
-        }).and_then(move |(docker, _)| {
+        })
+        .and_then(move |(docker, _)| {
             docker.remove_image(
                 "integration_test_commit_container_next",
                 None::<RemoveImageOptions>,
+                if cfg!(windows) {
+                    None
+                } else {
+                    Some(integration_test_registry_credentials())
+                },
             )
-        }).and_then(move |(docker, _)| {
+        })
+        .and_then(move |(docker, _)| {
             docker.remove_container(
                 "integration_test_commit_container",
                 None::<RemoveContainerOptions>,
@@ -319,16 +334,20 @@ fn build_image_test<C>(docker: Docker<C>)
 where
     C: Connect + Sync + 'static,
 {
-    let dockerfile = {
-        if cfg!(windows) {
-            r#"FROM microsoft/nanoserver
+    let dockerfile = if cfg!(windows) {
+        format!(
+            "FROM {}microsoft/nanoserver
 RUN cmd.exe /C copy nul bollard.txt
-"#.as_bytes()
-        } else {
-            r#"FROM alpine
+",
+            registry_http_addr()
+        )
+    } else {
+        format!(
+            "FROM {}alpine
 RUN touch bollard.txt
-"#.as_bytes()
-        }
+",
+            registry_http_addr()
+        )
     };
     let mut header = tar::Header::new_gnu();
     header.set_path("Dockerfile").unwrap();
@@ -336,7 +355,7 @@ RUN touch bollard.txt
     header.set_mode(0o755);
     header.set_cksum();
     let mut tar = tar::Builder::new(Vec::new());
-    tar.append(&header, dockerfile).unwrap();
+    tar.append(&header, dockerfile.as_bytes()).unwrap();
 
     let uncompressed = tar.into_inner().unwrap();
     let mut c = flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::default());
@@ -348,11 +367,7 @@ RUN touch bollard.txt
     let mut creds = HashMap::new();
     creds.insert(
         "localhost:5000".to_string(),
-        bollard::auth::DockerCredentials {
-            username: Some("bollard".to_string()),
-            password: Some("Passw0rd!".to_string()),
-            ..Default::default()
-        },
+        integration_test_registry_credentials(),
     );
 
     let future = docker
@@ -365,7 +380,7 @@ RUN touch bollard.txt
                 rm: true,
                 ..Default::default()
             },
-            Some(creds),
+            if cfg!(windows) { None } else { Some(creds) },
             Some(compressed.into()),
         )
         .and_then(move |(docker, stream)| {
@@ -410,18 +425,29 @@ RUN touch bollard.txt
                     }
                     assert_eq!(first.status_code, 0);
                     docker
-                }).or_else(|e| {
+                })
+                .or_else(|e| {
                     println!("{}", e.0);
                     Err(e.0)
                 })
-        }).flatten()
+        })
+        .flatten()
         .and_then(move |docker| {
             docker.remove_container(
                 "integration_test_build_image",
                 None::<RemoveContainerOptions>,
             )
-        }).and_then(move |(docker, _)| {
-            docker.remove_image("integration_test_build_image", None::<RemoveImageOptions>)
+        })
+        .and_then(move |(docker, _)| {
+            docker.remove_image(
+                "integration_test_build_image",
+                None::<RemoveImageOptions>,
+                if cfg!(windows) {
+                    None
+                } else {
+                    Some(integration_test_registry_credentials())
+                },
+            )
         });
 
     run_runtime(rt, future);


### PR DESCRIPTION
- Adds the `upload_to_container` and `download_from_container` endpoints.
- Change fields of result enum from `build_image` endpoint to public, thanks @Qwaz 
- Fix remote registry authentication across multiple endpoints:
  - *Breaking change* add credentials argument to `create_image` and `remove_image`
  - Use a `HashMap` for multiple registry authentication on `build_image` endpoint
  - Make sure we base64 encode credentials
  - Add integration tests for remote registry authentication