### PR TITLE
Remove `Connect` type parameter in `Docker`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "bollard"
 description = "An asynchronous Docker daemon API"
-version = "0.2.1"
+version = "0.3.0"
 authors = ["Graham Lee <ghmlee@ghmlee.com>",
            "Toby Lawrence <toby@nuclearfurnace.com>",
            "Eric Kidd <git@randomhacks.net>",

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Add the following to your `Cargo.toml` file
 
 ```nocompile
 [dependencies]
-bollard = "0.2"
+bollard = "0.3"
 ```
 
 ## API
@@ -59,6 +59,17 @@ to parameterise the interface.
 use bollard::Docker;
 #[cfg(windows)]
 Docker::connect_with_named_pipe_defaults();
+```
+
+#### Local
+
+The client will connect to the OS specific handler it is compiled for.
+This is a convenience for localhost environment that should run on multiple
+operating systems.
+Use the `Docker::connect_with_local` method API to parameterise the interface.
+```rust
+use bollard::Docker;
+Docker::connect_with_local_defaults();
 ```
 
 #### HTTP
@@ -122,25 +133,30 @@ Tokio is below.
 
 First, check that the API is working with your server:
 
-```rust
+```rust, no_run
+## extern crate bollard;
+## extern crate futures;
+## fn main () {
 use futures::Future;
 
 use bollard::Docker;
 
 // Use a connection function described above
 // let docker = Docker::connect_...;
+## let docker = Docker::connect_with_local_defaults().unwrap();
 
 docker.version()
     .map(|version| {
         println!("{:?}", version);
     });
-```
+## }
+```rust
 
-#### Listing images
+### Listing images
 
 To list docker images available on the Docker server:
 
-```rust
+```rust,no_run
 use futures::Future;
 
 use bollard::Docker;
@@ -206,6 +222,7 @@ use std::default::Default;
 
 // Use a connection function described above
 // let docker = Docker::connect_...;
+
 docker.chain().create_image(Some(CreateImageOptions{
     from_image: "hello-world",
     ..Default::default()

--- a/examples/kafka.rs
+++ b/examples/kafka.rs
@@ -14,7 +14,6 @@ use bollard::image::CreateImageOptions;
 use bollard::{Docker, DockerChain};
 
 use failure::Error;
-use hyper::client::connect::Connect;
 use serde::ser::Serialize;
 use tokio::prelude::*;
 use tokio::runtime::Runtime;
@@ -25,13 +24,12 @@ use std::hash::Hash;
 const KAFKA_IMAGE: &'static str = "confluentinc/cp-kafka:5.0.1";
 const ZOOKEEPER_IMAGE: &'static str = "confluentinc/cp-zookeeper:5.0.1";
 
-fn create_and_logs<C, T>(
-    docker: DockerChain<C>,
+fn create_and_logs<T>(
+    docker: DockerChain,
     name: &'static str,
     config: Config<T>,
 ) -> impl Stream<Item = LogOutput, Error = Error>
 where
-    C: Connect + 'static + Sync,
     T: AsRef<str> + Eq + Hash + Serialize,
 {
     docker

--- a/examples/stats.rs
+++ b/examples/stats.rs
@@ -37,7 +37,8 @@ fn main() {
                     all: true,
                     filters: filter,
                     ..Default::default()
-                })).and_then(move |(docker, containers)| {
+                }))
+                .and_then(move |(docker, containers)| {
                     if containers.is_empty() {
                         Err(bail!("no running containers"))
                     } else {
@@ -65,7 +66,8 @@ fn main() {
                         }
                         Ok(Loop::Continue((docker, new_monitor)))
                     }
-                }).map_err(|e| println!("{:?}", e))
+                })
+                .map_err(|e| println!("{:?}", e))
         },
     );
 

--- a/examples/top.rs
+++ b/examples/top.rs
@@ -28,13 +28,10 @@ fn flatten<T>(lst: Vec<Option<T>>) -> Vec<T> {
     o
 }
 
-fn top_processes<C>(
-    client: DockerChain<C>,
+fn top_processes(
+    client: DockerChain,
     container: &APIContainers,
-) -> impl Future<Item = Option<(String, (DockerChain<C>, TopResult))>, Error = failure::Error>
-where
-    C: Connect + Sync + 'static,
-{
+) -> impl Future<Item = Option<(String, (DockerChain, TopResult))>, Error = failure::Error> {
     let name = container.id.to_owned();
     client
         .top_processes(&container.id, Some(TopOptions { ps_args: "ef" }))

--- a/examples/top.rs
+++ b/examples/top.rs
@@ -14,7 +14,6 @@ use std::default::Default;
 use futures::stream::futures_ordered;
 use futures::stream::futures_unordered;
 use futures::{future, Future, Stream};
-use hyper::client::connect::Connect;
 use tokio::runtime::Runtime;
 
 /// flatten exists on an iterator in nightly

--- a/src/container.rs
+++ b/src/container.rs
@@ -2942,7 +2942,8 @@ where
             .map(|(first, rest)| match first {
                 Some(head) => (self, EitherStream::A(stream::once(Ok(head)).chain(rest))),
                 None => (self, EitherStream::B(stream::empty())),
-            }).map_err(|(err, _)| err)
+            })
+            .map_err(|(err, _)| err)
     }
 
     /// ---
@@ -3125,7 +3126,8 @@ where
             .map(|(first, rest)| match first {
                 Some(head) => (self, EitherStream::A(stream::once(Ok(head)).chain(rest))),
                 None => (self, EitherStream::B(stream::empty())),
-            }).map_err(|(err, _)| err)
+            })
+            .map_err(|(err, _)| err)
     }
 
     /// ---
@@ -3206,7 +3208,8 @@ where
             .map(|(first, rest)| match first {
                 Some(head) => (self, EitherStream::A(stream::once(Ok(head)).chain(rest))),
                 None => (self, EitherStream::B(stream::empty())),
-            }).map_err(|(err, _)| err)
+            })
+            .map_err(|(err, _)| err)
     }
 
     /// ---
@@ -3552,7 +3555,8 @@ mod tests {
             .or_else(|e| {
                 println!("{:?}", e);
                 Err(e)
-            }).unwrap();
+            })
+            .unwrap();
 
         rt.shutdown_now().wait().unwrap();
     }
@@ -3576,7 +3580,8 @@ mod tests {
             .or_else(|e| {
                 println!("{:?}", e);
                 Err(e)
-            }).unwrap();
+            })
+            .unwrap();
 
         rt.shutdown_now().wait().unwrap();
     }
@@ -3602,7 +3607,8 @@ mod tests {
             .or_else(|e| {
                 println!("{:?}", e);
                 Err(e)
-            }).unwrap();
+            })
+            .unwrap();
 
         rt.shutdown_now().wait().unwrap();
     }
@@ -3631,7 +3637,8 @@ mod tests {
             .or_else(|e| {
                 println!("{:?}", e);
                 Err(e)
-            }).unwrap();
+            })
+            .unwrap();
 
         rt.shutdown_now().wait().unwrap();
     }
@@ -3661,7 +3668,8 @@ mod tests {
             .or_else(|e| {
                 println!("{:?}", e.0);
                 Err(e.0)
-            }).unwrap();
+            })
+            .unwrap();
 
         rt.shutdown_now().wait().unwrap();
     }
@@ -3687,7 +3695,8 @@ mod tests {
             .or_else(|e| {
                 println!("{:?}", e);
                 Err(e)
-            }).unwrap();
+            })
+            .unwrap();
 
         rt.shutdown_now().wait().unwrap();
     }
@@ -3713,7 +3722,8 @@ mod tests {
             .or_else(|e| {
                 println!("{:?}", e);
                 Err(e)
-            }).unwrap();
+            })
+            .unwrap();
 
         rt.shutdown_now().wait().unwrap();
     }
@@ -3743,7 +3753,8 @@ mod tests {
             .or_else(|e| {
                 println!("{:?}", e);
                 Err(e)
-            }).unwrap();
+            })
+            .unwrap();
 
         rt.shutdown_now().wait().unwrap();
     }
@@ -3779,7 +3790,8 @@ mod tests {
             .or_else(|e| {
                 println!("{:?}", e.0);
                 Err(e.0)
-            }).unwrap();
+            })
+            .unwrap();
 
         rt.shutdown_now().wait().unwrap();
     }
@@ -3804,7 +3816,8 @@ mod tests {
             .or_else(|e| {
                 println!("{:?}", e);
                 Err(e)
-            }).unwrap();
+            })
+            .unwrap();
 
         rt.shutdown_now().wait().unwrap();
     }
@@ -3831,7 +3844,8 @@ mod tests {
             .or_else(|e| {
                 println!("{:?}", e.0);
                 Err(e.0)
-            }).unwrap();
+            })
+            .unwrap();
 
         rt.shutdown_now().wait().unwrap();
     }
@@ -3859,7 +3873,8 @@ mod tests {
             .or_else(|e| {
                 println!("{:?}", e);
                 Err(e)
-            }).unwrap();
+            })
+            .unwrap();
 
         rt.shutdown_now().wait().unwrap();
     }
@@ -3889,7 +3904,8 @@ mod tests {
             .or_else(|e| {
                 println!("{:?}", e);
                 Err(e)
-            }).unwrap();
+            })
+            .unwrap();
 
         rt.shutdown_now().wait().unwrap();
     }
@@ -3917,7 +3933,8 @@ mod tests {
             .or_else(|e| {
                 println!("{:?}", e);
                 Err(e)
-            }).unwrap();
+            })
+            .unwrap();
 
         rt.shutdown_now().wait().unwrap();
     }
@@ -3941,7 +3958,8 @@ mod tests {
             .or_else(|e| {
                 println!("{:?}", e);
                 Err(e)
-            }).unwrap();
+            })
+            .unwrap();
 
         rt.shutdown_now().wait().unwrap();
     }
@@ -3965,7 +3983,8 @@ mod tests {
             .or_else(|e| {
                 println!("{:?}", e);
                 Err(e)
-            }).unwrap();
+            })
+            .unwrap();
 
         rt.shutdown_now().wait().unwrap();
     }
@@ -3989,7 +4008,8 @@ mod tests {
             .or_else(|e| {
                 println!("{:?}", e);
                 Err(e)
-            }).unwrap();
+            })
+            .unwrap();
 
         rt.shutdown_now().wait().unwrap();
     }

--- a/src/container.rs
+++ b/src/container.rs
@@ -7,7 +7,6 @@ use failure::Error;
 use futures::{stream, Stream};
 use http::header::CONTENT_TYPE;
 use http::request::Builder;
-use hyper::client::connect::Connect;
 use hyper::rt::Future;
 use hyper::{Body, Chunk, Method};
 use serde::Serialize;
@@ -1603,10 +1602,7 @@ impl<'a, T: AsRef<str>> DownloadFromContainerQueryParams<&'a str, T>
         Ok(ArrayVec::from([("path", self.path)]))
     }
 }
-impl<C> Docker<C>
-where
-    C: Connect + Sync + 'static,
-{
+impl Docker {
     /// ---
     ///
     /// # List Containers
@@ -1655,7 +1651,7 @@ where
         let req = self.build_request(
             url,
             Builder::new().method(Method::GET),
-            Docker::<C>::transpose_option(options.map(|o| o.into_array())),
+            Docker::transpose_option(options.map(|o| o.into_array())),
             Ok(Body::empty()),
         );
 
@@ -1714,8 +1710,8 @@ where
         let req = self.build_request(
             url,
             Builder::new().method(Method::POST),
-            Docker::<C>::transpose_option(options.map(|o| o.into_array())),
-            Docker::<C>::serialize_payload(Some(config)),
+            Docker::transpose_option(options.map(|o| o.into_array())),
+            Docker::serialize_payload(Some(config)),
         );
 
         self.process_into_value(req)
@@ -1761,7 +1757,7 @@ where
         let req = self.build_request(
             &url,
             Builder::new().method(Method::POST),
-            Docker::<C>::transpose_option(options.map(|o| o.into_array())),
+            Docker::transpose_option(options.map(|o| o.into_array())),
             Ok(Body::empty()),
         );
 
@@ -1810,7 +1806,7 @@ where
         let req = self.build_request(
             &url,
             Builder::new().method(Method::POST),
-            Docker::<C>::transpose_option(options.map(|o| o.into_array())),
+            Docker::transpose_option(options.map(|o| o.into_array())),
             Ok(Body::empty()),
         );
 
@@ -1864,7 +1860,7 @@ where
         let req = self.build_request(
             &url,
             Builder::new().method(Method::DELETE),
-            Docker::<C>::transpose_option(options.map(|o| o.into_array())),
+            Docker::transpose_option(options.map(|o| o.into_array())),
             Ok(Body::empty()),
         );
 
@@ -1917,7 +1913,7 @@ where
         let req = self.build_request(
             &url,
             Builder::new().method(Method::POST),
-            Docker::<C>::transpose_option(options.map(|o| o.into_array())),
+            Docker::transpose_option(options.map(|o| o.into_array())),
             Ok(Body::empty()),
         );
 
@@ -1967,7 +1963,7 @@ where
         let req = self.build_request(
             &url,
             Builder::new().method(Method::POST),
-            Docker::<C>::transpose_option(options.map(|o| o.into_array())),
+            Docker::transpose_option(options.map(|o| o.into_array())),
             Ok(Body::empty()),
         );
 
@@ -2017,7 +2013,7 @@ where
         let req = self.build_request(
             &url,
             Builder::new().method(Method::GET),
-            Docker::<C>::transpose_option(options.map(|o| o.into_array())),
+            Docker::transpose_option(options.map(|o| o.into_array())),
             Ok(Body::empty()),
         );
 
@@ -2067,7 +2063,7 @@ where
         let req = self.build_request(
             &url,
             Builder::new().method(Method::GET),
-            Docker::<C>::transpose_option(options.map(|o| o.into_array())),
+            Docker::transpose_option(options.map(|o| o.into_array())),
             Ok(Body::empty()),
         );
 
@@ -2121,7 +2117,7 @@ where
         let req = self.build_request(
             &url,
             Builder::new().method(Method::GET),
-            Docker::<C>::transpose_option(options.map(|o| o.into_array())),
+            Docker::transpose_option(options.map(|o| o.into_array())),
             Ok(Body::empty()),
         );
 
@@ -2212,7 +2208,7 @@ where
         let req = self.build_request(
             &url,
             Builder::new().method(Method::GET),
-            Docker::<C>::transpose_option(options.map(|o| o.into_array())),
+            Docker::transpose_option(options.map(|o| o.into_array())),
             Ok(Body::empty()),
         );
 
@@ -2263,7 +2259,7 @@ where
         let req = self.build_request(
             &url,
             Builder::new().method(Method::POST),
-            Docker::<C>::transpose_option(options.map(|o| o.into_array())),
+            Docker::transpose_option(options.map(|o| o.into_array())),
             Ok(Body::empty()),
         );
 
@@ -2313,7 +2309,7 @@ where
             &url,
             Builder::new().method(Method::POST),
             Ok(None::<ArrayVec<[(_, _); 0]>>),
-            Docker::<C>::serialize_payload(Some(config)),
+            Docker::serialize_payload(Some(config)),
         );
 
         self.process_into_unit(req)
@@ -2363,7 +2359,7 @@ where
         let req = self.build_request(
             &url,
             Builder::new().method(Method::POST),
-            Docker::<C>::transpose_option(Some(options.into_array())),
+            Docker::transpose_option(Some(options.into_array())),
             Ok(Body::empty()),
         );
 
@@ -2486,7 +2482,7 @@ where
         let req = self.build_request(
             &url,
             Builder::new().method(Method::POST),
-            Docker::<C>::transpose_option(options.map(|o| o.into_array())),
+            Docker::transpose_option(options.map(|o| o.into_array())),
             Ok(Body::empty()),
         );
 
@@ -2547,7 +2543,7 @@ where
             Builder::new()
                 .method(Method::PUT)
                 .header(CONTENT_TYPE, "application/x-tar"),
-            Docker::<C>::transpose_option(options.map(|o| o.into_array())),
+            Docker::transpose_option(options.map(|o| o.into_array())),
             Ok(tar),
         );
 
@@ -2597,7 +2593,7 @@ where
         let req = self.build_request(
             &url,
             Builder::new().method(Method::GET),
-            Docker::<C>::transpose_option(options.map(|o| o.into_array())),
+            Docker::transpose_option(options.map(|o| o.into_array())),
             Ok(Body::empty()),
         );
 
@@ -2605,10 +2601,7 @@ where
     }
 }
 
-impl<C> DockerChain<C>
-where
-    C: Connect + Sync + 'static,
-{
+impl DockerChain {
     /// ---
     ///
     /// # Kill Container
@@ -2643,7 +2636,7 @@ where
         self,
         container_name: &str,
         options: Option<T>,
-    ) -> impl Future<Item = (DockerChain<C>, ()), Error = Error>
+    ) -> impl Future<Item = (DockerChain, ()), Error = Error>
     where
         T: KillContainerQueryParams<K, V>,
         K: AsRef<str>,
@@ -2691,7 +2684,7 @@ where
         self,
         container_name: &str,
         options: Option<T>,
-    ) -> impl Future<Item = (DockerChain<C>, ()), Error = Error>
+    ) -> impl Future<Item = (DockerChain, ()), Error = Error>
     where
         T: RemoveContainerQueryParams<K, V>,
         K: AsRef<str>,
@@ -2744,7 +2737,7 @@ where
         self,
         options: Option<T>,
         config: Config<Z>,
-    ) -> impl Future<Item = (DockerChain<C>, CreateContainerResults), Error = Error>
+    ) -> impl Future<Item = (DockerChain, CreateContainerResults), Error = Error>
     where
         T: CreateContainerQueryParams<K, V>,
         K: AsRef<str>,
@@ -2786,7 +2779,7 @@ where
         self,
         container_name: &str,
         options: Option<T>,
-    ) -> impl Future<Item = (DockerChain<C>, ()), Error = Error>
+    ) -> impl Future<Item = (DockerChain, ()), Error = Error>
     where
         T: StartContainerQueryParams<K, V>,
         K: AsRef<str>,
@@ -2830,7 +2823,7 @@ where
         self,
         container_name: &str,
         options: Option<T>,
-    ) -> impl Future<Item = (DockerChain<C>, ()), Error = Error>
+    ) -> impl Future<Item = (DockerChain, ()), Error = Error>
     where
         T: StopContainerQueryParams<K>,
         K: AsRef<str>,
@@ -2879,7 +2872,7 @@ where
     pub fn list_containers<T, K>(
         self,
         options: Option<T>,
-    ) -> impl Future<Item = (DockerChain<C>, Vec<APIContainers>), Error = Error>
+    ) -> impl Future<Item = (DockerChain, Vec<APIContainers>), Error = Error>
     where
         T: ListContainersQueryParams<K, String>,
         K: AsRef<str>,
@@ -2926,7 +2919,7 @@ where
         options: Option<T>,
     ) -> impl Future<
         Item = (
-            DockerChain<C>,
+            DockerChain,
             impl Stream<Item = WaitContainerResults, Error = Error>,
         ),
         Error = Error,
@@ -2979,7 +2972,7 @@ where
         self,
         container_name: &str,
         options: Option<T>,
-    ) -> impl Future<Item = (DockerChain<C>, Container), Error = Error>
+    ) -> impl Future<Item = (DockerChain, Container), Error = Error>
     where
         T: InspectContainerQueryParams<K, V>,
         K: AsRef<str>,
@@ -3024,7 +3017,7 @@ where
         self,
         container_name: &str,
         options: Option<T>,
-    ) -> impl Future<Item = (DockerChain<C>, ()), Error = Error>
+    ) -> impl Future<Item = (DockerChain, ()), Error = Error>
     where
         T: RestartContainerQueryParams<K>,
         K: AsRef<str>,
@@ -3067,7 +3060,7 @@ where
         self,
         container_name: &str,
         options: Option<T>,
-    ) -> impl Future<Item = (DockerChain<C>, TopResult), Error = Error>
+    ) -> impl Future<Item = (DockerChain, TopResult), Error = Error>
     where
         T: TopQueryParams<K, V>,
         K: AsRef<str>,
@@ -3115,7 +3108,7 @@ where
         self,
         container_name: &str,
         options: Option<T>,
-    ) -> impl Future<Item = (DockerChain<C>, impl Stream<Item = LogOutput, Error = Error>), Error = Error>
+    ) -> impl Future<Item = (DockerChain, impl Stream<Item = LogOutput, Error = Error>), Error = Error>
     where
         T: LogsQueryParams<K>,
         K: AsRef<str>,
@@ -3156,7 +3149,7 @@ where
     pub fn container_changes(
         self,
         container_name: &str,
-    ) -> impl Future<Item = (DockerChain<C>, Option<Vec<Change>>), Error = Error> {
+    ) -> impl Future<Item = (DockerChain, Option<Vec<Change>>), Error = Error> {
         self.inner
             .container_changes(container_name)
             .map(|result| (self, result))
@@ -3196,7 +3189,7 @@ where
         self,
         container_name: &str,
         options: Option<T>,
-    ) -> impl Future<Item = (DockerChain<C>, impl Stream<Item = Stats, Error = Error>), Error = Error>
+    ) -> impl Future<Item = (DockerChain, impl Stream<Item = Stats, Error = Error>), Error = Error>
     where
         T: StatsQueryParams<K, V>,
         K: AsRef<str>,
@@ -3249,7 +3242,7 @@ where
         self,
         container_name: &str,
         config: UpdateContainerOptions,
-    ) -> impl Future<Item = (DockerChain<C>, ()), Error = Error> {
+    ) -> impl Future<Item = (DockerChain, ()), Error = Error> {
         self.inner
             .update_container(container_name, config)
             .map(|result| (self, result))
@@ -3289,7 +3282,7 @@ where
         self,
         container_name: &str,
         options: T,
-    ) -> impl Future<Item = (DockerChain<C>, ()), Error = Error>
+    ) -> impl Future<Item = (DockerChain, ()), Error = Error>
     where
         T: RenameContainerQueryParams<K, V>,
         K: AsRef<str>,
@@ -3327,7 +3320,7 @@ where
     pub fn pause_container(
         self,
         container_name: &str,
-    ) -> impl Future<Item = (DockerChain<C>, ()), Error = Error> {
+    ) -> impl Future<Item = (DockerChain, ()), Error = Error> {
         self.inner
             .pause_container(container_name)
             .map(|result| (self, result))
@@ -3355,7 +3348,7 @@ where
     pub fn unpause_container(
         self,
         container_name: &str,
-    ) -> impl Future<Item = (DockerChain<C>, ()), Error = Error> {
+    ) -> impl Future<Item = (DockerChain, ()), Error = Error> {
         self.inner
             .unpause_container(container_name)
             .map(|result| (self, result))
@@ -3399,7 +3392,7 @@ where
     pub fn prune_containers<T, K>(
         self,
         options: Option<T>,
-    ) -> impl Future<Item = (DockerChain<C>, PruneContainersResults), Error = Error>
+    ) -> impl Future<Item = (DockerChain, PruneContainersResults), Error = Error>
     where
         T: PruneContainersQueryParams<K>,
         K: AsRef<str> + Eq + Hash,
@@ -3452,7 +3445,7 @@ where
         container_name: &str,
         options: Option<T>,
         tar: Body,
-    ) -> impl Future<Item = (DockerChain<C>, ()), Error = Error>
+    ) -> impl Future<Item = (DockerChain, ()), Error = Error>
     where
         T: UploadToContainerQueryParams<K, V>,
         K: AsRef<str>,
@@ -3498,7 +3491,7 @@ where
         self,
         container_name: &str,
         options: Option<T>,
-    ) -> impl Future<Item = (DockerChain<C>, impl Stream<Item = Chunk, Error = Error>), Error = Error>
+    ) -> impl Future<Item = (DockerChain, impl Stream<Item = Chunk, Error = Error>), Error = Error>
     where
         T: DownloadFromContainerQueryParams<K, V>,
         K: AsRef<str>,
@@ -3531,7 +3524,7 @@ mod tests {
             "HTTP/1.1 200 OK\r\nServer: mock1\r\nContent-Type: application/json\r\nContent-Length: 89\r\n\r\n{\"Id\":\"696ce476e95d5122486cac5a446280c56aa0b02617690936e25243195992d3cc\",\"Warnings\":null}\r\n\r\n".to_string()
         );
 
-        let docker = Docker::connect_with(connector, "_".to_string(), 5).unwrap();
+        let docker = Docker::connect_with_host_to_reply(connector, "_".to_string(), 5).unwrap();
 
         let options = Some(CreateContainerOptions {
             name: "unit-test".to_string(),
@@ -3570,7 +3563,7 @@ mod tests {
             "HTTP/1.1 200 OK\r\nServer: mock1\r\nContent-Type: application/json\r\nContent-Length: 0\r\n\r\n".to_string()
         );
 
-        let docker = Docker::connect_with(connector, "_".to_string(), 5).unwrap();
+        let docker = Docker::connect_with_host_to_reply(connector, "_".to_string(), 5).unwrap();
 
         let results = docker.start_container("hello-world", None::<StartContainerOptions<String>>);
 
@@ -3595,7 +3588,7 @@ mod tests {
             "HTTP/1.1 200 OK\r\nServer: mock1\r\nContent-Type: application/json\r\nContent-Length: 0\r\n\r\n".to_string()
         );
 
-        let docker = Docker::connect_with(connector, "_".to_string(), 5).unwrap();
+        let docker = Docker::connect_with_host_to_reply(connector, "_".to_string(), 5).unwrap();
 
         let results = docker.stop_container("hello-world", None::<StopContainerOptions>);
 
@@ -3622,7 +3615,7 @@ mod tests {
             "HTTP/1.1 200 OK\r\nServer: mock1\r\nContent-Type: application/json\r\nContent-Length: 0\r\n\r\n".to_string()
         );
 
-        let docker = Docker::connect_with(connector, "_".to_string(), 5).unwrap();
+        let docker = Docker::connect_with_host_to_reply(connector, "_".to_string(), 5).unwrap();
 
         let options = Some(RemoveContainerOptions {
             force: true,
@@ -3652,7 +3645,7 @@ mod tests {
             "HTTP/1.1 200 OK\r\nServer: mock1\r\nContent-Type: application/json\r\nContent-Length: 33\r\n\r\n{\"Error\":null,\"StatusCode\":0}\r\n\r\n".to_string()
         );
 
-        let docker = Docker::connect_with(connector, "_".to_string(), 5).unwrap();
+        let docker = Docker::connect_with_host_to_reply(connector, "_".to_string(), 5).unwrap();
 
         let options = Some(WaitContainerOptions {
             condition: String::from("not-running"),
@@ -3683,7 +3676,7 @@ mod tests {
             "HTTP/1.1 200 OK\r\nServer: mock1\r\nContent-Type: application/json\r\nContent-Length: 0\r\n\r\n".to_string()
         );
 
-        let docker = Docker::connect_with(connector, "_".to_string(), 5).unwrap();
+        let docker = Docker::connect_with_host_to_reply(connector, "_".to_string(), 5).unwrap();
 
         let options = Some(RestartContainerOptions { t: 30 });
 
@@ -3711,7 +3704,7 @@ mod tests {
             "HTTP/1.1 200 OK\r\nServer: mock1\r\nContent-Type: application/json\r\nContent-Length: 2596\r\n\r\n{\"Id\":\"156ffa6b4233d93b91dc3185b9de7225c22350d55a6db250549039a7e53efda7\",\"Created\":\"2018-10-06T15:15:43.525300512Z\",\"Path\":\"/usr/sbin/run_uhttpd\",\"Args\":[],\"State\":{\"Status\":\"running\",\"Running\":true,\"Paused\":false,\"Restarting\":false,\"OOMKilled\":false,\"Dead\":false,\"Pid\":28837,\"ExitCode\":0,\"Error\":\"\",\"StartedAt\":\"2018-10-06T15:15:54.444625149Z\",\"FinishedAt\":\"2018-10-06T15:15:53.958358249Z\"},\"Image\":\"sha256:df0db1779d4d71e169756bbcc7757f3d3d8b99032f4022c44509bf9b8f297997\",\"ResolvConfPath\":\"/home/docker/containers/156ffa6b4233d93b91dc3185b9de7225c22350d55a6db250549039a7e53efda7/resolv.conf\",\"HostnamePath\":\"/home/docker/containers/156ffa6b4233d93b91dc3185b9de7225c22350d55a6db250549039a7e53efda7/hostname\",\"HostsPath\":\"/home/docker/containers/156ffa6b4233d93b91dc3185b9de7225c22350d55a6db250549039a7e53efda7/hosts\",\"LogPath\":\"/home/docker/containers/156ffa6b4233d93b91dc3185b9de7225c22350d55a6db250549039a7e53efda7/156ffa6b4233d93b91dc3185b9de7225c22350d55a6db250549039a7e53efda7-json.log\",\"Name\":\"/integration_test_restart_container\",\"RestartCount\":0,\"Driver\":\"overlay2\",\"Platform\":\"linux\",\"MountLabel\":\"\",\"ProcessLabel\":\"\",\"AppArmorProfile\":\"docker-default\",\"ExecIDs\":null,\"HostConfig\":{},\"GraphDriver\":{\"Data\":null,\"Name\":\"overlay2\"},\"Mounts\":[],\"Config\":{\"Hostname\":\"156ffa6b4233\",\"Domainname\":\"\",\"User\":\"\",\"AttachStdin\":false,\"AttachStdout\":false,\"AttachStderr\":false,\"ExposedPorts\":{\"80/tcp\":{}},\"Tty\":false,\"OpenStdin\":false,\"StdinOnce\":false,\"Env\":[],\"Cmd\":null,\"Image\":\"fnichol/uhttpd\",\"Volumes\":{\"/www\":{}},\"WorkingDir\":\"\",\"Entrypoint\":[\"/usr/sbin/run_uhttpd\",\"-f\",\"-p\",\"80\",\"-h\",\"/www\"],\"OnBuild\":null,\"Labels\":{}},\"NetworkSettings\":{\"Bridge\":\"\",\"SandboxID\":\"20cd513ef83bc14934be89953d22aab5a54c7769b07c8e93e90f0227d0aba96b\",\"HairpinMode\":false,\"LinkLocalIPv6Address\":\"\",\"LinkLocalIPv6PrefixLen\":0,\"Ports\":{\"80/tcp\":null},\"SandboxKey\":\"/var/run/docker/netns/20cd513ef83b\",\"SecondaryIPAddresses\":null,\"SecondaryIPv6Addresses\":null,\"EndpointID\":\"992f7e94fd721f627d9d1611c27b477d39b959c209286c38426215ea764f6d63\",\"Gateway\":\"172.17.0.1\",\"GlobalIPv6Address\":\"\",\"GlobalIPv6PrefixLen\":0,\"IPAddress\":\"172.17.0.3\",\"IPPrefixLen\":16,\"IPv6Gateway\":\"\",\"MacAddress\":\"02:42:ac:11:00:03\",\"Networks\":{\"bridge\":{\"IPAMConfig\":null,\"Links\":null,\"Aliases\":null,\"NetworkID\":\"424a1638d72f8984c670bc8bf269102360f24bd356188635ab359cb0b0792b20\",\"EndpointID\":\"992f7e94fd721f627d9d1611c27b477d39b959c209286c38426215ea764f6d63\",\"Gateway\":\"172.17.0.1\",\"IPAddress\":\"172.17.0.3\",\"IPPrefixLen\":16,\"IPv6Gateway\":\"\",\"GlobalIPv6Address\":\"\",\"GlobalIPv6PrefixLen\":0,\"MacAddress\":\"02:42:ac:11:00:03\",\"DriverOpts\":null}}}}\r\n\r\n".to_string()
         );
 
-        let docker = Docker::connect_with(connector, "_".to_string(), 5).unwrap();
+        let docker = Docker::connect_with_host_to_reply(connector, "_".to_string(), 5).unwrap();
 
         let results = docker.inspect_container("uhttpd", None::<InspectContainerOptions>);
 
@@ -3738,7 +3731,7 @@ mod tests {
             "HTTP/1.1 200 OK\r\nServer: mock1\r\nContent-Type: application/json\r\nContent-Length: 243\r\n\r\n{\"Processes\":[[\"root\",\"3773\",\"0.0\",\"0.0\",\"11056\",\"348\",\"?\",\"Ss\",\"19:42\",\"0:00\",\"/usr/sbin/uhttpd -f -p 80 -h /www /usr/sbin/run_uhttpd -f -p 80 -h /www\"]],\"Titles\":[\"USER\",\"PID\",\"%CPU\",\"%MEM\",\"VSZ\",\"RSS\",\"TTY\",\"STAT\",\"START\",\"TIME\",\"COMMAND\"]}\r\n\r\n".to_string()
         );
 
-        let docker = Docker::connect_with(connector, "_".to_string(), 5).unwrap();
+        let docker = Docker::connect_with_host_to_reply(connector, "_".to_string(), 5).unwrap();
 
         let results = docker.top_processes(
             "uhttpd",
@@ -3769,7 +3762,7 @@ mod tests {
             "HTTP/1.1 200 OK\r\nServer: mock1\r\nContent-Type: application/json\r\nContent-Length: 28\r\n\r\n\u{1}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{13}Hello from Docker!\n\n".to_string()
         );
 
-        let docker = Docker::connect_with(connector, "_".to_string(), 5).unwrap();
+        let docker = Docker::connect_with_host_to_reply(connector, "_".to_string(), 5).unwrap();
 
         let stream = docker.logs(
             "hello-world",
@@ -3806,7 +3799,7 @@ mod tests {
             "HTTP/1.1 200 OK\r\nServer: mock1\r\nContent-Type: application/json\r\nContent-Length: 4\r\n\r\nnull\r\n\r\n".to_string()
         );
 
-        let docker = Docker::connect_with(connector, "_".to_string(), 5).unwrap();
+        let docker = Docker::connect_with_host_to_reply(connector, "_".to_string(), 5).unwrap();
 
         let result = docker.container_changes("hello-world");
 
@@ -3832,7 +3825,7 @@ mod tests {
             "HTTP/1.1 200 OK\r\nServer: mock1\r\nContent-Type: application/json\r\nContent-Length: 1879\r\n\r\n{\"read\":\"2018-10-19T06:11:22.220728356Z\",\"preread\":\"2018-10-19T06:11:21.218466258Z\",\"pids_stats\":{\"current\":1,\"limit\":1000},\"blkio_stats\":{\"io_service_bytes_recursive\":[],\"io_serviced_recursive\":[],\"io_queue_recursive\":[],\"io_service_time_recursive\":[],\"io_wait_time_recursive\":[],\"io_merged_recursive\":[],\"io_time_recursive\":[],\"sectors_recursive\":[]},\"num_procs\":0,\"storage_stats\":{},\"cpu_stats\":{\"cpu_usage\":{\"total_usage\":23097208,\"percpu_usage\":[709093,1595689,5032998,15759428],\"usage_in_kernelmode\":0,\"usage_in_usermode\":10000000},\"system_cpu_usage\":4447677200000000,\"online_cpus\":4,\"throttling_data\":{\"periods\":0,\"throttled_periods\":0,\"throttled_time\":0}},\"precpu_stats\":{\"cpu_usage\":{\"total_usage\":23097208,\"percpu_usage\":[709093,1595689,5032998,15759428],\"usage_in_kernelmode\":0,\"usage_in_usermode\":10000000},\"system_cpu_usage\":4447673150000000,\"online_cpus\":4,\"throttling_data\":{\"periods\":0,\"throttled_periods\":0,\"throttled_time\":0}},\"memory_stats\":{\"usage\":962560,\"max_usage\":5406720,\"stats\":{\"active_anon\":86016,\"active_file\":0,\"cache\":0,\"dirty\":0,\"hierarchical_memory_limit\":9223372036854771712,\"hierarchical_memsw_limit\":0,\"inactive_anon\":0,\"inactive_file\":0,\"mapped_file\":0,\"pgfault\":1485,\"pgmajfault\":0,\"pgpgin\":1089,\"pgpgout\":1084,\"rss\":0,\"rss_huge\":0,\"total_active_anon\":86016,\"total_active_file\":0,\"total_cache\":0,\"total_dirty\":0,\"total_inactive_anon\":0,\"total_inactive_file\":0,\"total_mapped_file\":0,\"total_pgfault\":1485,\"total_pgmajfault\":0,\"total_pgpgin\":1089,\"total_pgpgout\":1084,\"total_rss\":0,\"total_rss_huge\":0,\"total_unevictable\":0,\"total_writeback\":0,\"unevictable\":0,\"writeback\":0},\"limit\":16750219264},\"name\":\"/integration_test_stats\",\"id\":\"66667eab5737dda2da2f578e9496e45c074d1bc5badc0484314f1c3afccfaeb0\",\"networks\":{\"eth0\":{\"rx_bytes\":1635,\"rx_packets\":14,\"rx_errors\":0,\"rx_dropped\":0,\"tx_bytes\":0,\"tx_packets\":0,\"tx_errors\":0,\"tx_dropped\":0}}}\r\n\r\n".to_string()
         );
 
-        let docker = Docker::connect_with(connector, "_".to_string(), 5).unwrap();
+        let docker = Docker::connect_with_host_to_reply(connector, "_".to_string(), 5).unwrap();
 
         let stream = docker.stats("hello-world", Some(StatsOptions { stream: false }));
 
@@ -3859,7 +3852,7 @@ mod tests {
             "HTTP/1.1 200 OK\r\nServer: mock1\r\nContent-Type: application/json\r\nContent-Length: 0\r\n\r\n".to_string()
         );
 
-        let docker = Docker::connect_with(connector, "_".to_string(), 5).unwrap();
+        let docker = Docker::connect_with_host_to_reply(connector, "_".to_string(), 5).unwrap();
 
         let options = Some(KillContainerOptions {
             signal: "SIGKILL".to_string(),
@@ -3888,7 +3881,7 @@ mod tests {
             "HTTP/1.1 200 OK\r\nServer: mock1\r\nContent-Type: application/json\r\nContent-Length: 0\r\n\r\n".to_string()
         );
 
-        let docker = Docker::connect_with(connector, "_".to_string(), 5).unwrap();
+        let docker = Docker::connect_with_host_to_reply(connector, "_".to_string(), 5).unwrap();
 
         let config = UpdateContainerOptions {
             memory: Some(314572800),
@@ -3919,7 +3912,7 @@ mod tests {
             "HTTP/1.1 200 OK\r\nServer: mock1\r\nContent-Type: application/json\r\nContent-Length: 0\r\n\r\n".to_string()
         );
 
-        let docker = Docker::connect_with(connector, "_".to_string(), 5).unwrap();
+        let docker = Docker::connect_with_host_to_reply(connector, "_".to_string(), 5).unwrap();
 
         let options = RenameContainerOptions {
             name: "my_new_container_name".to_string(),
@@ -3948,7 +3941,7 @@ mod tests {
             "HTTP/1.1 200 OK\r\nServer: mock1\r\nContent-Type: application/json\r\nContent-Length: 0\r\n\r\n".to_string()
         );
 
-        let docker = Docker::connect_with(connector, "_".to_string(), 5).unwrap();
+        let docker = Docker::connect_with_host_to_reply(connector, "_".to_string(), 5).unwrap();
 
         let results = docker.pause_container("postgres");
 
@@ -3973,7 +3966,7 @@ mod tests {
             "HTTP/1.1 200 OK\r\nServer: mock1\r\nContent-Type: application/json\r\nContent-Length: 0\r\n\r\n".to_string()
         );
 
-        let docker = Docker::connect_with(connector, "_".to_string(), 5).unwrap();
+        let docker = Docker::connect_with_host_to_reply(connector, "_".to_string(), 5).unwrap();
 
         let results = docker.unpause_container("postgres");
 
@@ -3998,7 +3991,7 @@ mod tests {
             "HTTP/1.1 200 OK\r\nServer: mock1\r\nContent-Type: application/json\r\nContent-Length: 45\r\n\r\n{\"ContainersDeleted\":null,\"SpaceReclaimed\":0}\r\n\r\n".to_string()
         );
 
-        let docker = Docker::connect_with(connector, "_".to_string(), 5).unwrap();
+        let docker = Docker::connect_with_host_to_reply(connector, "_".to_string(), 5).unwrap();
 
         let results = docker.prune_containers(None::<PruneContainersOptions<String>>);
 

--- a/src/docker.rs
+++ b/src/docker.rs
@@ -130,7 +130,7 @@ impl fmt::Debug for Transport {
             #[cfg(unix)]
             Transport::Unix { .. } => write!(f, "Unix"),
             #[cfg(windows)]
-            Tranport::NamedPipe { .. } => write!(f, "NamedPipe"),
+            Transport::NamedPipe { .. } => write!(f, "NamedPipe"),
             #[cfg(test)]
             Transport::HostToReply { .. } => write!(f, "HostToReply"),
         }

--- a/src/docker.rs
+++ b/src/docker.rs
@@ -152,6 +152,7 @@ impl fmt::Debug for Transport {
 ///  - [`Docker::connect_with_ssl_defaults`](struct.Docker.html#method.connect_with_ssl_defaults)
 ///  - [`Docker::connect_with_unix_defaults`](struct.Docker.html#method.connect_with_unix_defaults)
 ///  - [`Docker::connect_with_tls_defaults`](struct.Docker.html#method.connect_with_tls_defaults)
+///  - [`Docker::connect_with_local_defaults`](struct.Docker.html#method.connect_with_local_defaults)
 #[derive(Debug)]
 pub struct Docker {
     pub(crate) transport: Arc<Transport>,
@@ -518,6 +519,40 @@ impl Docker {
         };
 
         Ok(docker)
+    }
+}
+
+/// A Docker implementation that wraps away which local implementation we are calling.
+#[cfg(any(unix, windows))]
+impl Docker {
+    /// Connect using the local machine connection method with default arguments.
+    ///
+    /// This is a simple wrapper over the OS specific handlers:
+    ///  * Unix: [`Docker::connect_with_unix_defaults`]
+    ///  * Windows: [`Docker::connect_with_named_pipe_defaults`]
+    ///
+    /// [`Docker::connect_with_unix_defaults`]: struct.Docker.html#method.connect_with_unix_defaults
+    /// [`Docker::connect_with_named_pipe_defaults`]: struct.Docker.html#method.connect_with_named_pipe_defaults
+    pub fn connect_with_local_defaults() -> Result<Docker, Error> {
+        #[cfg(unix)]
+        return Docker::connect_with_unix_defaults();
+        #[cfg(windows)]
+        return Docker::connect_with_named_pipe_defaults();
+    }
+
+    /// Connect using the local machine connection method with supplied arguments.
+    ///
+    /// This is a simple wrapper over the OS specific handlers:
+    ///  * Unix: [`Docker::connect_with_unix`]
+    ///  * Windows: [`Docker::connect_with_named_pipe`]
+    ///
+    /// [`Docker::connect_with_unix`]: struct.Docker.html#method.connect_with_unix
+    /// [`Docker::connect_with_named_pipe`]: struct.Docker.html#method.connect_with_named_pipe
+    pub fn connect_with_local(addr: &str, timeout: u64) -> Result<Docker, Error> {
+        #[cfg(unix)]
+        return Docker::connect_with_unix(addr, timeout);
+        #[cfg(windows)]
+        return Docker::connect_with_named_pipe(addr, timeout);
     }
 }
 

--- a/src/docker.rs
+++ b/src/docker.rs
@@ -114,6 +114,10 @@ pub(crate) enum Transport {
     Unix {
         client: Client<UnixConnector>,
     },
+    #[cfg(windows)]
+    NamedPipe {
+        client: Client<NamedPipeConnector>,
+    }
     #[cfg(test)]
     HostToReply {
         client: Client<HostToReplyConnector>,

--- a/src/docker.rs
+++ b/src/docker.rs
@@ -676,7 +676,7 @@ impl Docker {
     ///
     /// # Arguments
     ///
-    ///  - `connector`: theHostToReplyConnector
+    ///  - `connector`: the HostToReplyConnector.
     ///  - `client_addr`: location to connect to.
     ///  - `timeout`: the read/write timeout (seconds) to use for every hyper connection
     ///
@@ -691,7 +691,7 @@ impl Docker {
     ///
     /// use futures::future::Future;
     ///
-    /// # use hyper_mock::SequentialConnector;
+    /// # use hyper_mock::HostToReplyConnector;
     /// let mut connector = HostToReplyConnector::default();
     /// connector.content.push(
     ///   "HTTP/1.1 200 OK\r\nServer: mock1\r\nContent-Type: application/json\r\nContent-Length: 0\r\n\r\n".to_string()

--- a/src/docker.rs
+++ b/src/docker.rs
@@ -510,7 +510,7 @@ impl Docker<hyper_tls::HttpsConnector<HttpConnector>> {
     /// # }
     /// ```
     pub fn connect_with_tls_defaults(
-) -> Result<Docker<hyper_tls::HttpsConnector<HttpConnector>>, Error> {
+    ) -> Result<Docker<hyper_tls::HttpsConnector<HttpConnector>>, Error> {
         let cert_path = default_cert_path()?;
         if let Ok(ref host) = env::var("DOCKER_HOST") {
             Docker::connect_with_tls(
@@ -801,7 +801,8 @@ where
             Some(Ok(res)) => Ok(Some(res)),
             Some(Err(e)) => Err(e),
             None => Ok(None),
-        }.map_err(|e| e.into())
+        }
+        .map_err(|e| e.into())
         .map(|payload| {
             debug!("{}", payload.clone().unwrap_or_else(String::new));
             payload
@@ -861,7 +862,8 @@ where
                             Err(DockerResponseServerError {
                                 status_code: status.as_u16(),
                                 message,
-                            }.into())
+                            }
+                            .into())
                         },
                     )),
                 }
