### PR TITLE
Support newer Docker API versions by ignoring additional properties in API responses

### DIFF
--- a/src/container.rs
+++ b/src/container.rs
@@ -149,7 +149,7 @@ impl<'a, T: AsRef<str>> CreateContainerQueryParams<&'a str, T> for CreateContain
 
 /// Container configuration that depends on the host we are running on
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
-#[serde(rename_all = "PascalCase", deny_unknown_fields)]
+#[serde(rename_all = "PascalCase")]
 #[allow(missing_docs)]
 pub struct HostConfig<T>
 where
@@ -320,7 +320,7 @@ where
 
 /// Storage driver name and configuration.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "PascalCase", deny_unknown_fields)]
+#[serde(rename_all = "PascalCase")]
 #[allow(missing_docs)]
 pub struct GraphDriver {
     pub name: String,
@@ -332,7 +332,7 @@ pub struct GraphDriver {
 /// container's port is mapped for multiple protocols, separate entries are added to the mapping
 /// table.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "PascalCase", deny_unknown_fields)]
+#[serde(rename_all = "PascalCase")]
 #[allow(missing_docs)]
 pub struct PortBinding<T>
 where
@@ -347,7 +347,7 @@ where
 /// increasing delay (double the previous delay, starting at 100ms) is added before each restart to
 /// prevent flooding the server.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
-#[serde(rename_all = "PascalCase", deny_unknown_fields)]
+#[serde(rename_all = "PascalCase")]
 #[allow(missing_docs)]
 pub struct RestartPolicy<T>
 where
@@ -359,7 +359,7 @@ where
 
 /// The logging configuration for this container.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
-#[serde(rename_all = "PascalCase", deny_unknown_fields)]
+#[serde(rename_all = "PascalCase")]
 #[allow(missing_docs)]
 pub struct LogConfig {
     #[serde(rename = "Type")]
@@ -369,7 +369,6 @@ pub struct LogConfig {
 
 /// This container's networking configuration.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(deny_unknown_fields)]
 #[allow(missing_docs)]
 pub struct NetworkingConfig {
     pub endpoints_config: HashMap<String, ContainerNetwork>,
@@ -377,7 +376,7 @@ pub struct NetworkingConfig {
 
 /// Configuration for a network endpoint.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "PascalCase", deny_unknown_fields)]
+#[serde(rename_all = "PascalCase")]
 #[allow(missing_docs)]
 pub struct ContainerNetwork {
     #[serde(rename = "IPAMConfig")]
@@ -405,7 +404,7 @@ pub struct ContainerNetwork {
 
 /// Network Settings for a container.
 #[derive(Debug, Clone, Deserialize)]
-#[serde(rename_all = "PascalCase", deny_unknown_fields)]
+#[serde(rename_all = "PascalCase")]
 #[allow(missing_docs)]
 pub struct NetworkSettings {
     pub networks: HashMap<String, ContainerNetwork>,
@@ -441,7 +440,7 @@ pub struct NetworkSettings {
 
 /// Specification for mounts to be added to the container.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "PascalCase", deny_unknown_fields)]
+#[serde(rename_all = "PascalCase")]
 #[allow(missing_docs)]
 pub struct Mount {
     pub name: Option<String>,
@@ -458,7 +457,7 @@ pub struct Mount {
 
 /// Log of the health of a running container.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "PascalCase", deny_unknown_fields)]
+#[serde(rename_all = "PascalCase")]
 #[allow(missing_docs)]
 pub struct LogStateHealth {
     pub start: DateTime<Utc>,
@@ -469,7 +468,7 @@ pub struct LogStateHealth {
 
 /// Health of a running container.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "PascalCase", deny_unknown_fields)]
+#[serde(rename_all = "PascalCase")]
 #[allow(missing_docs)]
 pub struct StateHealth {
     pub status: String,
@@ -479,7 +478,7 @@ pub struct StateHealth {
 
 /// Runtime status of the container.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "PascalCase", deny_unknown_fields)]
+#[serde(rename_all = "PascalCase")]
 #[allow(missing_docs)]
 pub struct State {
     pub status: String,
@@ -499,7 +498,7 @@ pub struct State {
 
 /// Maps internal container port to external host port.
 #[derive(Debug, Clone, Deserialize)]
-#[serde(rename_all = "PascalCase", deny_unknown_fields)]
+#[serde(rename_all = "PascalCase")]
 #[allow(missing_docs)]
 pub struct APIPort {
     #[serde(rename = "IP")]
@@ -512,7 +511,7 @@ pub struct APIPort {
 
 /// A mapping of network name to endpoint configuration for that network.
 #[derive(Debug, Clone, Deserialize)]
-#[serde(rename_all = "PascalCase", deny_unknown_fields)]
+#[serde(rename_all = "PascalCase")]
 #[allow(missing_docs)]
 pub struct NetworkList {
     pub networks: HashMap<String, ContainerNetwork>,
@@ -520,7 +519,7 @@ pub struct NetworkList {
 
 /// Result type for the [List Containers API](../struct.Docker.html#method.list_containers)
 #[derive(Debug, Clone, Deserialize)]
-#[serde(rename_all = "PascalCase", deny_unknown_fields)]
+#[serde(rename_all = "PascalCase")]
 #[allow(missing_docs)]
 pub struct APIContainers {
     pub id: String,
@@ -544,7 +543,7 @@ pub struct APIContainers {
 
 /// Result type for the [Inspect Container API](../struct.Docker.html#method.inspect_container)
 #[derive(Debug, Clone, Deserialize)]
-#[serde(rename_all = "PascalCase", deny_unknown_fields)]
+#[serde(rename_all = "PascalCase")]
 #[allow(missing_docs)]
 pub struct Container {
     pub id: String,
@@ -575,7 +574,7 @@ pub struct Container {
 
 /// A test to perform to check that the container is healthy.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "PascalCase", deny_unknown_fields)]
+#[serde(rename_all = "PascalCase")]
 pub struct HealthConfig {
     /// The test to perform. Possible values are:
     ///  - `[]` inherit healthcheck from image or parent image
@@ -599,7 +598,7 @@ pub struct HealthConfig {
 
 /// Container to create.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
-#[serde(rename_all = "PascalCase", deny_unknown_fields)]
+#[serde(rename_all = "PascalCase")]
 pub struct Config<T>
 where
     T: AsRef<str> + Eq + Hash,
@@ -666,7 +665,7 @@ where
 
 /// Result type for the [Create Container API](../struct.Docker.html#method.create_container)
 #[derive(Debug, Clone, Deserialize)]
-#[serde(rename_all = "PascalCase", deny_unknown_fields)]
+#[serde(rename_all = "PascalCase")]
 #[allow(missing_docs)]
 pub struct CreateContainerResults {
     pub id: String,
@@ -823,7 +822,7 @@ impl<'a, T: AsRef<str>> WaitContainerQueryParams<&'a str, T> for WaitContainerOp
 
 /// Error messages returned in the [Wait Container API](../struct.Docker.html#method.wait_container)
 #[derive(Debug, Clone, Deserialize)]
-#[serde(rename_all = "PascalCase", deny_unknown_fields)]
+#[serde(rename_all = "PascalCase")]
 #[allow(missing_docs)]
 pub struct WaitContainerResultsError {
     pub message: String,
@@ -831,7 +830,7 @@ pub struct WaitContainerResultsError {
 
 /// Result type for the [Wait Container API](../struct.Docker.html#method.wait_container)
 #[derive(Debug, Clone, Deserialize)]
-#[serde(rename_all = "PascalCase", deny_unknown_fields)]
+#[serde(rename_all = "PascalCase")]
 #[allow(missing_docs)]
 pub struct WaitContainerResults {
     pub status_code: u64,
@@ -946,7 +945,7 @@ impl<'a, T: AsRef<str>> TopQueryParams<&'a str, T> for TopOptions<T> {
 
 /// Result type for the [Top Processes API](../struct.Docker.html#method.top_processes)
 #[derive(Debug, Clone, Deserialize)]
-#[serde(rename_all = "PascalCase", deny_unknown_fields)]
+#[serde(rename_all = "PascalCase")]
 #[allow(missing_docs)]
 pub struct TopResult {
     pub titles: Vec<String>,
@@ -1032,7 +1031,7 @@ impl fmt::Display for LogOutput {
 
 /// Result type for the [Container Changes API](../struct.Docker.html#method.container_changes)
 #[derive(Debug, Clone, Deserialize)]
-#[serde(rename_all = "PascalCase", deny_unknown_fields)]
+#[serde(rename_all = "PascalCase")]
 #[allow(missing_docs)]
 pub struct Change {
     pub path: String,
@@ -1088,7 +1087,6 @@ impl<'a> StatsQueryParams<&'a str, &'a str> for StatsOptions {
 
 /// Granular memory statistics for the container.
 #[derive(Debug, Copy, Clone, Deserialize)]
-#[serde(deny_unknown_fields)]
 #[allow(missing_docs)]
 pub struct MemoryStatsStats {
     pub cache: u64,
@@ -1127,7 +1125,6 @@ pub struct MemoryStatsStats {
 
 /// General memory statistics for the container.
 #[derive(Debug, Copy, Clone, Deserialize)]
-#[serde(deny_unknown_fields)]
 #[allow(missing_docs)]
 pub struct MemoryStats {
     pub stats: Option<MemoryStatsStats>,
@@ -1144,7 +1141,6 @@ pub struct MemoryStats {
 
 /// Process ID statistics for the container.
 #[derive(Debug, Copy, Clone, Deserialize)]
-#[serde(deny_unknown_fields)]
 #[allow(missing_docs)]
 pub struct PidsStats {
     pub current: Option<u64>,
@@ -1153,7 +1149,6 @@ pub struct PidsStats {
 
 /// I/O statistics for the container.
 #[derive(Debug, Clone, Deserialize)]
-#[serde(deny_unknown_fields)]
 #[allow(missing_docs)]
 pub struct BlkioStats {
     pub io_service_bytes_recursive: Option<Vec<BlkioStatsEntry>>,
@@ -1168,7 +1163,6 @@ pub struct BlkioStats {
 
 /// File I/O statistics for the container.
 #[derive(Debug, Copy, Clone, Deserialize)]
-#[serde(deny_unknown_fields)]
 #[allow(missing_docs)]
 pub struct StorageStats {
     pub read_count_normalized: Option<u64>,
@@ -1179,7 +1173,6 @@ pub struct StorageStats {
 
 /// Statistics for the container.
 #[derive(Debug, Clone, Deserialize)]
-#[serde(deny_unknown_fields)]
 #[allow(missing_docs)]
 pub struct Stats {
     pub read: DateTime<Utc>,
@@ -1199,7 +1192,6 @@ pub struct Stats {
 
 /// Network statistics for the container.
 #[derive(Debug, Copy, Clone, Deserialize)]
-#[serde(deny_unknown_fields)]
 #[allow(missing_docs)]
 pub struct NetworkStats {
     pub rx_dropped: u64,
@@ -1214,7 +1206,6 @@ pub struct NetworkStats {
 
 /// CPU usage statistics for the container.
 #[derive(Debug, Clone, Deserialize)]
-#[serde(deny_unknown_fields)]
 #[allow(missing_docs)]
 pub struct CPUUsage {
     pub percpu_usage: Option<Vec<u64>>,
@@ -1225,7 +1216,6 @@ pub struct CPUUsage {
 
 /// CPU throttling statistics.
 #[derive(Debug, Copy, Clone, Deserialize)]
-#[serde(deny_unknown_fields)]
 #[allow(missing_docs)]
 pub struct ThrottlingData {
     pub periods: u64,
@@ -1235,7 +1225,6 @@ pub struct ThrottlingData {
 
 /// General CPU statistics for the container.
 #[derive(Debug, Clone, Deserialize)]
-#[serde(deny_unknown_fields)]
 #[allow(missing_docs)]
 pub struct CPUStats {
     pub cpu_usage: CPUUsage,
@@ -1245,7 +1234,6 @@ pub struct CPUStats {
 }
 
 #[derive(Debug, Clone, Deserialize)]
-#[serde(deny_unknown_fields)]
 #[allow(missing_docs)]
 pub struct BlkioStatsEntry {
     pub major: u64,
@@ -1292,7 +1280,7 @@ impl<'a, T: AsRef<str>> KillContainerQueryParams<&'a str, T> for KillContainerOp
 
 /// Block IO weight (relative device weight).
 #[derive(Debug, Clone, Default, Serialize)]
-#[serde(rename_all = "PascalCase", deny_unknown_fields)]
+#[serde(rename_all = "PascalCase")]
 #[allow(missing_docs)]
 pub struct UpdateContainerOptionsBlkioWeight {
     pub path: String,
@@ -1301,7 +1289,7 @@ pub struct UpdateContainerOptionsBlkioWeight {
 
 /// Limit read/write rate (IO/bytes per second) from/to a device.
 #[derive(Debug, Clone, Default, Serialize)]
-#[serde(rename_all = "PascalCase", deny_unknown_fields)]
+#[serde(rename_all = "PascalCase")]
 #[allow(missing_docs)]
 pub struct UpdateContainerOptionsBlkioDeviceRate {
     pub path: String,
@@ -1310,7 +1298,7 @@ pub struct UpdateContainerOptionsBlkioDeviceRate {
 
 /// A list of devices to add to the container.
 #[derive(Debug, Clone, Default, Serialize)]
-#[serde(rename_all = "PascalCase", deny_unknown_fields)]
+#[serde(rename_all = "PascalCase")]
 #[allow(missing_docs)]
 pub struct UpdateContainerOptionsDevices {
     pub path_on_host: String,
@@ -1320,7 +1308,7 @@ pub struct UpdateContainerOptionsDevices {
 
 /// A list of resource limits to set in the container.
 #[derive(Debug, Clone, Default, Serialize)]
-#[serde(rename_all = "PascalCase", deny_unknown_fields)]
+#[serde(rename_all = "PascalCase")]
 #[allow(missing_docs)]
 pub struct UpdateContainerOptionsUlimits {
     pub name: String,
@@ -1333,7 +1321,7 @@ pub struct UpdateContainerOptionsUlimits {
 /// An ever increasing delay (double the previous delay, starting at 100ms) is added before each
 /// restart to prevent flooding the server.
 #[derive(Debug, Clone, Default, Serialize)]
-#[serde(rename_all = "PascalCase", deny_unknown_fields)]
+#[serde(rename_all = "PascalCase")]
 #[allow(missing_docs)]
 pub struct UpdateContainerOptionsRestartPolicy {
     pub name: String,
@@ -1355,7 +1343,7 @@ pub struct UpdateContainerOptionsRestartPolicy {
 /// };
 /// ```
 #[derive(Debug, Clone, Default, Serialize)]
-#[serde(rename_all = "PascalCase", deny_unknown_fields)]
+#[serde(rename_all = "PascalCase")]
 pub struct UpdateContainerOptions {
     /// An integer value representing this container's relative CPU weight versus other containers.
     pub cpu_shares: Option<isize>,
@@ -1524,7 +1512,7 @@ impl<'a, T: AsRef<str> + Eq + Hash + Serialize> PruneContainersQueryParams<&'a s
 
 /// Result type for the [Prune Containers API](../struct.Docker.html#method.prune_containers)
 #[derive(Debug, Clone, Deserialize)]
-#[serde(rename_all = "PascalCase", deny_unknown_fields)]
+#[serde(rename_all = "PascalCase")]
 #[allow(missing_docs)]
 pub struct PruneContainersResults {
     pub containers_deleted: Option<Vec<String>>,

--- a/src/exec.rs
+++ b/src/exec.rs
@@ -17,7 +17,7 @@ use container::LogOutput;
 
 /// Exec configuration used in the [Create Exec API](../struct.Docker.html#method.create_exec)
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
-#[serde(rename_all = "PascalCase", deny_unknown_fields)]
+#[serde(rename_all = "PascalCase")]
 pub struct CreateExecOptions<T>
 where
     T: AsRef<str> + Serialize,
@@ -46,7 +46,7 @@ where
 
 /// Result type for the [Create Exec API](../struct.Docker.html#method.create_exec)
 #[derive(Debug, Clone, Deserialize)]
-#[serde(rename_all = "PascalCase", deny_unknown_fields)]
+#[serde(rename_all = "PascalCase")]
 #[allow(missing_docs)]
 pub struct CreateExecResults {
     pub id: String,
@@ -54,7 +54,7 @@ pub struct CreateExecResults {
 
 /// Exec configuration used in the [Create Exec API](../struct.Docker.html#method.create_exec)
 #[derive(Debug, Clone, Copy, Default, Serialize, Deserialize)]
-#[serde(rename_all = "PascalCase", deny_unknown_fields)]
+#[serde(rename_all = "PascalCase")]
 pub struct StartExecOptions {
     /// Detach from the command.
     pub detach: bool,
@@ -69,7 +69,6 @@ pub enum StartExecResults {
 }
 
 #[derive(Debug, Clone, Deserialize)]
-#[serde(deny_unknown_fields)]
 #[allow(missing_docs)]
 pub struct ExecProcessConfig {
     pub user: Option<String>,
@@ -81,7 +80,7 @@ pub struct ExecProcessConfig {
 
 /// Result type for the [Inspect Exec API](../struct.Docker.html#method.inspect_exec)
 #[derive(Debug, Clone, Deserialize)]
-#[serde(rename_all = "PascalCase", deny_unknown_fields)]
+#[serde(rename_all = "PascalCase")]
 #[allow(missing_docs)]
 pub struct ExecInspect {
     pub can_remove: bool,

--- a/src/image.rs
+++ b/src/image.rs
@@ -26,7 +26,7 @@ use std::hash::Hash;
 
 /// Image type returned by the [Inspect Image API](../struct.Docker.html#method.inspect_image)
 #[derive(Debug, Clone, Deserialize)]
-#[serde(rename_all = "PascalCase", deny_unknown_fields)]
+#[serde(rename_all = "PascalCase")]
 #[allow(missing_docs)]
 pub struct Image {
     #[serde(rename = "Id")]
@@ -54,7 +54,7 @@ pub struct Image {
 
 /// Metadata returned by the [Inspect Image API](../struct.Docker.html#method.inspect_image)
 #[derive(Debug, Copy, Clone, Deserialize)]
-#[serde(rename_all = "PascalCase", deny_unknown_fields)]
+#[serde(rename_all = "PascalCase")]
 #[allow(missing_docs)]
 pub struct Metadata {
     pub last_tag_time: DateTime<Utc>,
@@ -62,7 +62,7 @@ pub struct Metadata {
 
 /// Root FS returned by the [Inspect Image API](../struct.Docker.html#method.inspect_image)
 #[derive(Debug, Clone, Deserialize)]
-#[serde(rename_all = "PascalCase", deny_unknown_fields)]
+#[serde(rename_all = "PascalCase")]
 #[allow(missing_docs)]
 pub struct RootFS {
     #[serde(rename = "Type")]
@@ -72,7 +72,7 @@ pub struct RootFS {
 
 /// APIImages type returned by the [List Images API](../struct.Docker.html#method.list_images)
 #[derive(Debug, Clone, Deserialize)]
-#[serde(rename_all = "PascalCase", deny_unknown_fields)]
+#[serde(rename_all = "PascalCase")]
 #[allow(missing_docs)]
 pub struct APIImages {
     pub id: String,
@@ -169,7 +169,6 @@ impl<'a> CreateImageQueryParams<&'a str, String> for CreateImageOptions<String> 
 
 /// Subtype for the [Create Image Results](struct.CreateImagesResults.html) type.
 #[derive(Debug, Copy, Clone, Deserialize)]
-#[serde(deny_unknown_fields)]
 #[allow(missing_docs)]
 pub struct CreateImageProgressDetail {
     pub current: Option<u64>,
@@ -178,14 +177,13 @@ pub struct CreateImageProgressDetail {
 
 /// Subtype for the [Create Image Results](struct.CreateImagesResults.html) type.
 #[derive(Debug, Clone, Deserialize)]
-#[serde(deny_unknown_fields)]
 pub struct CreateImageErrorDetail {
     message: String,
 }
 
 /// Result type for the [Create Image API](../struct.Docker.html#method.create_image)
 #[derive(Debug, Clone, Deserialize)]
-#[serde(untagged, deny_unknown_fields)]
+#[serde(untagged)]
 #[allow(missing_docs)]
 pub enum CreateImageResults {
     #[serde(rename_all = "camelCase")]
@@ -334,7 +332,7 @@ impl<'a, T: AsRef<str> + Eq + Hash + Serialize> PruneImagesQueryParams<&'a str>
 
 /// Subtype for the [Prune Image Results](struct.PruneImagesResults.html) type.
 #[derive(Debug, Clone, Deserialize)]
-#[serde(rename_all = "PascalCase", deny_unknown_fields)]
+#[serde(rename_all = "PascalCase")]
 #[allow(missing_docs)]
 pub struct PruneImagesImagesDeleted {
     pub untagged: Option<String>,
@@ -343,7 +341,7 @@ pub struct PruneImagesImagesDeleted {
 
 /// Result type for the [Prune Images API](../struct.Docker.html#method.prune_images)
 #[derive(Debug, Clone, Deserialize)]
-#[serde(rename_all = "PascalCase", deny_unknown_fields)]
+#[serde(rename_all = "PascalCase")]
 #[allow(missing_docs)]
 pub struct PruneImagesResults {
     pub images_deleted: Option<Vec<PruneImagesImagesDeleted>>,
@@ -352,7 +350,7 @@ pub struct PruneImagesResults {
 
 /// Result type for the [Image History API](../struct.Docker.html#method.image_history)
 #[derive(Debug, Clone, Deserialize)]
-#[serde(rename_all = "PascalCase", deny_unknown_fields)]
+#[serde(rename_all = "PascalCase")]
 #[allow(missing_docs)]
 pub struct ImageHistory {
     pub id: String,
@@ -447,7 +445,6 @@ impl<'a> SearchImagesQueryParams<&'a str> for SearchImagesOptions<String> {
 
 /// Result type for the [Image Search API](../struct.Docker.html#method.image_search)
 #[derive(Debug, Clone, Deserialize)]
-#[serde(deny_unknown_fields)]
 #[allow(missing_docs)]
 pub struct APIImageSearch {
     pub description: String,
@@ -500,7 +497,7 @@ impl<'a> RemoveImageQueryParams<&'a str, &'a str> for RemoveImageOptions {
 
 /// Result type for the [Remove Image API](../struct.Docker.html#method.remove_image)
 #[derive(Debug, Clone, Deserialize)]
-#[serde(untagged, deny_unknown_fields)]
+#[serde(untagged)]
 #[allow(missing_docs)]
 pub enum RemoveImageResults {
     #[serde(rename_all = "PascalCase")]
@@ -677,7 +674,7 @@ impl<'a> CommitContainerQueryParams<&'a str, String> for CommitContainerOptions<
 
 /// Result type for the [Commit Container API](../struct.Docker.html#method.commit_container)
 #[derive(Debug, Clone, Deserialize)]
-#[serde(rename_all = "PascalCase", deny_unknown_fields)]
+#[serde(rename_all = "PascalCase")]
 #[allow(missing_docs)]
 pub struct CommitContainerResults {
     pub id: String,
@@ -852,7 +849,6 @@ impl<'a> BuildImageQueryParams<&'a str> for BuildImageOptions<String> {
 
 /// Subtype for the [Build Image Results](struct.BuildImageResults.html) type.
 #[derive(Debug, Clone, Deserialize)]
-#[serde(deny_unknown_fields)]
 #[allow(missing_docs)]
 pub struct BuildImageAuxDetail {
     #[serde(rename = "ID")]
@@ -861,7 +857,6 @@ pub struct BuildImageAuxDetail {
 
 /// Subtype for the [Build Image Results](struct.BuildImageResults.html) type.
 #[derive(Debug, Clone, Deserialize)]
-#[serde(deny_unknown_fields)]
 #[allow(missing_docs)]
 pub struct BuildImageErrorDetail {
     pub code: Option<u64>,
@@ -870,7 +865,6 @@ pub struct BuildImageErrorDetail {
 
 /// Subtype for the [Build Image Results](struct.BuildImageResults.html) type.
 #[derive(Debug, Clone, Copy, Deserialize)]
-#[serde(deny_unknown_fields)]
 #[allow(missing_docs)]
 pub struct BuildImageProgressDetail {
     pub current: Option<u64>,
@@ -879,10 +873,9 @@ pub struct BuildImageProgressDetail {
 
 /// Result type for the [Build Image API](../struct.Docker.html#method.build_image)
 #[derive(Debug, Clone, Deserialize)]
-#[serde(untagged, deny_unknown_fields)]
+#[serde(untagged)]
 #[allow(missing_docs)]
 pub enum BuildImageResults {
-    BuildImageNone {},
     BuildImageStream {
         stream: String,
     },
@@ -901,6 +894,7 @@ pub enum BuildImageResults {
         progress: Option<String>,
         id: Option<String>,
     },
+    BuildImageNone {},
 }
 
 impl Docker {

--- a/src/network.rs
+++ b/src/network.rs
@@ -17,7 +17,7 @@ use docker::{FALSE_STR, TRUE_STR};
 
 /// Network configuration used in the [Create Network API](../struct.Docker.html#method.create_network)
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
-#[serde(rename_all = "PascalCase", deny_unknown_fields)]
+#[serde(rename_all = "PascalCase")]
 pub struct CreateNetworkOptions<T>
 where
     T: AsRef<str> + Eq + Hash,
@@ -52,7 +52,7 @@ where
 
 /// IPAM represents IP Address Management
 #[derive(Debug, Default, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "PascalCase", deny_unknown_fields)]
+#[serde(rename_all = "PascalCase")]
 #[allow(missing_docs)]
 pub struct IPAM<T>
 where
@@ -68,7 +68,7 @@ where
 
 /// IPAMConfig represents IPAM configurations
 #[derive(Debug, Default, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "PascalCase", deny_unknown_fields)]
+#[serde(rename_all = "PascalCase")]
 #[allow(missing_docs)]
 pub struct IPAMConfig<T>
 where
@@ -83,7 +83,7 @@ where
 
 /// Result type for the [Create Network API](../struct.Docker.html#method.create_network)
 #[derive(Debug, Clone, Deserialize)]
-#[serde(rename_all = "PascalCase", deny_unknown_fields)]
+#[serde(rename_all = "PascalCase")]
 #[allow(missing_docs)]
 pub struct CreateNetworkResults {
     pub id: String,
@@ -111,7 +111,7 @@ pub struct CreateNetworkResults {
 /// };
 /// ```
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
-#[serde(rename_all = "PascalCase", deny_unknown_fields)]
+#[serde(rename_all = "PascalCase")]
 pub struct InspectNetworkOptions<T> {
     /// Detailed inspect output for troubleshooting.
     pub verbose: bool,
@@ -149,7 +149,7 @@ impl<'a> InspectNetworkQueryParams<'a, String> for InspectNetworkOptions<String>
 
 /// Result type for the [Inspect Network API](../struct.Docker.html#method.inspect_network)
 #[derive(Debug, Clone, Deserialize)]
-#[serde(rename_all = "PascalCase", deny_unknown_fields)]
+#[serde(rename_all = "PascalCase")]
 #[allow(missing_docs)]
 pub struct InspectNetworkResults {
     pub name: String,
@@ -173,7 +173,7 @@ pub struct InspectNetworkResults {
 
 /// Result type for the [Inspect Network API](../struct.Docker.html#method.inspect_network)
 #[derive(Debug, Clone, Deserialize)]
-#[serde(rename_all = "PascalCase", deny_unknown_fields)]
+#[serde(rename_all = "PascalCase")]
 #[allow(missing_docs)]
 pub struct InspectNetworkResultsContainers {
     pub name: String,
@@ -188,7 +188,7 @@ pub struct InspectNetworkResultsContainers {
 
 /// Result type for the [List Networks API](../struct.Docker.html#method.list_networks)
 #[derive(Debug, Clone, Deserialize)]
-#[serde(rename_all = "PascalCase", deny_unknown_fields)]
+#[serde(rename_all = "PascalCase")]
 #[allow(missing_docs)]
 pub struct ListNetworksResults {
     pub name: String,
@@ -236,7 +236,7 @@ pub struct ListNetworksResults {
 /// };
 /// ```
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
-#[serde(rename_all = "PascalCase", deny_unknown_fields)]
+#[serde(rename_all = "PascalCase")]
 pub struct ListNetworksOptions<T>
 where
     T: AsRef<str> + Eq + Hash,
@@ -273,7 +273,7 @@ impl<'a> ListNetworksQueryParams<&'a str, String> for ListNetworksOptions<&'a st
 
 /// Network configuration used in the [Connect Network API](../struct.Docker.html#method.connect_network)
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
-#[serde(rename_all = "PascalCase", deny_unknown_fields)]
+#[serde(rename_all = "PascalCase")]
 pub struct ConnectNetworkOptions<T>
 where
     T: AsRef<str> + Eq + Hash,
@@ -286,7 +286,7 @@ where
 
 /// Configuration for a network endpoint.
 #[derive(Debug, Default, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "PascalCase", deny_unknown_fields)]
+#[serde(rename_all = "PascalCase")]
 pub struct EndpointSettings<T>
 where
     T: AsRef<str> + Eq + Hash,
@@ -329,7 +329,6 @@ where
 }
 
 #[derive(Debug, Default, Clone, Serialize, Deserialize)]
-#[serde(deny_unknown_fields)]
 #[allow(missing_docs)]
 pub struct EndpointIPAMConfig<T>
 where
@@ -345,7 +344,7 @@ where
 
 /// Network configuration used in the [Disconnect Network API](../struct.Docker.html#method.disconnect_network)
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
-#[serde(rename_all = "PascalCase", deny_unknown_fields)]
+#[serde(rename_all = "PascalCase")]
 pub struct DisconnectNetworkOptions<T>
 where
     T: AsRef<str>,
@@ -417,7 +416,7 @@ impl<'a> PruneNetworksQueryParams<&'a str, String> for PruneNetworksOptions<&'a 
 
 /// Result type for the [Prune Networks API](../struct.Docker.html#method.prune_networks)
 #[derive(Debug, Clone, Deserialize)]
-#[serde(rename_all = "PascalCase", deny_unknown_fields)]
+#[serde(rename_all = "PascalCase")]
 #[allow(missing_docs)]
 pub struct PruneNetworksResults {
     pub networks_deleted: Option<Vec<String>>,


### PR DESCRIPTION
Recently Docker 19.03 was released and it introduced the new 1.40 API version with [whole lot of new fields](https://docs.docker.com/engine/api/version-history/#v140-api-changes), which cause Bollard to fail due to it's use of deny_unknown_fields serde attribute.

Quote from the [Docker Engine API reference](https://docs.docker.com/engine/api/v1.39/#section/Versioning):

>The API uses an open schema model, which means server may add extra properties to responses.

>Likewise, the server will ignore any extra query parameters and request body properties.

>When you write clients, you need to ignore additional properties in responses to ensure they do not break when talking to newer daemons.