### PR TITLE
Bollard v0.2.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 jobs:
   test_ssl:
     docker:
-      - image: docker:18.09.0
+      - image: docker:18.09.1
     steps:
       - checkout
       - setup_remote_docker
@@ -14,7 +14,7 @@ jobs:
       - run: docker run -e -ti -e DOCKER_CERT_PATH=/certs -e DOCKER_HOST='tcp://test.example.com:2375' --volumes-from certs --rm --link test-docker-daemon:docker bollard cargo test --features ssl -- --test test_version_ssl
   test_tls:
     docker:
-      - image: docker:18.09.0
+      - image: docker:18.09.1
     steps:
       - checkout
       - setup_remote_docker
@@ -27,7 +27,7 @@ jobs:
       - run: docker run -e -ti -e DOCKER_CERT_PATH=/certs -e DOCKER_HOST='tcp://test.example.com:2375' --volumes-from certs --rm --link test-docker-daemon:docker bollard cargo test -- --test test_version_tls
   test_http:
     docker:
-      - image: docker:18.09.0
+      - image: docker:18.09.1
     steps:
       - checkout
       - setup_remote_docker
@@ -36,7 +36,7 @@ jobs:
       - run: docker run -e -ti -e DOCKER_HOST='tcp://test.example.com:2375' --rm --link test-docker-daemon:docker bollard cargo test --features test_http -- --test test_version_http
   test_unix:
     docker:
-      - image: docker:18.09.0
+      - image: docker:18.09.1
     steps:
       - checkout
       - setup_remote_docker
@@ -44,7 +44,7 @@ jobs:
       - run: dockerfiles/bin/run_integration_tests.sh
   test_doc:
     docker:
-      - image: docker:18.09.0
+      - image: docker:18.09.1
     steps:
       - checkout
       - setup_remote_docker

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "bollard"
 description = "An asynchronous Docker daemon API"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Graham Lee <ghmlee@ghmlee.com>",
            "Toby Lawrence <toby@nuclearfurnace.com>",
            "Eric Kidd <git@randomhacks.net>",

--- a/README.md
+++ b/README.md
@@ -22,9 +22,14 @@ Add the following to your `Cargo.toml` file
 bollard = "0.2"
 ```
 
-## API documentation
+## API
+### Documentation
 
 [API docs](https://docs.rs/bollard/)
+
+### Version
+
+The [Docker API](https://docs.docker.com/engine/api/v1.39/) is pegged at version `1.39`
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![crates.io](https://img.shields.io/crates/v/bollard.svg)](https://crates.io/crates/bollard)
 [![license](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![circle-ci](https://circleci.com/gh/fussybeaver/bollard/tree/master.svg?style=svg)](https://circleci.com/gh/fussybeaver/bollard/tree/master)
-[![appveyor](https://ci.appveyor.com/api/projects/status/n5khebyfae0u1sbv?svg=true)](https://ci.appveyor.com/project/fussybeaver/boondock)
+[![appveyor](https://ci.appveyor.com/api/projects/status/n5khebyfae0u1sbv/branch/master?svg=true)](https://ci.appveyor.com/project/fussybeaver/boondock)
 [![docs](https://docs.rs/bollard/badge.svg?version=0.1.0)](https://docs.rs/bollard/)
 
 ## Bollard: an asynchronous rust client library for the docker API
@@ -19,7 +19,7 @@ Add the following to your `Cargo.toml` file
 
 ```nocompile
 [dependencies]