@@ -954,7 +956,8 @@ where
                         message: e.to_string(),
                         column: e.column(),
                         contents: contents.to_owned(),
-                    }.into()
+                    }
+                    .into()
                 } else {
                     e.into()
                 }

--- a/src/docker.rs
+++ b/src/docker.rs
@@ -117,7 +117,7 @@ pub(crate) enum Transport {
     #[cfg(windows)]
     NamedPipe {
         client: Client<NamedPipeConnector>,
-    }
+    },
     #[cfg(test)]
     HostToReply {
         client: Client<HostToReplyConnector>,

--- a/src/image.rs
+++ b/src/image.rs
@@ -9,7 +9,6 @@ use futures::future::Either;
 use futures::{stream, Stream};
 use http::header::CONTENT_TYPE;
 use http::request::Builder;
-use hyper::client::connect::Connect;
 use hyper::rt::Future;
 use hyper::{Body, Method};
 use serde::Serialize;
@@ -904,10 +903,7 @@ pub enum BuildImageResults {
     },
 }
 
-impl<C> Docker<C>
-where
-    C: Connect + Sync + 'static,
-{
+impl Docker {
     /// ---
     ///
     /// # List Images
@@ -957,7 +953,7 @@ where
         let req = self.build_request(
             url,
             Builder::new().method(Method::GET),
-            Docker::<C>::transpose_option(options.map(|o| o.into_array())),
+            Docker::transpose_option(options.map(|o| o.into_array())),
             Ok(Body::empty()),
         );
 
@@ -1023,7 +1019,7 @@ where
                     Builder::new()
                         .method(Method::POST)
                         .header("X-Registry-Auth", base64::encode(&ser_cred)),
-                    Docker::<C>::transpose_option(options.map(|o| o.into_array())),
+                    Docker::transpose_option(options.map(|o| o.into_array())),
                     Ok(Body::empty()),
                 );
                 EitherStream::A(self.process_into_stream(req))
@@ -1114,7 +1110,7 @@ where
         let req = self.build_request(
             url,
             Builder::new().method(Method::POST),
-            Docker::<C>::transpose_option(options.map(|o| o.into_array())),
+            Docker::transpose_option(options.map(|o| o.into_array())),
             Ok(Body::empty()),
         );
 
@@ -1209,7 +1205,7 @@ where
         let req = self.build_request(
             url,
             Builder::new().method(Method::GET),
-            Docker::<C>::transpose_option(Some(options.into_array())),
+            Docker::transpose_option(Some(options.into_array())),
             Ok(Body::empty()),
         );
 
@@ -1270,7 +1266,7 @@ where
                     Builder::new()
                         .method(Method::DELETE)
                         .header("X-Registry-Auth", base64::encode(&ser_cred)),
-                    Docker::<C>::transpose_option(options.map(|o| o.into_array())),
+                    Docker::transpose_option(options.map(|o| o.into_array())),
                     Ok(Body::empty()),
                 );
                 Either::A(self.process_into_value(req))
@@ -1325,7 +1321,7 @@ where
         let req = self.build_request(
             &url,
             Builder::new().method(Method::POST),
-            Docker::<C>::transpose_option(options.map(|o| o.into_array())),
+            Docker::transpose_option(options.map(|o| o.into_array())),
             Ok(Body::empty()),
         );
 
@@ -1394,7 +1390,7 @@ where
                         .method(Method::POST)
                         .header(CONTENT_TYPE, "application/json")
                         .header("X-Registry-Auth", base64::encode(&ser_cred)),
-                    Docker::<C>::transpose_option(options.map(|o| o.into_array())),
+                    Docker::transpose_option(options.map(|o| o.into_array())),
                     Ok(Body::empty()),
                 );
 
@@ -1458,7 +1454,7 @@ where
             url,
             Builder::new().method(Method::POST),
             options.into_array().map(|v| Some(v)),
-            Docker::<C>::serialize_payload(Some(config)),
+            Docker::serialize_payload(Some(config)),
         );
 
         self.process_into_value(req)
@@ -1542,10 +1538,7 @@ where
     }
 }
 
-impl<C> DockerChain<C>
-where
-    C: Connect + Sync + 'static,
-{
+impl DockerChain {
     /// ---
     ///
     /// # Create Image
@@ -1591,7 +1584,7 @@ where
         credentials: Option<DockerCredentials>,
     ) -> impl Future<
         Item = (
-            DockerChain<C>,
+            DockerChain,
             impl Stream<Item = CreateImageResults, Error = Error>,
         ),
         Error = Error,
@@ -1646,7 +1639,7 @@ where
         self,
         image_name: &str,
         options: Option<T>,
-    ) -> impl Future<Item = (DockerChain<C>, ()), Error = Error>
+    ) -> impl Future<Item = (DockerChain, ()), Error = Error>
     where
         T: TagImageQueryParams<K, V>,
         K: AsRef<str>,