-bollard = "0.1"
+bollard = "0.2"
 ```
 
 ## API documentation

--- a/src/container.rs
+++ b/src/container.rs
@@ -822,7 +822,7 @@ pub struct WaitContainerResultsError {
 #[serde(rename_all = "PascalCase", deny_unknown_fields)]
 #[allow(missing_docs)]
 pub struct WaitContainerResults {
-    pub status_code: u16,
+    pub status_code: u64,
     pub error: Option<WaitContainerResultsError>,
 }
 

--- a/src/container.rs
+++ b/src/container.rs
@@ -1126,7 +1126,8 @@ pub struct MemoryStats {
     pub commit: Option<u64>,
     pub commit_peak: Option<u64>,
     pub commitbytes: Option<u64>,
-    pub private_working_set: Option<u64>,
+    pub commitpeakbytes: Option<u64>,
+    pub privateworkingset: Option<u64>,
 }
 
 /// Process ID statistics for the container.

--- a/src/container.rs
+++ b/src/container.rs
@@ -1004,6 +1004,7 @@ pub enum LogOutput {
     StdErr { message: String },
     StdOut { message: String },
     StdIn { message: String },
+    Console { message: String },
 }
 
 impl fmt::Display for LogOutput {
@@ -1012,6 +1013,7 @@ impl fmt::Display for LogOutput {
             LogOutput::StdErr { message } => write!(f, "{}", message),
             LogOutput::StdOut { message } => write!(f, "{}", message),
             LogOutput::StdIn { message } => write!(f, "{}", message),
+            LogOutput::Console { message } => write!(f, "{}", message),
         }
     }
 }

--- a/src/docker.rs
+++ b/src/docker.rs
@@ -37,7 +37,7 @@ use errors::{
 };
 #[cfg(windows)]
 use named_pipe::NamedPipeConnector;
-use read::{JsonLineDecoder, LineDecoder, StreamReader};
+use read::{JsonLineDecoder, NewlineLogOutputDecoder, StreamReader};
 use uri::Uri;
 
 use serde::de::DeserializeOwned;
@@ -766,7 +766,17 @@ where
     ) -> impl Stream<Item = Chunk, Error = Error> {
         self.process_request(req)
             .into_stream()
-            .map(|response| response.into_body().map_err(|e| e.into()))
+            .map(|response| response.into_body().from_err())
+            .flatten()
+    }
+
+    pub(crate) fn process_upgraded_stream_string(
+        &self,
+        req: Result<Request<Body>, Error>,
+    ) -> impl Stream<Item = LogOutput, Error = Error> {
+        self.process_request(req)
+            .into_stream()
+            .map(Docker::<C>::decode_into_upgraded_stream_string)
             .flatten()
     }
 
@@ -811,6 +821,8 @@ where
                 match status {
                     // Status code 200 - 299
                     s if s.is_success() => EitherResponse::A(future::ok(response)),
+
+                    StatusCode::SWITCHING_PROTOCOLS => EitherResponse::G(future::ok(response)),
 
                     // Status code 304: Not Modified
                     StatusCode::NOT_MODIFIED => {
@@ -885,8 +897,7 @@ where
     ) -> impl Future<Item = Response<Body>, Error = Error> {
         let now = Instant::now();
 
-        Timeout::new_at(client.request(request), now + Duration::from_secs(timeout))
-            .map_err(|e| e.into())
+        Timeout::new_at(client.request(request), now + Duration::from_secs(timeout)).from_err()
     }
 
     fn decode_into_stream<T>(res: Response<Body>) -> impl Stream<Item = T, Error = Error>
@@ -904,15 +915,27 @@ where
     ) -> impl Stream<Item = LogOutput, Error = Error> {
         FramedRead::new(
             StreamReader::new(res.into_body().from_err()),
-            LineDecoder::new(),
-        ).map_err(|e| e)
+            NewlineLogOutputDecoder::new(),
+        )
+        .from_err()
+    }
+
+    fn decode_into_upgraded_stream_string(
+        res: Response<Body>,
+    ) -> impl Stream<Item = LogOutput, Error = Error> {
+        res.into_body()
+            .on_upgrade()
+            .into_stream()
+            .map(|r| FramedRead::new(r, NewlineLogOutputDecoder::new()))
+            .map_err::<Error, _>(|e: hyper::Error| e.into())
+            .flatten()
     }
 
     fn decode_into_string(response: Response<Body>) -> impl Future<Item = String, Error = Error> {
         response
             .into_body()
             .concat2()
-            .map_err(|e| e.into())
+            .from_err()
             .and_then(|body| from_utf8(&body).map(|x| x.to_owned()).map_err(|e| e.into()))
     }
 

--- a/src/docker.rs
+++ b/src/docker.rs
@@ -61,6 +61,9 @@ const DEFAULT_NUM_THREADS: usize = 1;
 /// Default timeout for all requests is 2 minutes.
 const DEFAULT_TIMEOUT: u64 = 120;
 
+/// Docker API version
+pub(crate) const API_VERSION: &'static str = "v1.39";
+
 pub(crate) const TRUE_STR: &'static str = "true";
 pub(crate) const FALSE_STR: &'static str = "false";
 

--- a/src/either.rs
+++ b/src/either.rs
@@ -27,22 +27,24 @@ where
 }
 
 #[derive(Debug)]
-pub(crate) enum EitherResponse<B, C, D, E, F> {
+pub(crate) enum EitherResponse<B, C, D, E, F, G> {
     A(future::FutureResult<Response<Body>, Error>),
     B(B),
     C(C),
     D(D),
     E(E),
     F(F),
+    G(G),
 }
 
-impl<B, C, D, E, F> Future for EitherResponse<B, C, D, E, F>
+impl<B, C, D, E, F, G> Future for EitherResponse<B, C, D, E, F, G>
 where
     B: Future<Item = Response<Body>, Error = Error>,
     C: Future<Item = Response<Body>, Error = Error>,
     D: Future<Item = Response<Body>, Error = Error>,
     E: Future<Item = Response<Body>, Error = Error>,
     F: Future<Item = Response<Body>, Error = Error>,
+    G: Future<Item = Response<Body>, Error = Error>,
 {
     type Item = Response<Body>;
     type Error = Error;
@@ -55,6 +57,7 @@ where
             EitherResponse::D(ref mut d) => d.poll(),
             EitherResponse::E(ref mut e) => e.poll(),
             EitherResponse::F(ref mut f) => f.poll(),
+            EitherResponse::G(ref mut g) => g.poll(),
         }
     }
 }

--- a/src/exec.rs
+++ b/src/exec.rs
@@ -1,0 +1,474 @@
+//! Exec API: Run new commands inside running containers
+
+use arrayvec::ArrayVec;
+use failure::Error;
+use futures::{stream, Stream};
+use http::header::{CONNECTION, UPGRADE};
+use http::request::Builder;
+use hyper::client::connect::Connect;
+use hyper::rt::Future;
+use hyper::Body;
+use hyper::Method;
+use serde::ser::Serialize;
+
+use super::{Docker, DockerChain};
+use either::EitherStream;
+
+use container::LogOutput;
+
+/// Exec configuration used in the [Create Exec API](../struct.Docker.html#method.create_exec)
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "PascalCase", deny_unknown_fields)]
+pub struct CreateExecOptions<T>
+where
+    T: AsRef<str> + Serialize,
+{
+    /// Attach to `stdin` of the exec command.
+    pub attach_stdin: Option<bool>,
+    /// Attach to stdout of the exec command.
+    pub attach_stdout: Option<bool>,
+    /// Attach to stderr of the exec command.
+    pub attach_stderr: Option<bool>,
+    /// Override the key sequence for detaching a container. Format is a single character `[a-Z]`
+    /// or `ctrl-<value>` where `<value>` is one of: `a-z`, `@`, `^`, `[`, `,` or `_`.
+    pub detach_keys: Option<T>,
+    /// A list of environment variables in the form `["VAR=value", ...].`
+    pub env: Option<Vec<T>>,
+    /// Command to run, as a string or array of strings.
+    pub cmd: Option<Vec<T>>,
+    /// Runs the exec process with extended privileges.
+    pub privileged: Option<bool>,
+    /// The user, and optionally, group to run the exec process inside the container. Format is one
+    /// of: `user`, `user:group`, `uid`, or `uid:gid`.
+    pub user: Option<T>,
+    /// The working directory for the exec process inside the container.
+    pub working_dir: Option<T>,
+}
+
+/// Result type for the [Create Exec API](../struct.Docker.html#method.create_exec)
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "PascalCase", deny_unknown_fields)]
+#[allow(missing_docs)]
+pub struct CreateExecResults {
+    pub id: String,
+}
+
+/// Exec configuration used in the [Create Exec API](../struct.Docker.html#method.create_exec)
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize)]
+#[serde(rename_all = "PascalCase", deny_unknown_fields)]
+pub struct StartExecOptions {
+    /// Detach from the command.
+    pub detach: bool,
+}
+
+/// Result type for the [Start Exec API](../struct.Docker.html#method.start_exec)
+#[derive(Debug, Clone)]
+#[allow(missing_docs)]
+pub enum StartExecResults {
+    Attached { log: LogOutput },
+    Detached,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+#[allow(missing_docs)]
+pub struct ExecProcessConfig {
+    pub user: Option<String>,
+    pub privileged: Option<bool>,
+    pub tty: bool,
+    pub entrypoint: String,
+    pub arguments: Vec<String>,
+}
+
+/// Result type for the [Inspect Exec API](../struct.Docker.html#method.inspect_exec)
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "PascalCase", deny_unknown_fields)]
+#[allow(missing_docs)]
+pub struct ExecInspect {
+    pub can_remove: bool,
+    #[serde(rename = "ContainerID")]
+    pub container_id: String,
+    pub detach_keys: String,
+    pub exit_code: Option<u64>,
+    #[serde(rename = "ID")]
+    pub id: String,
+    pub open_stderr: bool,
+    pub open_stdin: bool,
+    pub open_stdout: bool,
+    pub process_config: ExecProcessConfig,
+    pub running: bool,
+    pub pid: u64,
+}
+
+impl<C> Docker<C>
+where
+    C: Connect + Sync + 'static,
+{
+    /// ---
+    ///
+    /// # Create Exec
+    ///
+    /// Run a command inside a running container.
+    ///
+    /// # Arguments
+    ///
+    ///  - Container name as string slice.
+    ///  - [Create Exec Options](container/struct.CreateExecOptions.html) struct.
+    ///
+    /// # Returns
+    ///
+    ///  - A [Create Exec Results](container/struct.CreateExecResults.html) struct, wrapped in a
+    ///  Future.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use bollard::Docker;
+    /// # let docker = Docker::connect_with_http_defaults().unwrap();
+    ///
+    /// use bollard::exec::CreateExecOptions;
+    ///
+    /// use std::default::Default;
+    ///
+    /// let config = CreateExecOptions {
+    ///     cmd: Some(vec!["ps", "-ef"]),
+    ///     attach_stdout: Some(true),
+    ///     ..Default::default()
+    /// };
+    ///
+    /// docker.create_exec("hello-world", config);
+    /// ```
+    pub fn create_exec<T>(
+        &self,
+        container_name: &str,
+        config: CreateExecOptions<T>,
+    ) -> impl Future<Item = CreateExecResults, Error = Error>
+    where
+        T: AsRef<str> + Serialize,
+    {
+        let url = format!("/containers/{}/exec", container_name);
+
+        let req = self.build_request::<_, String, String>(
+            &url,
+            Builder::new().method(Method::POST),
+            Ok(None::<ArrayVec<[(_, _); 0]>>),
+            Docker::<C>::serialize_payload(Some(config)),
+        );
+
+        self.process_into_value(req)
+    }
+
+    /// ---
+    ///
+    /// # Start Exec
+    ///
+    /// Starts a previously set up exec instance. If detach is true, this endpoint returns
+    /// immediately after starting the command.
+    ///
+    /// # Arguments
+    ///
+    ///  - Container name as string slice.
+    ///
+    /// # Returns
+    ///
+    ///  - [Log Output](container/enum.LogOutput.html) enum, wrapped in a Stream.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use bollard::Docker;
+    /// # let docker = Docker::connect_with_http_defaults().unwrap();
+    ///
+    /// use bollard::exec::StartExecOptions;
+    ///
+    /// docker.start_exec("hello-world", None::<StartExecOptions>);
+    /// ```
+    pub fn start_exec(
+        &self,
+        container_name: &str,
+        config: Option<StartExecOptions>,
+    ) -> impl Stream<Item = StartExecResults, Error = Error> {
+        let url = format!("/exec/{}/start", container_name);
+
+        match config {
+            Some(StartExecOptions { detach: true, .. }) => {
+                let req = self.build_request::<_, String, String>(
+                    &url,
+                    Builder::new().method(Method::POST),
+                    Ok(None::<ArrayVec<[(_, _); 0]>>),
+                    Docker::<C>::serialize_payload(config),
+                );
+
+                EitherStream::A(
+                    self.process_into_unit(req)
+                        .map(|_| StartExecResults::Detached)
+                        .into_stream(),
+                )
+            }
+            _ => {
+                let req = self.build_request::<_, String, String>(
+                    &url,
+                    Builder::new()
+                        .method(Method::POST)
+                        .header(CONNECTION, "Upgrade")
+                        .header(UPGRADE, "tcp"),
+                    Ok(None::<ArrayVec<[(_, _); 0]>>),
+                    Docker::<C>::serialize_payload(config.or_else(|| {
+                        Some(StartExecOptions {
+                            ..Default::default()
+                        })
+                    })),
+                );
+
+                EitherStream::B(
+                    self.process_upgraded_stream_string(req)
+                        .map(|s| StartExecResults::Attached { log: s }),
+                )
+            }
+        }
+    }
+
+    /// ---
+    ///
+    /// # Inspect Exec
+    ///
+    /// Return low-level information about an exec instance.
+    ///
+    /// # Arguments
+    ///
+    ///  - Container name as string slice.
+    ///
+    /// # Returns
+    ///
+    ///  - An [ExecInspect](container/struct.ExecInspect.html) struct, wrapped in a Future.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use bollard::Docker;
+    /// # let docker = Docker::connect_with_http_defaults().unwrap();
+    ///
+    /// docker.inspect_exec("hello-world");
+    /// ```
+    pub fn inspect_exec(
+        &self,
+        container_name: &str,
+    ) -> impl Future<Item = ExecInspect, Error = Error> {
+        let url = format!("/exec/{}/json", container_name);
+
+        let req = self.build_request::<_, String, String>(
+            &url,
+            Builder::new().method(Method::GET),
+            Ok(None::<ArrayVec<[(_, _); 0]>>),
+            Ok(Body::empty()),
+        );
+
+        self.process_into_value(req)
+    }
+}
+
+impl<C> DockerChain<C>
+where
+    C: Connect + Sync + 'static,
+{
+    /// ---
+    ///
+    /// # Create Exec
+    ///
+    /// Run a command inside a running container. Consumes the client instance.
+    ///
+    /// # Arguments
+    ///
+    ///  - Container name as string slice.
+    ///  - [Create Exec Options](container/struct.CreateExecOptions.html) struct.
+    ///
+    /// # Returns
+    ///
+    ///  - A Tuple containing the original [DockerChain](struct.Docker.html) instance, and a
+    ///  [Create Exec Results](container/struct.CreateExecResults.html) struct, wrapped in a
+    ///  Future.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use bollard::Docker;
+    /// # let docker = Docker::connect_with_http_defaults().unwrap();
+    ///
+    /// use bollard::exec::CreateExecOptions;
+    ///
+    /// use std::default::Default;
+    ///
+    /// let config = CreateExecOptions {
+    ///     cmd: Some(vec!["ps", "-ef"]),
+    ///     attach_stdout: Some(true),
+    ///     ..Default::default()
+    /// };
+    ///
+    /// docker.chain().create_exec("hello-world", config);
+    /// ```
+    pub fn create_exec<T>(
+        self,
+        container_name: &str,
+        config: CreateExecOptions<T>,
+    ) -> impl Future<Item = (DockerChain<C>, CreateExecResults), Error = Error>
+    where
+        T: AsRef<str> + Serialize,
+    {
+        self.inner
+            .create_exec(container_name, config)
+            .map(|result| (self, result))
+    }
+
+    /// ---
+    ///
+    /// # Start Exec
+    ///
+    /// Starts a previously set up exec instance. If detach is true, this endpoint returns
+    /// immediately after starting the command. Consumes the client instance.
+    ///
+    /// # Arguments
+    ///
+    ///  - Container name as string slice.
+    ///
+    /// # Returns
+    ///
+    ///  - A Tuple containing the original [DockerChain](struct.Docker.html) instance, and a [Log
+    ///  Output](container/enum.LogOutput.html) enum, wrapped in a Stream.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use bollard::Docker;
+    /// # let docker = Docker::connect_with_http_defaults().unwrap();
+    ///
+    /// use bollard::exec::StartExecOptions;
+    ///
+    /// docker.chain().start_exec("hello-world", None::<StartExecOptions>);
+    /// ```
+    pub fn start_exec(
+        self,
+        container_name: &str,
+        config: Option<StartExecOptions>,
+    ) -> impl Future<
+        Item = (
+            DockerChain<C>,
+            impl Stream<Item = StartExecResults, Error = Error>,
+        ),
+        Error = Error,
+    > {
+        self.inner
+            .start_exec(container_name, config)
+            .into_future()
+            .map(|(first, rest)| match first {
+                Some(head) => (self, EitherStream::A(stream::once(Ok(head)).chain(rest))),
+                None => (self, EitherStream::B(stream::empty())),
+            })
+            .map_err(|(err, _)| err)
+    }
+
+    /// ---
+    ///
+    /// # Inspect Exec
+    ///
+    /// Return low-level information about an exec instance. Consumes the client instance.
+    ///
+    /// # Arguments
+    ///
+    ///  - Container name as string slice.
+    ///
+    /// # Returns
+    ///
+    ///  - A Tuple containing the original [DockerChain](struct.Docker.html) instance, and an
+    ///  [ExecInspect](container/struct.ExecInspect.html) struct, wrapped in a Future.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use bollard::Docker;
+    /// # let docker = Docker::connect_with_http_defaults().unwrap();
+    ///
+    /// docker.chain().inspect_exec("hello-world");
+    /// ```
+    pub fn inspect_exec(
+        self,
+        container_name: &str,
+    ) -> impl Future<Item = (DockerChain<C>, ExecInspect), Error = Error> {
+        self.inner
+            .inspect_exec(container_name)
+            .map(|result| (self, result))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use hyper_mock::HostToReplyConnector;
+    use tokio::runtime::Runtime;
+
+    #[test]
+    fn test_start_exec() {
+        let mut rt = Runtime::new().unwrap();
+        let mut connector = HostToReplyConnector::default();
+
+        connector.m.insert(
+            format!("{}://5f", if cfg!(windows) { "net.pipe" } else { "unix" }),
+            "HTTP/1.1 101 UPGRADED\r\nServer: mock1\r\nContent-Type: application/vnd.docker.raw-stream\r\nConnection: Upgrade\r\nUpgrade: tcp\r\n\r\n# Server configuration\nconfig uhttpd main".to_string()
+        );
+
+        let docker = Docker::connect_with(connector, "_".to_string(), 5).unwrap();
+
+        let options = Some(StartExecOptions { detach: false });
+
+        let results = docker.start_exec("68099c450e6a", options);
+
+        let future = results.into_future().map(|(result, _)| {
+            assert!(match result {
+                Some(StartExecResults::Attached {
+                    log: LogOutput::Console { ref message },
+                }) if message == "# Server configuration" => true,
+                _ => false,
+            })
+        });
+
+        rt.block_on(future)
+            .or_else(|e| {
+                println!("{:?}", e.0);
+                Err(e.0)
+            })
+            .unwrap();
+
+        rt.shutdown_now().wait().unwrap();
+    }
+
+    #[test]
+    fn test_inspect_exec() {
+        let mut rt = Runtime::new().unwrap();
+        let mut connector = HostToReplyConnector::default();
+
+        connector.m.insert(
+            format!("{}://5f", if cfg!(windows) { "net.pipe" } else { "unix" }),
+            "HTTP/1.1 200 OK\r\nServer: mock1\r\nContent-Type: application/json\r\nContent-Length: 393\r\n\r\n{\"ID\":\"6b8cf3d95b64cf32d140836f4a3b8f03c1b895398f6fdbd33b69db06fa04d897\",\"Running\":true,\"ExitCode\":null,\"ProcessConfig\":{\"tty\":false,\"entrypoint\":\"/bin/cat\",\"arguments\":[\"/etc/config/uhttpd\"],\"privileged\":false},\"OpenStdin\":false,\"OpenStderr\":false,\"OpenStdout\":true,\"CanRemove\":false,\"ContainerID\":\"a181d0e0bf4bbf0e37d8eb1d68677e0abef838f1aa4d8757c43c1216cfdaa965\",\"DetachKeys\":\"\",\"Pid\":7169}\r\n".to_string()
+        );
+
+        let docker = Docker::connect_with(connector, "_".to_string(), 5).unwrap();
+
+        let results = docker.inspect_exec("68099c450e6a");
+
+        let future = results.map(|result| {
+            println!(":::{:?}", result);
+            assert_eq!(
+                "/etc/config/uhttpd".to_string(),
+                result.process_config.arguments[0]
+            )
+        });
+
+        rt.block_on(future)
+            .or_else(|e| {
+                println!("{:?}", e);
+                Err(e)
+            })
+            .unwrap();
+
+        rt.shutdown_now().wait().unwrap();
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -418,6 +418,7 @@ pub mod container;
 mod docker;
 mod either;
 pub mod errors;
+pub mod exec;
 pub mod image;
 mod named_pipe;
 mod options;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,9 +22,14 @@
 //! bollard = "0.2"
 //! ```
 //!
-//! # API documentation
+//! # API
+//! ## Documentation
 //!
 //! [API docs](https://docs.rs/bollard/)
+//!
+//! ## Version
+//!
+//! The [Docker API](https://docs.docker.com/engine/api/v1.39/) is pegged at version `1.39`
 //!
 //! # Usage
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 //! [![crates.io](https://img.shields.io/crates/v/bollard.svg)](https://crates.io/crates/bollard)
 //! [![license](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 //! [![circle-ci](https://circleci.com/gh/fussybeaver/bollard/tree/master.svg?style=svg)](https://circleci.com/gh/fussybeaver/bollard/tree/master)
-//! [![appveyor](https://ci.appveyor.com/api/projects/status/n5khebyfae0u1sbv?svg=true)](https://ci.appveyor.com/project/fussybeaver/boondock)
+//! [![appveyor](https://ci.appveyor.com/api/projects/status/n5khebyfae0u1sbv/branch/master?svg=true)](https://ci.appveyor.com/project/fussybeaver/boondock)
 //! [![docs](https://docs.rs/bollard/badge.svg?version=0.1.0)](https://docs.rs/bollard/)
 //!
 //! # Bollard: an asynchronous rust client library for the docker API
@@ -19,7 +19,7 @@
 //!
 //! ```nocompile
 //! [dependencies]
-//! bollard = "0.1"
+//! bollard = "0.2"
 //! ```
 //!
 //! # API documentation

--- a/src/uri.rs
+++ b/src/uri.rs
@@ -11,6 +11,7 @@ use std::borrow::Cow;
 use std::ffi::OsStr;
 
 use docker::ClientType;
+use docker::API_VERSION;
 
 #[derive(Debug)]
 pub struct Uri<'a> {
@@ -38,7 +39,13 @@ impl<'a> Uri<'a> where {
     {
         let host: String = Uri::socket_host(socket, client_type)?;
 
-        let host_str = format!("{}://{}{}", Uri::socket_scheme(client_type), host, path);
+        let host_str = format!(
+            "{}://{}/{}{}",
+            Uri::socket_scheme(client_type),
+            host,
+            API_VERSION,
+            path
+        );
         let mut url = Url::parse(host_str.as_ref()).unwrap();
         url = url.join(path).unwrap();
 

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -360,10 +360,6 @@ where
         .and_then(move |docker| {
             docker.start_container(container_name, None::<StartContainerOptions<String>>)
         })
-        .and_then(move |(docker, _)| {
-            // note: windows workaround for non-starting container ?
-            docker.restart_container(container_name, None::<RestartContainerOptions>)
-        })
         .map(|(docker, _)| docker)
 }
 

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -304,7 +304,11 @@ where
 
     let cmd = || {
         if cfg!(windows) {
-            Some(vec![])
+            Some(vec![
+                "net".to_string(),
+                "start".to_string(),
+                "w3svc".to_string(),
+            ])
         } else {
             Some(vec![
                 "/usr/sbin/run_uhttpd".to_string(),

--- a/tests/exec_test.rs
+++ b/tests/exec_test.rs
@@ -1,0 +1,155 @@
+#![type_length_limit = "2097152"]
+extern crate bollard;
+extern crate hyper;
+extern crate tokio;
+
+use bollard::container::*;
+use bollard::exec::*;
+use bollard::Docker;
+
+use hyper::client::connect::Connect;
+use hyper::rt::{Future, Stream};
+use tokio::runtime::Runtime;
+
+#[macro_use]
+pub mod common;
+use common::*;
+
+fn start_exec_test<C>(docker: Docker<C>)
+where
+    C: Connect + Sync + 'static,
+{
+    let rt = Runtime::new().unwrap();
+    let future = chain_create_daemon(docker.chain(), "integration_test_start_exec_test")
+        .and_then(move |docker| {
+            docker.create_exec(
+                "integration_test_start_exec_test",
+                CreateExecOptions {
+                    attach_stdout: Some(true),
+                    cmd: if cfg!(windows) {
+                        Some(vec![
+                            "cmd.exe",
+                            "/C",
+                            "type",
+                            "C:\\Windows\\System32\\Inetsrv\\Config\\ApplicationHost.config",
+                        ])
+                    } else {
+                        Some(vec!["/bin/cat", "/etc/config/uhttpd"])
+                    },
+                    ..Default::default()
+                },
+            )
+        })
+        .and_then(|(docker, message)| docker.start_exec(&message.id, None::<StartExecOptions>))
+        .and_then(|(docker, stream)| stream.take(2).collect().map(|v| (docker, v)))
+        .map(|(docker, lst)| {
+            assert!(lst.into_iter().any(|line| {
+                println!("{:?}", line);
+                let expected = if cfg!(windows) {
+                    "<configuration>\r"
+                } else {
+                    "config uhttpd main"
+                };
+                match line {
+                    StartExecResults::Attached { ref log } if format!("{}", log) == expected => {
+                        true
+                    }
+                    _ => false,
+                }
+            }));
+            docker
+        })
+        .and_then(|docker| {
+            docker.kill_container(
+                "integration_test_start_exec_test",
+                None::<KillContainerOptions<String>>,
+            )
+        })
+        .and_then(|(docker, _)| {
+            docker.wait_container(
+                "integration_test_start_exec_test",
+                None::<WaitContainerOptions<String>>,
+            )
+        })
+        .and_then(|(docker, _)| {
+            docker.remove_container(
+                "integration_test_start_exec_test",
+                None::<RemoveContainerOptions>,
+            )
+        });
+
+    run_runtime(rt, future);
+}
+
+fn inspect_exec_test<C>(docker: Docker<C>)
+where
+    C: Connect + Sync + 'static,
+{
+    let rt = Runtime::new().unwrap();
+    let future = chain_create_daemon(docker.chain(), "integration_test_inspect_exec_test")
+        .and_then(move |docker| {
+            docker.create_exec(
+                "integration_test_inspect_exec_test",
+                CreateExecOptions {
+                    attach_stdout: Some(true),
+                    cmd: if cfg!(windows) {
+                        Some(vec![
+                            "cmd.exe",
+                            "/C",
+                            "type",
+                            "C:\\Windows\\System32\\Inetsrv\\Config\\ApplicationHost.config",
+                        ])
+                    } else {
+                        Some(vec!["/bin/cat", "/etc/config/uhttpd"])
+                    },
+                    ..Default::default()
+                },
+            )
+        })
+        .and_then(|(docker, message)| {
+            docker
+                .start_exec(&message.id, Some(StartExecOptions { detach: true }))
+                .map(|(docker, _)| (docker, message.id))
+        })
+        .and_then(|(docker, id)| docker.inspect_exec(&id))
+        .map(|(docker, exec_process)| {
+            assert_eq!(
+                if cfg!(windows) {
+                    "cmd.exe".to_string()
+                } else {
+                    "/bin/cat".to_string()
+                },
+                exec_process.process_config.entrypoint
+            );
+            docker
+        })
+        .and_then(|docker| {
+            docker.kill_container(
+                "integration_test_inspect_exec_test",
+                None::<KillContainerOptions<String>>,
+            )
+        })
+        .and_then(|(docker, _)| {
+            docker.wait_container(
+                "integration_test_inspect_exec_test",
+                None::<WaitContainerOptions<String>>,
+            )
+        })
+        .and_then(|(docker, _)| {
+            docker.remove_container(
+                "integration_test_inspect_exec_test",
+                None::<RemoveContainerOptions>,
+            )
+        });
+
+    run_runtime(rt, future);
+}
+#[test]
+fn integration_test_start_exec() {
+    connect_to_docker_and_run!(start_exec_test);
+}
+
+#[test]
+fn integration_test_inspect_exec() {
+    connect_to_docker_and_run!(inspect_exec_test);
+}


### PR DESCRIPTION
- Exec API implementation, unit tests and integration tests.
- Change type of `status_code` to `u64` in container wait API.
- Fix `privateworkingset` field in `MemoryStats` for container stats API.
- Run Windows "daemon" macro correctly in integration tests.
- Update README to point to Bollard `v0.2`. 
- Peg Docker API version to `1.39`.
- Bump docker server version to `18.09.01`.