@@ -1702,7 +1695,7 @@ where
         image_name: &str,
         options: Option<T>,
         credentials: Option<DockerCredentials>,
-    ) -> impl Future<Item = (DockerChain<C>, ()), Error = Error>
+    ) -> impl Future<Item = (DockerChain, ()), Error = Error>
     where
         T: PushImageQueryParams<K, V>,
         K: AsRef<str>,
@@ -1750,7 +1743,7 @@ where
         image_name: &str,
         options: Option<T>,
         credentials: Option<DockerCredentials>,
-    ) -> impl Future<Item = (DockerChain<C>, Vec<RemoveImageResults>), Error = Error>
+    ) -> impl Future<Item = (DockerChain, Vec<RemoveImageResults>), Error = Error>
     where
         T: RemoveImageQueryParams<K, V>,
         K: AsRef<str>,
@@ -1800,7 +1793,7 @@ where
     pub fn search_images<T, K>(
         self,
         options: T,
-    ) -> impl Future<Item = (DockerChain<C>, Vec<APIImageSearch>), Error = Error>
+    ) -> impl Future<Item = (DockerChain, Vec<APIImageSearch>), Error = Error>
     where
         T: SearchImagesQueryParams<K>,
         K: AsRef<str>,
@@ -1838,7 +1831,7 @@ where
     pub fn inspect_image(
         self,
         image_name: &str,
-    ) -> impl Future<Item = (DockerChain<C>, Image), Error = Error> {
+    ) -> impl Future<Item = (DockerChain, Image), Error = Error> {
         self.inner
             .inspect_image(image_name)
             .map(|result| (self, result))
@@ -1884,7 +1877,7 @@ where
     pub fn list_images<T, K>(
         self,
         options: Option<T>,
-    ) -> impl Future<Item = (DockerChain<C>, Vec<APIImages>), Error = Error>
+    ) -> impl Future<Item = (DockerChain, Vec<APIImages>), Error = Error>
     where
         T: ListImagesQueryParams<K>,
         K: AsRef<str>,
@@ -1918,7 +1911,7 @@ where
     pub fn image_history(
         self,
         image_name: &str,
-    ) -> impl Future<Item = (DockerChain<C>, Vec<ImageHistory>), Error = Error> {
+    ) -> impl Future<Item = (DockerChain, Vec<ImageHistory>), Error = Error> {
         self.inner
             .image_history(image_name)
             .map(|result| (self, result))
@@ -1959,7 +1952,7 @@ where
     pub fn prune_images<T, K>(
         self,
         options: Option<T>,
-    ) -> impl Future<Item = (DockerChain<C>, PruneImagesResults), Error = Error>
+    ) -> impl Future<Item = (DockerChain, PruneImagesResults), Error = Error>
     where
         T: PruneImagesQueryParams<K>,
         K: AsRef<str>,
@@ -2010,7 +2003,7 @@ where
         self,
         options: T,
         config: Config<Z>,
-    ) -> impl Future<Item = (DockerChain<C>, CommitContainerResults), Error = Error>
+    ) -> impl Future<Item = (DockerChain, CommitContainerResults), Error = Error>
     where
         T: CommitContainerQueryParams<K, V>,
         K: AsRef<str>,
@@ -2076,7 +2069,7 @@ where
         tar: Option<Body>,
     ) -> impl Future<
         Item = (
-            DockerChain<C>,
+            DockerChain,
             impl Stream<Item = BuildImageResults, Error = Error>,
         ),
         Error = Error,
@@ -2112,7 +2105,7 @@ mod tests {
             "HTTP/1.1 200 OK\r\nServer: mock1\r\nContent-Type: application/json\r\nContent-Length: 310\r\n\r\n[{\"Containers\":-1,\"Created\":1484347856,\"Id\":\"sha256:48b5124b2768d2b917edcb640435044a97967015485e812545546cbed5cf0233\",\"Labels\":{},\"ParentId\":\"\",\"RepoDigests\":[\"hello-world@sha256:c5515758d4c5e1e838e9cd307f6c6a0d620b5e07e6f927b07d05f6d12a1ac8d7\"],\"RepoTags\":null,\"SharedSize\":-1,\"Size\":1840,\"VirtualSize\":1840}]\r\n\r\n".to_string()
      );
 
-        let docker = Docker::connect_with(connector, "_".to_string(), 5).unwrap();
+        let docker = Docker::connect_with_host_to_reply(connector, "_".to_string(), 5).unwrap();
 
         let mut filters = HashMap::new();
         filters.insert("dangling", vec!["true"]);
@@ -2147,7 +2140,7 @@ mod tests {
             "HTTP/1.1 200 OK\r\nServer: mock1\r\nContent-Type: application/json\r\nContent-Length: 542\r\n\r\n{\"status\":\"Pulling from library/hello-world\",\"id\":\"latest\"}\r\n{\"status\":\"Digest: sha256:0add3ace90ecb4adbf7777e9aacf18357296e799f81cabc9fde470971e499788\"}\r\n{\"status\":\"Pulling from library/hello-world\",\"id\":\"linux\"}\r\n{\"status\":\"Digest: sha256:d5c7d767f5ba807f9b363aa4db87d75ab030404a670880e16aedff16f605484b\"}\r\n{\"status\":\"Pulling from library/hello-world\",\"id\":\"nanoserver-1709\"}\r\n{\"errorDetail\":{\"message\":\"no matching manifest for unknown in the manifest list entries\"},\"error\":\"no matching manifest for unknown in the manifest list entries\"}\r\n\r\n".to_string()
         );
 
-        let docker = Docker::connect_with(connector, "_".to_string(), 5).unwrap();
+        let docker = Docker::connect_with_host_to_reply(connector, "_".to_string(), 5).unwrap();
 
         let options = Some(CreateImageOptions {
             from_image: String::from("hello-world"),
@@ -2179,7 +2172,7 @@ mod tests {
             "HTTP/1.1 200 OK\r\nServer: mock1\r\nContent-Type: application/json\r\nContent-Length: 1744\r\n\r\n{\"Id\":\"sha256:4ab4c602aa5eed5528a6620ff18a1dc4faef0e1ab3a5eddeddb410714478c67f\",\"RepoTags\":[\"hello-world:latest\",\"hello-world:linux\"],\"RepoDigests\":[\"hello-world@sha256:0add3ace90ecb4adbf7777e9aacf18357296e799f81cabc9fde470971e499788\",\"hello-world@sha256:d5c7d767f5ba807f9b363aa4db87d75ab030404a670880e16aedff16f605484b\"],\"Parent\":\"\",\"Comment\":\"\",\"Created\":\"2018-09-07T19:25:39.809797627Z\",\"Container\":\"15c5544a385127276a51553acb81ed24a9429f9f61d6844db1fa34f46348e420\",\"ContainerConfig\":{\"Hostname\":\"15c5544a3851\",\"Domainname\":\"\",\"User\":\"\",\"AttachStdin\":false,\"AttachStdout\":false,\"AttachStderr\":false,\"Tty\":false,\"OpenStdin\":false,\"StdinOnce\":false,\"Env\":[\"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin\"],\"Cmd\":[\"/bin/sh\",\"-c\",\"#(nop) \",\"CMD [\\\"/hello\\\"]\"],\"ArgsEscaped\":true,\"Image\":\"sha256:9a5813f1116c2426ead0a44bbec252bfc5c3d445402cc1442ce9194fc1397027\",\"Volumes\":null,\"WorkingDir\":\"\",\"Entrypoint\":null,\"OnBuild\":null,\"Labels\":{}},\"DockerVersion\":\"17.06.2-ce\",\"Author\":\"\",\"Config\":{\"Hostname\":\"\",\"Domainname\":\"\",\"User\":\"\",\"AttachStdin\":false,\"AttachStdout\":false,\"AttachStderr\":false,\"Tty\":false,\"OpenStdin\":false,\"StdinOnce\":false,\"Env\":[\"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin\"],\"Cmd\":[\"/hello\"],\"ArgsEscaped\":true,\"Image\":\"sha256:9a5813f1116c2426ead0a44bbec252bfc5c3d445402cc1442ce9194fc1397027\",\"Volumes\":null,\"WorkingDir\":\"\",\"Entrypoint\":null,\"OnBuild\":null,\"Labels\":null},\"Architecture\":\"amd64\",\"Os\":\"linux\",\"Size\":1840,\"VirtualSize\":1840,\"GraphDriver\":{\"Data\":{\"MergedDir\":\"\",\"UpperDir\":\"\",\"WorkDir\":\"\"},\"Name\":\"overlay2\"},\"RootFS\":{\"Type\":\"layers\",\"Layers\":[\"sha256:428c97da766c4c13b19088a471de6b622b038f3ae8efa10ec5a37d6d31a2df0b\"]},\"Metadata\":{\"LastTagTime\":\"0001-01-01T00:00:00Z\"}}\r\n\r\n".to_string()
         );
 
-        let docker = Docker::connect_with(connector, "_".to_string(), 5).unwrap();
+        let docker = Docker::connect_with_host_to_reply(connector, "_".to_string(), 5).unwrap();
 
         let image = docker.inspect_image("hello-world");
 
@@ -2204,7 +2197,7 @@ mod tests {
             "HTTP/1.1 200 OK\r\nServer: mock1\r\nContent-Type: application/json\r\nContent-Length: 42\r\n\r\n{\"ImagesDeleted\":null,\"SpaceReclaimed\":40}\r\n\r\n".to_string()
         );
 
-        let docker = Docker::connect_with(connector, "_".to_string(), 5).unwrap();
+        let docker = Docker::connect_with_host_to_reply(connector, "_".to_string(), 5).unwrap();
 
         let prune_images_results = docker.prune_images(None::<PruneImagesOptions<String>>);
 
@@ -2229,7 +2222,7 @@ mod tests {
             "HTTP/1.1 200 OK\r\nServer: mock1\r\nContent-Type: application/json\r\nContent-Length: 415\r\n\r\n[{\"Comment\":\"\",\"Created\":1536348339,\"CreatedBy\":\"/bin/sh -c #(nop)  CMD [\\\"/hello\\\"]\",\"Id\":\"sha256:4ab4c602aa5eed5528a6620ff18a1dc4faef0e1ab3a5eddeddb410714478c67f\",\"Size\":0,\"Tags\":[\"hello-world:latest\",\"hello-world:linux\"]},{\"Comment\":\"\",\"Created\":1536348339,\"CreatedBy\":\"/bin/sh -c #(nop) COPY file:9824c33ef192ac944822908370af9f04ab049bfa5c10724e4f727206f5167094 in / \",\"Id\":\"<missing>\",\"Size\":1840,\"Tags\":null}]\r\n\r\n".to_string()
       );
 
-        let docker = Docker::connect_with(connector, "_".to_string(), 5).unwrap();
+        let docker = Docker::connect_with_host_to_reply(connector, "_".to_string(), 5).unwrap();
 
         let image_history_results = docker.image_history("hello-world");
 
@@ -2260,7 +2253,7 @@ mod tests {
             "HTTP/1.1 200 OK\r\nServer: mock1\r\nContent-Type: application/json\r\nContent-Length: 148\r\n\r\n[{\"star_count\":660,\"is_official\":true,\"name\":\"hello-world\",\"is_automated\":false,\"description\":\"Hello World! (an example of minimal Dockerization)\"}]\r\n\r\n".to_string()
         );
 
-        let docker = Docker::connect_with(connector, "_".to_string(), 5).unwrap();
+        let docker = Docker::connect_with_host_to_reply(connector, "_".to_string(), 5).unwrap();
 
         let search_options = SearchImagesOptions {
             term: "hello-world".to_string(),
@@ -2294,7 +2287,7 @@ mod tests {
             "HTTP/1.1 200 OK\r\nServer: mock1\r\nContent-Type: application/json\r\nContent-Length: 35\r\n\r\n[{\"Untagged\":\"hello-world:latest\"}]\r\n\r\n".to_string()
         );
 
-        let docker = Docker::connect_with(connector, "_".to_string(), 5).unwrap();
+        let docker = Docker::connect_with_host_to_reply(connector, "_".to_string(), 5).unwrap();
 
         let remove_options = RemoveImageOptions {
             noprune: true,
@@ -2331,7 +2324,7 @@ mod tests {
             "HTTP/1.1 200 OK\r\nServer: mock1\r\nContent-Type: application/json\r\nContent-Length: 0\r\n\r\n".to_string()
         );
 
-        let docker = Docker::connect_with(connector, "_".to_string(), 5).unwrap();
+        let docker = Docker::connect_with_host_to_reply(connector, "_".to_string(), 5).unwrap();
 
         let push_options = PushImageOptions {
             tag: "v1.0.1".to_string(),
@@ -2366,7 +2359,7 @@ mod tests {
             "HTTP/1.1 200 OK\r\nServer: mock1\r\nContent-Type: application/json\r\nContent-Length: 0\r\n\r\n".to_string()
         );
 
-        let docker = Docker::connect_with(connector, "_".to_string(), 5).unwrap();
+        let docker = Docker::connect_with_host_to_reply(connector, "_".to_string(), 5).unwrap();
 
         let tag_options = TagImageOptions {
             tag: "v1.0.1".to_string(),
@@ -2396,7 +2389,7 @@ mod tests {
             "HTTP/1.1 200 OK\r\nServer: mock1\r\nContent-Type: application/json\r\nContent-Length: 80\r\n\r\n{\"Id\":\"sha256:c69d56ed58eb9b519bb3de569de7e83f5c3eff57858eaa7883a9e206cf7ca5eb\"}\r\n\r\n".to_string()
         );
 
-        let docker = Docker::connect_with(connector, "_".to_string(), 5).unwrap();
+        let docker = Docker::connect_with_host_to_reply(connector, "_".to_string(), 5).unwrap();
 
         let commit_container_options = CommitContainerOptions {
             container: "my-running-container",
@@ -2432,7 +2425,7 @@ mod tests {
             "HTTP/1.1 200 OK\r\nServer: mock1\r\nContent-Type: application/x-tar\r\nContent-Length: 520\r\n\r\n{\"stream\":\"Step 1/2 : FROM alpine\"}\r\n{\"stream\":\"\\n\"}\r\n{\"stream\":\" ---\\u003e 3f53bb00af94\\n\"}\r\n{\"stream\":\"Step 2/2 : RUN touch bollard.txt\"}\r\n{\"stream\":\"\\n\"}\r\n{\"stream\":\" ---\\u003e Running in 853fceb48e80\\n\"}\r\n{\"stream\":\"Removing intermediate container 853fceb48e80\\n\"}\r\n{\"stream\":\" ---\\u003e 5949ad5433c9\\n\"}\r\n{\"aux\":{\"ID\":\"sha256:5949ad5433c96bb38c6a60acc84653600ccb06f1bdd7216acdba752bc2da7460\"}}\r\n{\"stream\":\"Successfully built 5949ad5433c9\\n\"}\r\n{\"stream\":\"Successfully tagged integration_test_build_image:latest\\n\"}\r\n".to_string()
         );
 
-        let docker = Docker::connect_with(connector, "_".to_string(), 5).unwrap();
+        let docker = Docker::connect_with_host_to_reply(connector, "_".to_string(), 5).unwrap();
 
         let build_image_options = BuildImageOptions {
             t: "my-image",

--- a/src/image.rs
+++ b/src/image.rs
@@ -1,5 +1,6 @@
 //! Image API: creating, manipulating and pushing docker images
 use arrayvec::ArrayVec;
+use base64;
 use chrono::serde::ts_seconds;
 use chrono::{DateTime, Utc};
 use failure::Error;
@@ -13,7 +14,6 @@ use hyper::rt::Future;
 use hyper::{Body, Method};
 use serde::Serialize;
 use serde_json;
-use base64;
 
 use super::{Docker, DockerChain};
 use auth::DockerCredentials;
@@ -805,7 +805,8 @@ impl<'a> BuildImageQueryParams<&'a str> for BuildImageOptions<&'a str> {
                 self.cpuperiod.map(|v| ("cpuperiod", v.to_string())),
                 self.cpuquota.map(|v| ("cpuperiod", v.to_string())),
                 self.shmsize.map(|v| ("shmsize", v.to_string())),
-            ].into_iter()
+            ]
+            .into_iter()
             .flatten(),
         );
 
@@ -841,7 +842,8 @@ impl<'a> BuildImageQueryParams<&'a str> for BuildImageOptions<String> {
                 self.cpuperiod.map(|v| ("cpuperiod", v.to_string())),
                 self.cpuquota.map(|v| ("cpuperiod", v.to_string())),
                 self.shmsize.map(|v| ("shmsize", v.to_string())),
-            ].into_iter()
+            ]
+            .into_iter()
             .flatten(),
         );
 
@@ -2089,7 +2091,8 @@ where
             .map(|(first, rest)| match first {
                 Some(head) => (self, EitherStream::A(stream::once(Ok(head)).chain(rest))),
                 None => (self, EitherStream::B(stream::empty())),
-            }).map_err(|(err, _)| err)
+            })
+            .map_err(|(err, _)| err)
     }
 }
 
@@ -2129,7 +2132,8 @@ mod tests {
             .or_else(|e| {
                 println!("{:?}", e);
                 Err(e)
-            }).unwrap();
+            })
+            .unwrap();
 
         rt.shutdown_now().wait().unwrap();
     }
@@ -2160,7 +2164,8 @@ mod tests {
             .or_else(|e| {
                 println!("{:?}", e.0);
                 Err(e.0)
-            }).unwrap();
+            })
+            .unwrap();
 
         rt.shutdown_now().wait().unwrap();
     }
@@ -2184,7 +2189,8 @@ mod tests {
             .or_else(|e| {
                 println!("{:?}", e);
                 Err(e)
-            }).unwrap();
+            })
+            .unwrap();
 
         rt.shutdown_now().wait().unwrap();
     }
@@ -2208,7 +2214,8 @@ mod tests {
             .or_else(|e| {
                 println!("{:?}", e);
                 Err(e)
-            }).unwrap();
+            })
+            .unwrap();
 
         rt.shutdown_now().wait().unwrap();
     }
@@ -2227,19 +2234,19 @@ mod tests {
         let image_history_results = docker.image_history("hello-world");
 
         let future = image_history_results.map(|vec| {
-            assert!(
-                vec.into_iter()
-                    .take(1)
-                    .any(|history| history.tags.unwrap_or(vec![String::new()])[0]
-                        == "hello-world:latest")
-            )
+            assert!(vec
+                .into_iter()
+                .take(1)
+                .any(|history| history.tags.unwrap_or(vec![String::new()])[0]
+                    == "hello-world:latest"))
         });
 
         rt.block_on(future)
             .or_else(|e| {
                 println!("{:?}", e);
                 Err(e)
-            }).unwrap();
+            })
+            .unwrap();
 
         rt.shutdown_now().wait().unwrap();
     }
@@ -2263,17 +2270,17 @@ mod tests {
         let search_results = docker.search_images(search_options);
 
         let future = search_results.map(|vec| {
-            assert!(
-                vec.into_iter()
-                    .any(|api_image| &api_image.name == "hello-world")
-            )
+            assert!(vec
+                .into_iter()
+                .any(|api_image| &api_image.name == "hello-world"))
         });
 
         rt.block_on(future)
             .or_else(|e| {
                 println!("{:?}", e);
                 Err(e)
-            }).unwrap();
+            })
+            .unwrap();
 
         rt.shutdown_now().wait().unwrap();
     }
@@ -2309,7 +2316,8 @@ mod tests {
             .or_else(|e| {
                 println!("{:?}", e);
                 Err(e)
-            }).unwrap();
+            })
+            .unwrap();
 
         rt.shutdown_now().wait().unwrap();
     }
@@ -2343,7 +2351,8 @@ mod tests {
             .or_else(|e| {
                 println!("{:?}", e);
                 Err(e)
-            }).unwrap();
+            })
+            .unwrap();
 
         rt.shutdown_now().wait().unwrap();
     }
@@ -2372,7 +2381,8 @@ mod tests {
             .or_else(|e| {
                 println!("{:?}", e);
                 Err(e)
-            }).unwrap();
+            })
+            .unwrap();
 
         rt.shutdown_now().wait().unwrap();
     }
@@ -2406,7 +2416,8 @@ mod tests {
             .or_else(|e| {
                 println!("{:?}", e);
                 Err(e)
-            }).unwrap();
+            })
+            .unwrap();
 
         rt.shutdown_now().wait().unwrap();
     }
@@ -2458,7 +2469,8 @@ mod tests {
             .or_else(|e| {
                 println!("{:?}", e);
                 Err(e)
-            }).unwrap();
+            })
+            .unwrap();
 
         rt.shutdown_now().wait().unwrap();
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,7 @@
 //!
 //! ```nocompile
 //! [dependencies]
-//! bollard = "0.2"
+//! bollard = "0.3"
 //! ```
 //!
 //! # API

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -133,10 +133,9 @@
 //!
 //! First, check that the API is working with your server:
 //!
-//! ```rust
+//! ```rust, no_run
 //! # extern crate bollard;
 //! # extern crate futures;
-//! # extern crate yup_hyper_mock;
 //! # fn main () {
 //! use futures::Future;
 //!
@@ -144,9 +143,7 @@
 //!
 //! // Use a connection function described above
 //! // let docker = Docker::connect_...;
-//! # use yup_hyper_mock::SequentialConnector;
-//! # let mut connector = SequentialConnector::default();
-//! # let docker = Docker::connect_with(connector, "localhost".to_string(), 5).unwrap();
+//! # let docker = Docker::connect_with_local_defaults().unwrap();
 //!
 //! docker.version()
 //!     .map(|version| {
@@ -159,10 +156,9 @@
 //!
 //! To list docker images available on the Docker server:
 //!
-//! ```rust
+//! ```rust,no_run
 //! # extern crate bollard;
 //! # extern crate futures;
-//! # extern crate yup_hyper_mock;
 //! # fn main () {
 //! use futures::Future;
 //!
@@ -173,9 +169,7 @@
 //!
 //! // Use a connection function described above
 //! // let docker = Docker::connect_...;
-//! # use yup_hyper_mock::SequentialConnector;
-//! # let mut connector = SequentialConnector::default();
-//! # let docker = Docker::connect_with(connector, "localhost".to_string(), 5).unwrap();
+//! # let docker = Docker::connect_with_local_defaults().unwrap();
 //!
 //! docker.list_images(Some(ListImagesOptions::<String> {
 //!    all: true,
@@ -193,10 +187,9 @@
 //!
 //! To receive a stream of stats for a running container.
 //!
-//! ```rust
+//! ```rust,no_run
 //! # extern crate bollard;
 //! # extern crate futures;
-//! # extern crate yup_hyper_mock;
 //! # fn main () {
 //! use futures::stream::Stream;
 //!
@@ -207,9 +200,7 @@
 //!
 //! // Use a connection function described above
 //! // let docker = Docker::connect_...;
-//! # use yup_hyper_mock::SequentialConnector;
-//! # let mut connector = SequentialConnector::default();
-//! # let docker = Docker::connect_with(connector, "localhost".to_string(), 5).unwrap();
+//! # let docker = Docker::connect_with_local_defaults().unwrap();
 //!
 //! docker.stats("postgres", Some(StatsOptions {
 //!    stream: true,
@@ -229,10 +220,9 @@
 //! It's sometimes more convenient to chain a string of Docker API calls. The `DockerChain` API
 //! will return an instance of itself in the return call.
 //!
-//! ```rust
+//! ```rust,no_run
 //! # extern crate bollard;
 //! # extern crate tokio;
-//! # extern crate yup_hyper_mock;
 //! # fn main () {
 //! use bollard::Docker;
 //! use bollard::image::CreateImageOptions;
@@ -245,9 +235,8 @@
 //!
 //! // Use a connection function described above
 //! // let docker = Docker::connect_...;
-//! # use yup_hyper_mock::SequentialConnector;
-//! # let mut connector = SequentialConnector::default();
-//! # let docker = Docker::connect_with(connector, "localhost".to_string(), 5).unwrap();
+//! # let docker = Docker::connect_with_local_defaults().unwrap();
+//!
 //! docker.chain().create_image(Some(CreateImageOptions{
 //!     from_image: "hello-world",
 //!     ..Default::default()
@@ -284,36 +273,30 @@
 //!
 //! Subsequently, use the docker API:
 //!
-//! ```rust
+//! ```rust,no_run
 //! # extern crate bollard;
-//! # extern crate yup_hyper_mock;
 //! # fn main () {
 //! # use bollard::Docker;
 //! # use bollard::image::ListImagesOptions;
-//! # use yup_hyper_mock::SequentialConnector;
 //! // Use a connection function described above
 //! // let docker = Docker::connect_...;
-//! # let mut connector = SequentialConnector::default();
-//! # let docker = Docker::connect_with(connector, "localhost".to_string(), 5).unwrap();
+//! # let docker = Docker::connect_with_local_defaults().unwrap();
 //! let future = docker.list_images(None::<ListImagesOptions<String>>);
 //! # }
 //! ```
 //!
 //! Execute the future aynchronously:
 //!
-//! ```rust
+//! ```rust,no_run
 //! # extern crate bollard;
 //! # extern crate tokio;
-//! # extern crate yup_hyper_mock;
 //! # fn main () {
 //! # use bollard::Docker;
 //! # use bollard::image::ListImagesOptions;
 //! # use tokio::runtime::Runtime;
 //! # use tokio::prelude::Future;
-//! # use yup_hyper_mock::SequentialConnector;
 //! # let mut rt = Runtime::new().unwrap();
-//! # let mut connector = SequentialConnector::default();
-//! # let docker = Docker::connect_with(connector, "localhost".to_string(), 5).unwrap();
+//! # let docker = Docker::connect_with_local_defaults().unwrap();
 //! # let future = docker.list_images(None::<ListImagesOptions<String>>).map(|_| ()).map_err(|_| ());
 //! rt.spawn(future);
 //! # }
@@ -321,22 +304,16 @@
 //!
 //! Or, to execute and receive the result:
 //!
-//! ```rust
+//! ```rust,no_run
 //! # extern crate bollard;
 //! # extern crate tokio;
-//! # extern crate yup_hyper_mock;
 //! # fn main () {
 //! # use bollard::Docker;
 //! # use bollard::image::ListImagesOptions;
 //! # use tokio::runtime::Runtime;
 //! # use tokio::prelude::Future;
-//! # use yup_hyper_mock::SequentialConnector;
 //! # let mut rt = Runtime::new().unwrap();
-//! # let mut connector = SequentialConnector::default();
-//! # connector.content.push(
-//! #   "HTTP/1.1 200 OK\r\nServer: mock1\r\nContent-Type: application/json\r\nContent-Length: 0\r\n\r\n".to_string()
-//! # );
-//! # let docker = Docker::connect_with(connector, "localhost".to_string(), 5).unwrap();
+//! # let docker = Docker::connect_with_local_defaults().unwrap();
 //! # let future = docker.list_images(None::<ListImagesOptions<String>>).map(|_| ()).map_err(|_| ());
 //! let result = rt.block_on(future);
 //! # }
@@ -344,7 +321,7 @@
 //!
 //! Finally, to shut down the executor:
 //!
-//! ```rust
+//! ```rust,no_run
 //! # extern crate tokio;
 //! # fn main () {
 //! # use tokio::runtime::Runtime;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,6 +61,17 @@
 //! Docker::connect_with_named_pipe_defaults();
 //! ```
 //!
+//! ### Local
+//!
+//! The client will connect to the OS specific handler it is compiled for.
+//! This is a convenience for localhost environment that should run on multiple
+//! operating systems.
+//! Use the `Docker::connect_with_local` method API to parameterise the interface.
+//! ```rust
+//! use bollard::Docker;
+//! Docker::connect_with_local_defaults();
+//! ```
+//!
 //! ### HTTP
 //!
 //! The client will connect to the location pointed to by `DOCKER_HOST` environment variable, or

--- a/src/system.rs
+++ b/src/system.rs
@@ -2,7 +2,6 @@
 use arrayvec::ArrayVec;
 use failure::Error;
 use http::request::Builder;
-use hyper::client::connect::Connect;
 use hyper::rt::Future;
 use hyper::{Body, Method};
 
@@ -24,10 +23,7 @@ pub struct Version {
     pub Experimental: Option<bool>,
 }
 
-impl<C> Docker<C>
-where
-    C: Connect + Sync + 'static,
-{
+impl Docker {
     /// ---
     ///
     /// # Version
@@ -89,10 +85,7 @@ where
     }
 }
 
-impl<C> DockerChain<C>
-where
-    C: Connect + Sync + 'static,
-{
+impl DockerChain {
     /// ---
     ///
     /// # Version
@@ -112,7 +105,7 @@ where
     /// # let docker = Docker::connect_with_http_defaults().unwrap();
     /// docker.chain().version();
     /// ```
-    pub fn version(self) -> impl Future<Item = (DockerChain<C>, Version), Error = Error> {
+    pub fn version(self) -> impl Future<Item = (DockerChain, Version), Error = Error> {
         self.inner.version().map(|result| (self, result))
     }
 
@@ -136,7 +129,7 @@ where
     ///
     /// docker.chain().ping();
     /// ```
-    pub fn ping(self) -> impl Future<Item = (DockerChain<C>, String), Error = Error> {
+    pub fn ping(self) -> impl Future<Item = (DockerChain, String), Error = Error> {
         self.inner.ping().map(|result| (self, result))
     }
 }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -3,7 +3,6 @@ extern crate futures;
 
 use self::failure::Error;
 use self::futures::future;
-use hyper::client::connect::Connect;
 use hyper::rt::{Future, Stream};
 use tokio::runtime::Runtime;
 
@@ -111,13 +110,10 @@ where
 }
 
 #[allow(dead_code)]
-pub fn chain_create_container_hello_world<C>(
-    chain: DockerChain<C>,
+pub fn chain_create_container_hello_world(
+    chain: DockerChain,
     container_name: &'static str,
-) -> impl Future<Item = DockerChain<C>, Error = Error>
-where
-    C: Connect + Sync + 'static,
-{
+) -> impl Future<Item = DockerChain, Error = Error> {
     let image = move || {
         if cfg!(windows) {
             format!("{}hello-world:nanoserver", registry_http_addr())
@@ -187,13 +183,10 @@ where
 }
 
 #[allow(dead_code)]
-pub fn chain_create_registry<C>(
-    chain: DockerChain<C>,
+pub fn chain_create_registry(
+    chain: DockerChain,
     container_name: &'static str,
-) -> impl Future<Item = DockerChain<C>, Error = Error>
-where
-    C: Connect + Sync + 'static,
-{
+) -> impl Future<Item = DockerChain, Error = Error> {
     let image = || {
         if cfg!(windows) {
             String::from("stefanscherer/registry-windows")
@@ -277,23 +270,15 @@ where
 }
 
 #[allow(dead_code)]
-pub fn chain_create_noop<C>(
-    chain: DockerChain<C>,
-) -> impl Future<Item = DockerChain<C>, Error = Error>
-where
-    C: Connect + Sync + 'static,
-{
+pub fn chain_create_noop(chain: DockerChain) -> impl Future<Item = DockerChain, Error = Error> {
     future::ok(chain)
 }
 
 #[allow(dead_code)]
-pub fn chain_create_daemon<C>(
-    chain: DockerChain<C>,
+pub fn chain_create_daemon(
+    chain: DockerChain,
     container_name: &'static str,
-) -> impl Future<Item = DockerChain<C>, Error = Error>
-where
-    C: Connect + Sync + 'static,
-{
+) -> impl Future<Item = DockerChain, Error = Error> {
     let image = move || {
         if cfg!(windows) {
             format!("{}nanoserver/iis", registry_http_addr())
@@ -364,13 +349,10 @@ where
 }
 
 #[allow(dead_code)]
-pub fn chain_kill_container<C>(
-    chain: DockerChain<C>,
+pub fn chain_kill_container(
+    chain: DockerChain,
     container_name: &'static str,
-) -> impl Future<Item = DockerChain<C>, Error = Error>
-where
-    C: Connect + Sync + 'static,
-{
+) -> impl Future<Item = DockerChain, Error = Error> {
     let cloned = chain.clone();
     chain
         .kill_container(container_name, None::<KillContainerOptions<String>>)
@@ -386,12 +368,9 @@ where
 }
 
 #[allow(dead_code)]
-pub fn chain_create_image_hello_world<C>(
-    chain: DockerChain<C>,
-) -> impl Future<Item = DockerChain<C>, Error = Error>
-where
-    C: Connect + Sync + 'static,
-{
+pub fn chain_create_image_hello_world(
+    chain: DockerChain,
+) -> impl Future<Item = DockerChain, Error = Error> {
     let image = move || {
         if cfg!(windows) {
             format!("{}hello-world:nanoserver", registry_http_addr())

--- a/tests/container_test.rs
+++ b/tests/container_test.rs
@@ -23,10 +23,7 @@ use std::io::Write;
 pub mod common;
 use common::*;
 
-fn list_containers_test<C>(docker: Docker<C>)
-where
-    C: Connect + Sync + 'static,
-{
+fn list_containers_test(docker: Docker) {
     let image = move || {
         if cfg!(windows) {
             format!("{}hello-world:nanoserver", registry_http_addr())
@@ -61,10 +58,7 @@ where
     run_runtime(rt, future);
 }
 
-fn image_push_test<C>(docker: Docker<C>)
-where
-    C: Connect + Sync + 'static,
-{
+fn image_push_test(docker: Docker) {
     let image = move || {
         if cfg!(windows) {
             format!("{}hello-world:nanoserver", registry_http_addr())
@@ -113,10 +107,7 @@ where
     run_runtime(rt, future);
 }
 
-fn container_restart_test<C>(docker: Docker<C>)
-where
-    C: Connect + Sync + 'static,
-{
+fn container_restart_test(docker: Docker) {
     let rt = Runtime::new().unwrap();
     let future = chain_create_daemon(docker.chain(), "integration_test_restart_container");
 
@@ -154,10 +145,7 @@ where
     run_runtime(rt, future);
 }
 
-fn top_processes_test<C>(docker: Docker<C>)
-where
-    C: Connect + Sync + 'static,
-{
+fn top_processes_test(docker: Docker) {
     let top_options = if cfg!(windows) {
         None
     } else {
@@ -188,10 +176,7 @@ where
     run_runtime(rt, future);
 }
 
-fn logs_test<C>(docker: Docker<C>)
-where
-    C: Connect + Sync + 'static,
-{
+fn logs_test(docker: Docker) {
     let rt = Runtime::new().unwrap();
     let docker2 = docker.clone();
     let future = chain_create_container_hello_world(docker.chain(), "integration_test_logs")
@@ -230,10 +215,7 @@ where
     run_runtime(rt, future);
 }
 
-fn container_changes_test<C>(docker: Docker<C>)
-where
-    C: Connect + Sync + 'static,
-{
+fn container_changes_test(docker: Docker) {
     let rt = Runtime::new().unwrap();
     let future =
         chain_create_container_hello_world(docker.chain(), "integration_test_container_changes")
@@ -257,10 +239,7 @@ where
     run_runtime(rt, future);
 }
 
-fn stats_test<C>(docker: Docker<C>)
-where
-    C: Connect + Sync + 'static,
-{
+fn stats_test(docker: Docker) {
     let rt = Runtime::new().unwrap();
     let future = chain_create_daemon(docker.chain(), "integration_test_stats")
         .and_then(|docker| {
@@ -288,10 +267,7 @@ where
     run_runtime(rt, future);
 }
 
-fn kill_container_test<C>(docker: Docker<C>)
-where
-    C: Connect + Sync + 'static,
-{
+fn kill_container_test(docker: Docker) {
     let kill_options = Some(KillContainerOptions { signal: "SIGKILL" });
 
     let rt = Runtime::new().unwrap();
@@ -307,10 +283,7 @@ where
     run_runtime(rt, future);
 }
 
-fn update_container_test<C>(docker: Docker<C>)
-where
-    C: Connect + Sync + 'static,
-{
+fn update_container_test(docker: Docker) {
     let update_options = UpdateContainerOptions {
         memory: Some(314572800),
         memory_swap: Some(314572800),
@@ -364,10 +337,7 @@ where
     run_runtime(rt, future);
 }
 
-fn rename_container_test<C>(docker: Docker<C>)
-where
-    C: Connect + Sync + 'static,
-{
+fn rename_container_test(docker: Docker) {
     let rt = Runtime::new().unwrap();
     let future =
         chain_create_container_hello_world(docker.chain(), "integration_test_rename_container")
@@ -389,10 +359,7 @@ where
     run_runtime(rt, future);
 }
 
-fn pause_container_test<C>(docker: Docker<C>)
-where
-    C: Connect + Sync + 'static,
-{
+fn pause_container_test(docker: Docker) {
     let rt = Runtime::new().unwrap();
     let future = chain_create_daemon(docker.chain(), "integration_test_pause_container")
         .and_then(|docker| docker.pause_container("integration_test_pause_container"))
@@ -422,10 +389,7 @@ where
     run_runtime(rt, future);
 }
 
-fn prune_containers_test<C>(docker: Docker<C>)
-where
-    C: Connect + Sync + 'static,
-{
+fn prune_containers_test(docker: Docker) {
     let rt = Runtime::new().unwrap();
     let future = docker
         .chain()
@@ -456,10 +420,7 @@ where
     run_runtime(rt, future);
 }
 
-fn archive_container_test<C>(docker: Docker<C>)
-where
-    C: Connect + Sync + 'static,
-{
+fn archive_container_test(docker: Docker) {
     let rt = Runtime::new().unwrap();
 
     let image = move || {

--- a/tests/container_test.rs
+++ b/tests/container_test.rs
@@ -13,7 +13,6 @@ use bollard::container::*;
 use bollard::image::*;
 use bollard::Docker;
 
-use hyper::client::connect::Connect;
 use hyper::rt::{Future, Stream};
 use tokio::runtime::Runtime;
 

--- a/tests/container_test.rs
+++ b/tests/container_test.rs
@@ -1,13 +1,13 @@
 #![type_length_limit = "2097152"]
 extern crate bollard;
 extern crate failure;
+extern crate flate2;
 extern crate futures;
 extern crate hyper;
 #[cfg(unix)]
 extern crate hyperlocal;
-extern crate tokio;
-extern crate flate2;
 extern crate tar;
+extern crate tokio;
 
 use bollard::container::*;
 use bollard::image::*;
@@ -43,15 +43,15 @@ where
                     all: true,
                     ..Default::default()
                 }))
-            }).map(move |(docker, result)| {
+            })
+            .map(move |(docker, result)| {
                 assert_ne!(0, result.len());
-                assert!(
-                    result
-                        .into_iter()
-                        .any(|container| container.image == image())
-                );
+                assert!(result
+                    .into_iter()
+                    .any(|container| container.image == image()));
                 docker
-            }).and_then(move |docker| {
+            })
+            .and_then(move |docker| {
                 docker.remove_container(
                     "integration_test_list_containers",
                     None::<RemoveContainerOptions>,
@@ -126,23 +126,28 @@ where
                 "integration_test_restart_container",
                 None::<InspectContainerOptions>,
             )
-        }).map(|(docker, result)| (docker, result.state.started_at))
+        })
+        .map(|(docker, result)| (docker, result.state.started_at))
         .and_then(|(docker, started_at)| {
             docker
                 .restart_container(
                     "integration_test_restart_container",
                     None::<RestartContainerOptions>,
-                ).map(move |(docker, _)| (docker, started_at))
-        }).and_then(|(docker, started_at)| {
+                )
+                .map(move |(docker, _)| (docker, started_at))
+        })
+        .and_then(|(docker, started_at)| {
             docker
                 .inspect_container(
                     "integration_test_restart_container",
                     None::<InspectContainerOptions>,
-                ).map(move |(docker, result)| {
+                )
+                .map(move |(docker, result)| {
                     assert_ne!(started_at, result.state.started_at);
                     (docker, result)
                 })
-        }).and_then(move |(docker, _)| {
+        })
+        .and_then(move |(docker, _)| {
             chain_kill_container(docker, "integration_test_restart_container")
         });
 
@@ -177,7 +182,8 @@ where
         .map(move |(docker, result)| {
             assert_eq!(result.titles[0], expected);
             docker
-        }).and_then(|docker| chain_kill_container(docker, "integration_test_top_processes"));
+        })
+        .and_then(|docker| chain_kill_container(docker, "integration_test_top_processes"));
 
     run_runtime(rt, future);
 }
@@ -200,7 +206,8 @@ where
                     ..Default::default()
                 }),
             )
-        }).map(|(_, stream)| {
+        })
+        .map(|(_, stream)| {
             stream
                 .skip(1)
                 .into_future()
@@ -209,11 +216,13 @@ where
                         format!("{}", value.unwrap()),
                         "Hello from Docker!".to_string()
                     );
-                }).or_else(|e| {
+                })
+                .or_else(|e| {
                     println!("{}", e.0);
                     Err(e.0)
                 })
-        }).flatten()
+        })
+        .flatten()
         .and_then(move |_| {
             docker2.remove_container("integration_test_logs", None::<RemoveContainerOptions>)
         });
@@ -237,7 +246,8 @@ where
                 };
 
                 docker
-            }).and_then(|docker| {
+            })
+            .and_then(|docker| {
                 docker.remove_container(
                     "integration_test_container_changes",
                     None::<RemoveContainerOptions>,
@@ -258,18 +268,22 @@ where
                 "integration_test_stats",
                 Some(StatsOptions { stream: false }),
             )
-        }).map(|(docker, stream)| {
+        })
+        .map(|(docker, stream)| {
             stream
                 .into_future()
                 .map(|(value, _)| {
                     assert_eq!(value.unwrap().name, "/integration_test_stats".to_string())
-                }).or_else(|e| {
+                })
+                .or_else(|e| {
                     println!("{}", e.0);
                     Err(e.0)
-                }).wait()
+                })
+                .wait()
                 .unwrap();
             docker
-        }).and_then(|docker| chain_kill_container(docker, "integration_test_stats"));
+        })
+        .and_then(|docker| chain_kill_container(docker, "integration_test_stats"));
 
     run_runtime(rt, future);
 }
@@ -307,33 +321,40 @@ where
     let future = chain_create_daemon(docker.chain(), "integration_test_update_container")
         .and_then(|docker| {
             docker.update_container("integration_test_update_container", update_options)
-        }).and_then(|(docker, _)| {
+        })
+        .and_then(|(docker, _)| {
             docker.inspect_container(
                 "integration_test_update_container",
                 None::<InspectContainerOptions>,
             )
-        }).map(|(docker, result)| {
+        })
+        .map(|(docker, result)| {
             assert_eq!(314572800, result.host_config.memory.unwrap());
             docker
-        }).and_then(|docker| {
+        })
+        .and_then(|docker| {
             docker.kill_container(
                 "integration_test_update_container",
                 None::<KillContainerOptions<String>>,
             )
-        }).and_then(|(docker, _)| {
+        })
+        .and_then(|(docker, _)| {
             docker.wait_container(
                 "integration_test_update_container",
                 None::<WaitContainerOptions<String>>,
             )
-        }).and_then(|(docker, _)| {
+        })
+        .and_then(|(docker, _)| {
             docker.inspect_container(
                 "integration_test_update_container",
                 None::<InspectContainerOptions>,
             )
-        }).map(|(docker, result)| {
+        })
+        .map(|(docker, result)| {
             assert_eq!("exited", result.state.status);
             docker
-        }).and_then(|docker| {
+        })
+        .and_then(|docker| {
             docker.remove_container(
                 "integration_test_update_container",
                 None::<RemoveContainerOptions>,
@@ -357,7 +378,8 @@ where
                         name: "integration_test_rename_container_renamed".to_string(),
                     },
                 )
-            }).and_then(|(docker, _)| {
+            })
+            .and_then(|(docker, _)| {
                 docker.remove_container(
                     "integration_test_rename_container_renamed",
                     None::<RemoveContainerOptions>,
@@ -379,19 +401,23 @@ where
                 "integration_test_pause_container",
                 None::<InspectContainerOptions>,
             )
-        }).map(|(docker, result)| {
+        })
+        .map(|(docker, result)| {
             assert_eq!("paused".to_string(), result.state.status);
             docker
-        }).and_then(|docker| docker.unpause_container("integration_test_pause_container"))
+        })
+        .and_then(|docker| docker.unpause_container("integration_test_pause_container"))
         .and_then(|(docker, _)| {
             docker.inspect_container(
                 "integration_test_pause_container",
                 None::<InspectContainerOptions>,
             )
-        }).map(|(docker, result)| {
+        })
+        .map(|(docker, result)| {
             assert_eq!("running".to_string(), result.state.status);
             docker
-        }).and_then(|docker| chain_kill_container(docker, "integration_test_pause_container"));
+        })
+        .and_then(|docker| chain_kill_container(docker, "integration_test_pause_container"));
 
     run_runtime(rt, future);
 }
@@ -409,7 +435,8 @@ where
                 all: true,
                 ..Default::default()
             }))
-        }).map(|(docker, result)| {
+        })
+        .map(|(docker, result)| {
             println!("{:?}", result.iter().map(|c| c.clone().names));
             assert_eq!(
                 0,
@@ -419,7 +446,8 @@ where
                         |r| vec!["bollard", "registry:2", "stefanscherer/registry-windows"]
                             .into_iter()
                             .all(|v| v.to_string() != r.image)
-                    ).collect::<Vec<_>>()
+                    )
+                    .collect::<Vec<_>>()
                     .len()
             );
             docker

--- a/tests/exec_test.rs
+++ b/tests/exec_test.rs
@@ -7,7 +7,6 @@ use bollard::container::*;
 use bollard::exec::*;
 use bollard::Docker;
 
-use hyper::client::connect::Connect;
 use hyper::rt::{Future, Stream};
 use tokio::runtime::Runtime;
 
@@ -15,10 +14,7 @@ use tokio::runtime::Runtime;
 pub mod common;
 use common::*;
 
-fn start_exec_test<C>(docker: Docker<C>)
-where
-    C: Connect + Sync + 'static,
-{
+fn start_exec_test(docker: Docker) {
     let rt = Runtime::new().unwrap();
     let future = chain_create_daemon(docker.chain(), "integration_test_start_exec_test")
         .and_then(move |docker| {
@@ -81,10 +77,7 @@ where
     run_runtime(rt, future);
 }
 
-fn inspect_exec_test<C>(docker: Docker<C>)
-where
-    C: Connect + Sync + 'static,
-{
+fn inspect_exec_test(docker: Docker) {
     let rt = Runtime::new().unwrap();
     let future = chain_create_daemon(docker.chain(), "integration_test_inspect_exec_test")
         .and_then(move |docker| {

--- a/tests/image_test.rs
+++ b/tests/image_test.rs
@@ -10,7 +10,6 @@ extern crate tar;
 extern crate tokio;
 
 use futures::Stream;
-use hyper::client::connect::Connect;
 use hyper::rt::Future;
 use tokio::runtime::Runtime;
 
@@ -29,19 +28,13 @@ use std::io::Write;
 pub mod common;
 use common::*;
 
-fn create_image_test<C>(docker: Docker<C>)
-where
-    C: Connect + Sync + 'static,
-{
+fn create_image_test(docker: Docker) {
     let rt = Runtime::new().unwrap();
     let future = chain_create_image_hello_world(docker.chain());
     run_runtime(rt, future);
 }
 
-fn search_images_test<C>(docker: Docker<C>)
-where
-    C: Connect + Sync + 'static,
-{
+fn search_images_test(docker: Docker) {
     let rt = Runtime::new().unwrap();
     let future = docker
         .chain()
@@ -59,10 +52,7 @@ where
     run_runtime(rt, future);
 }
 
-fn inspect_image_test<C>(docker: Docker<C>)
-where
-    C: Connect + Sync + 'static,
-{
+fn inspect_image_test(docker: Docker) {
     let image = move || {
         if cfg!(windows) {
             format!("{}hello-world:nanoserver", registry_http_addr())
@@ -85,10 +75,7 @@ where
     run_runtime(rt, future);
 }
 
-fn list_images_test<C>(docker: Docker<C>)
-where
-    C: Connect + Sync + 'static,
-{
+fn list_images_test(docker: Docker) {
     let image = move || {
         if cfg!(windows) {
             format!("{}hello-world:nanoserver", registry_http_addr())
@@ -117,10 +104,7 @@ where
     run_runtime(rt, future);
 }
 
-fn image_history_test<C>(docker: Docker<C>)
-where
-    C: Connect + Sync + 'static,
-{
+fn image_history_test(docker: Docker) {
     let image = move || {
         if cfg!(windows) {
             format!("{}hello-world:nanoserver", registry_http_addr())
@@ -144,10 +128,7 @@ where
     run_runtime(rt, future);
 }
 
-fn prune_images_test<C>(docker: Docker<C>)
-where
-    C: Connect + Sync + 'static,
-{
+fn prune_images_test(docker: Docker) {
     let mut filters = HashMap::new();
     filters.insert("label", vec!["maintainer=some_maintainer"]);
     rt_exec!(
@@ -156,10 +137,7 @@ where
     );
 }
 
-fn remove_image_test<C>(docker: Docker<C>)
-where
-    C: Connect + Sync + 'static,
-{
+fn remove_image_test(docker: Docker) {
     let image = move || {
         if cfg!(windows) {
             format!("{}hello-world:nanoserver", registry_http_addr())
@@ -195,10 +173,7 @@ where
     run_runtime(rt, future);
 }
 
-fn commit_container_test<C>(docker: Docker<C>)
-where
-    C: Connect + Sync + 'static,
-{
+fn commit_container_test(docker: Docker) {
     let image = move || {
         if cfg!(windows) {
             format!("{}microsoft/nanoserver", registry_http_addr())
@@ -331,10 +306,7 @@ where
     run_runtime(rt, future);
 }
 
-fn build_image_test<C>(docker: Docker<C>)
-where
-    C: Connect + Sync + 'static,
-{
+fn build_image_test(docker: Docker) {
     let dockerfile = if cfg!(windows) {
         format!(
             "FROM {}microsoft/nanoserver

--- a/tests/image_test.rs
+++ b/tests/image_test.rs
@@ -48,12 +48,11 @@ where
         .search_images(SearchImagesOptions {
             term: "hello-world",
             ..Default::default()
-        }).map(|(docker, result)| {
-            assert!(
-                result
-                    .into_iter()
-                    .any(|api_image| &api_image.name == "hello-world")
-            );
+        })
+        .map(|(docker, result)| {
+            assert!(result
+                .into_iter()
+                .any(|api_image| &api_image.name == "hello-world"));
             docker
         });
 
@@ -76,12 +75,10 @@ where
     let future = chain_create_image_hello_world(docker.chain())
         .and_then(move |docker| docker.inspect_image(&image()))
         .map(move |(docker, result)| {
-            assert!(
-                result
-                    .repo_tags
-                    .into_iter()
-                    .any(|repo_tag| repo_tag == image().to_string())
-            );
+            assert!(result
+                .repo_tags
+                .into_iter()
+                .any(|repo_tag| repo_tag == image().to_string()));
             docker
         });
 
@@ -107,14 +104,13 @@ where
                 all: true,
                 ..Default::default()
             }))
-        }).map(move |(docker, result)| {
-            assert!(result.into_iter().any(|api_image| {
-                api_image
-                    .repo_tags
-                    .unwrap_or(vec![String::new()])
-                    .into_iter()
-                    .any(|repo_tag| repo_tag == image().to_string())
-            }));
+        })
+        .map(move |(docker, result)| {
+            assert!(result.into_iter().any(|api_image| api_image
+                .repo_tags
+                .unwrap_or(vec![String::new()])
+                .into_iter()
+                .any(|repo_tag| repo_tag == image().to_string())));
             docker
         });
 
@@ -137,13 +133,11 @@ where
     let future = chain_create_image_hello_world(docker.chain())
         .and_then(move |docker| docker.image_history(&image()))
         .map(move |(docker, result)| {
-            assert!(result.into_iter().take(1).any(|history| {
-                history
-                    .tags
-                    .unwrap_or(vec![String::new()])
-                    .into_iter()
-                    .any(|tag| tag == image().to_string())
-            }));
+            assert!(result.into_iter().take(1).any(|history| history
+                .tags
+                .unwrap_or(vec![String::new()])
+                .into_iter()
+                .any(|tag| tag == image().to_string())));
             docker
         });
 
@@ -238,17 +232,20 @@ where
                     ..Default::default()
                 },
             )
-        }).and_then(move |(docker, _)| {
+        })
+        .and_then(move |(docker, _)| {
             docker.start_container(
                 "integration_test_commit_container",
                 None::<StartContainerOptions<String>>,
             )
-        }).and_then(move |(docker, _)| {
+        })
+        .and_then(move |(docker, _)| {
             docker.wait_container(
                 "integration_test_commit_container",
                 None::<WaitContainerOptions<String>>,
             )
-        }).and_then(move |(docker, _)| {
+        })
+        .and_then(move |(docker, _)| {
             docker.commit_container(
                 CommitContainerOptions {
                     container: "integration_test_commit_container",
@@ -260,7 +257,8 @@ where
                     ..Default::default()
                 },
             )
-        }).and_then(move |(docker, _)| {
+        })
+        .and_then(move |(docker, _)| {
             docker.create_container(
                 Some(CreateContainerOptions {
                     name: "integration_test_commit_container_next",
@@ -275,17 +273,20 @@ where
                     ..Default::default()
                 },
             )
-        }).and_then(move |(docker, _)| {
+        })
+        .and_then(move |(docker, _)| {
             docker.start_container(
                 "integration_test_commit_container_next",
                 None::<StartContainerOptions<String>>,
             )
-        }).and_then(move |(docker, _)| {
+        })
+        .and_then(move |(docker, _)| {
             docker.wait_container(
                 "integration_test_commit_container_next",
                 None::<WaitContainerOptions<String>>,
             )
-        }).map(move |(docker, stream)| {
+        })
+        .map(move |(docker, stream)| {
             stream
                 .take(1)
                 .into_future()
@@ -404,17 +405,20 @@ RUN touch bollard.txt
                     ..Default::default()
                 },
             )
-        }).and_then(move |(docker, _)| {
+        })
+        .and_then(move |(docker, _)| {
             docker.start_container(
                 "integration_test_build_image",
                 None::<StartContainerOptions<String>>,
             )
-        }).and_then(move |(docker, _)| {
+        })
+        .and_then(move |(docker, _)| {
             docker.wait_container(
                 "integration_test_build_image",
                 None::<WaitContainerOptions<String>>,
             )
-        }).map(move |(docker, stream)| {
+        })
+        .map(move |(docker, stream)| {
             stream
                 .take(1)
                 .into_future()


### PR DESCRIPTION
As mentioned in [#17](https://github.com/fussybeaver/bollard/issues/17#issuecomment-468173704), the issues with requiring a `Connect` type parameter to the Docker structure entails that it is not usable in certain scenarios.

This PR introduces the following changes:
* Remove the `Connect` type parameter.
* Remove the generic `Docker::connect_with` method.
* Introduce a `Docker::connect_with_host_to_reply` that is only available in test.
* Convert all unit tests from `Docker::connect_with` to `Docker::connect_with_host_to_reply`.
* Introduce `Docker::connect_with_local` and `Docker::connect_with_local_defaults`.

This change is a *breaking* change, and will require a major version bump if merged (e.g., 0.3).