### PR TITLE
Updates to the v1.40 upstream Docker API

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 jobs:
   test_ssl:
     docker:
-      - image: docker:18.09.1
+      - image: docker:19.03.1
     steps:
       - checkout
       - setup_remote_docker
@@ -15,7 +15,7 @@ jobs:
       - run: docker run -ti -e DOCKER_CERT_PATH=/certs -e DOCKER_HOST='tcp://test.example.com:2376' --volumes-from certs --rm --link test-docker-daemon:docker bollard cargo test --features ssl -- --test test_version_ssl
   test_tls:
     docker:
-      - image: docker:18.09.1
+      - image: docker:19.03.1
     steps:
       - checkout
       - setup_remote_docker
@@ -29,7 +29,7 @@ jobs:
       - run: docker run -ti -e DOCKER_CERT_PATH=/certs -e DOCKER_HOST='tcp://test.example.com:2376' --volumes-from certs --rm --link test-docker-daemon:docker bollard cargo test -- --test test_version_tls
   test_http:
     docker:
-      - image: docker:18.09.1
+      - image: docker:19.03.1
     steps:
       - checkout
       - setup_remote_docker
@@ -38,7 +38,7 @@ jobs:
       - run: docker run -ti -e DOCKER_HOST='tcp://test.example.com:2375' --rm --link test-docker-daemon:docker bollard cargo test --features test_http -- --test test_version_http
   test_unix:
     docker:
-      - image: docker:18.09.1
+      - image: docker:19.03.1
     steps:
       - checkout
       - setup_remote_docker
@@ -46,7 +46,7 @@ jobs:
       - run: dockerfiles/bin/run_integration_tests.sh
   test_doc:
     docker:
-      - image: docker:18.09.1
+      - image: docker:19.03.1
     steps:
       - checkout
       - setup_remote_docker

--- a/src/container.rs
+++ b/src/container.rs
@@ -151,7 +151,7 @@ impl<'a, T: AsRef<str>> CreateContainerQueryParams<&'a str, T> for CreateContain
 
 /// Container configuration that depends on the host we are running on
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
-#[serde(rename_all = "PascalCase", deny_unknown_fields)]
+#[serde(rename_all = "PascalCase")]
 #[allow(missing_docs)]
 pub struct HostConfig<T>
 where
@@ -322,7 +322,7 @@ where
 
 /// Storage driver name and configuration.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "PascalCase", deny_unknown_fields)]
+#[serde(rename_all = "PascalCase")]
 #[allow(missing_docs)]
 pub struct GraphDriver {
     pub name: String,
@@ -334,7 +334,7 @@ pub struct GraphDriver {
 /// container's port is mapped for multiple protocols, separate entries are added to the mapping
 /// table.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "PascalCase", deny_unknown_fields)]
+#[serde(rename_all = "PascalCase")]
 #[allow(missing_docs)]
 pub struct PortBinding<T>
 where
@@ -349,7 +349,7 @@ where
 /// increasing delay (double the previous delay, starting at 100ms) is added before each restart to
 /// prevent flooding the server.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
-#[serde(rename_all = "PascalCase", deny_unknown_fields)]
+#[serde(rename_all = "PascalCase")]
 #[allow(missing_docs)]
 pub struct RestartPolicy<T>
 where
@@ -361,7 +361,7 @@ where
 
 /// The logging configuration for this container.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
-#[serde(rename_all = "PascalCase", deny_unknown_fields)]
+#[serde(rename_all = "PascalCase")]
 #[allow(missing_docs)]
 pub struct LogConfig {
     #[serde(rename = "Type")]
@@ -371,7 +371,6 @@ pub struct LogConfig {
 
 /// This container's networking configuration.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(deny_unknown_fields)]
 #[allow(missing_docs)]
 pub struct NetworkingConfig {
     pub endpoints_config: HashMap<String, ContainerNetwork>,
@@ -379,7 +378,7 @@ pub struct NetworkingConfig {
 
 /// Configuration for a network endpoint.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "PascalCase", deny_unknown_fields)]
+#[serde(rename_all = "PascalCase")]
 #[allow(missing_docs)]
 pub struct ContainerNetwork {
     #[serde(rename = "IPAMConfig")]
@@ -407,7 +406,7 @@ pub struct ContainerNetwork {
 
 /// Network Settings for a container.
 #[derive(Debug, Clone, Deserialize)]
-#[serde(rename_all = "PascalCase", deny_unknown_fields)]
+#[serde(rename_all = "PascalCase")]
 #[allow(missing_docs)]
 pub struct NetworkSettings {
     pub networks: HashMap<String, ContainerNetwork>,
@@ -443,7 +442,7 @@ pub struct NetworkSettings {
 
 /// Specification for mounts to be added to the container.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "PascalCase", deny_unknown_fields)]
+#[serde(rename_all = "PascalCase")]
 #[allow(missing_docs)]
 pub struct Mount {
     pub name: Option<String>,
@@ -460,7 +459,7 @@ pub struct Mount {
 
 /// Log of the health of a running container.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "PascalCase", deny_unknown_fields)]
+#[serde(rename_all = "PascalCase")]
 #[allow(missing_docs)]
 pub struct LogStateHealth {
     pub start: DateTime<Utc>,
@@ -471,7 +470,7 @@ pub struct LogStateHealth {
 
 /// Health of a running container.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "PascalCase", deny_unknown_fields)]
+#[serde(rename_all = "PascalCase")]
 #[allow(missing_docs)]
 pub struct StateHealth {
     pub status: String,
@@ -481,7 +480,7 @@ pub struct StateHealth {
 
 /// Runtime status of the container.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "PascalCase", deny_unknown_fields)]
+#[serde(rename_all = "PascalCase")]
 #[allow(missing_docs)]
 pub struct State {
     pub status: String,
@@ -501,7 +500,7 @@ pub struct State {
 
 /// Maps internal container port to external host port.
 #[derive(Debug, Clone, Deserialize)]
-#[serde(rename_all = "PascalCase", deny_unknown_fields)]
+#[serde(rename_all = "PascalCase")]
 #[allow(missing_docs)]
 pub struct APIPort {
     #[serde(rename = "IP")]
@@ -514,7 +513,7 @@ pub struct APIPort {
 
 /// A mapping of network name to endpoint configuration for that network.
 #[derive(Debug, Clone, Deserialize)]
-#[serde(rename_all = "PascalCase", deny_unknown_fields)]
+#[serde(rename_all = "PascalCase")]
 #[allow(missing_docs)]
 pub struct NetworkList {
     pub networks: HashMap<String, ContainerNetwork>,
@@ -522,7 +521,7 @@ pub struct NetworkList {
 
 /// Result type for the [List Containers API](../struct.Docker.html#method.list_containers)
 #[derive(Debug, Clone, Deserialize)]
-#[serde(rename_all = "PascalCase", deny_unknown_fields)]
+#[serde(rename_all = "PascalCase")]
 #[allow(missing_docs)]
 pub struct APIContainers {
     pub id: String,
@@ -546,7 +545,7 @@ pub struct APIContainers {
 
 /// Result type for the [Inspect Container API](../struct.Docker.html#method.inspect_container)
 #[derive(Debug, Clone, Deserialize)]
-#[serde(rename_all = "PascalCase", deny_unknown_fields)]
+#[serde(rename_all = "PascalCase")]
 #[allow(missing_docs)]
 pub struct Container {
     pub id: String,
@@ -577,7 +576,7 @@ pub struct Container {
 
 /// A test to perform to check that the container is healthy.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "PascalCase", deny_unknown_fields)]
+#[serde(rename_all = "PascalCase")]
 pub struct HealthConfig {
     /// The test to perform. Possible values are:
     ///  - `[]` inherit healthcheck from image or parent image
@@ -601,7 +600,7 @@ pub struct HealthConfig {
 
 /// Container to create.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
-#[serde(rename_all = "PascalCase", deny_unknown_fields)]
+#[serde(rename_all = "PascalCase")]
 pub struct Config<T>
 where
     T: AsRef<str> + Eq + Hash,
@@ -668,7 +667,7 @@ where
 
 /// Result type for the [Create Container API](../struct.Docker.html#method.create_container)
 #[derive(Debug, Clone, Deserialize)]
-#[serde(rename_all = "PascalCase", deny_unknown_fields)]
+#[serde(rename_all = "PascalCase")]
 #[allow(missing_docs)]
 pub struct CreateContainerResults {
     pub id: String,
@@ -825,7 +824,7 @@ impl<'a, T: AsRef<str>> WaitContainerQueryParams<&'a str, T> for WaitContainerOp
 
 /// Error messages returned in the [Wait Container API](../struct.Docker.html#method.wait_container)
 #[derive(Debug, Clone, Deserialize)]
-#[serde(rename_all = "PascalCase", deny_unknown_fields)]
+#[serde(rename_all = "PascalCase")]
 #[allow(missing_docs)]
 pub struct WaitContainerResultsError {
     pub message: String,
@@ -833,7 +832,7 @@ pub struct WaitContainerResultsError {
 
 /// Result type for the [Wait Container API](../struct.Docker.html#method.wait_container)
 #[derive(Debug, Clone, Deserialize)]
-#[serde(rename_all = "PascalCase", deny_unknown_fields)]
+#[serde(rename_all = "PascalCase")]
 #[allow(missing_docs)]
 pub struct WaitContainerResults {
     pub status_code: u64,
@@ -948,7 +947,7 @@ impl<'a, T: AsRef<str>> TopQueryParams<&'a str, T> for TopOptions<T> {
 
 /// Result type for the [Top Processes API](../struct.Docker.html#method.top_processes)
 #[derive(Debug, Clone, Deserialize)]
-#[serde(rename_all = "PascalCase", deny_unknown_fields)]
+#[serde(rename_all = "PascalCase")]
 #[allow(missing_docs)]
 pub struct TopResult {
     pub titles: Vec<String>,
@@ -1034,7 +1033,7 @@ impl fmt::Display for LogOutput {
 
 /// Result type for the [Container Changes API](../struct.Docker.html#method.container_changes)
 #[derive(Debug, Clone, Deserialize)]
-#[serde(rename_all = "PascalCase", deny_unknown_fields)]
+#[serde(rename_all = "PascalCase")]
 #[allow(missing_docs)]
 pub struct Change {
     pub path: String,
@@ -1090,7 +1089,6 @@ impl<'a> StatsQueryParams<&'a str, &'a str> for StatsOptions {
 
 /// Granular memory statistics for the container.
 #[derive(Debug, Copy, Clone, Deserialize)]
-#[serde(deny_unknown_fields)]
 #[allow(missing_docs)]
 pub struct MemoryStatsStats {
     pub cache: u64,
@@ -1129,7 +1127,6 @@ pub struct MemoryStatsStats {
 
 /// General memory statistics for the container.
 #[derive(Debug, Copy, Clone, Deserialize)]
-#[serde(deny_unknown_fields)]
 #[allow(missing_docs)]
 pub struct MemoryStats {
     pub stats: Option<MemoryStatsStats>,
@@ -1146,7 +1143,6 @@ pub struct MemoryStats {
 
 /// Process ID statistics for the container.
 #[derive(Debug, Copy, Clone, Deserialize)]
-#[serde(deny_unknown_fields)]
 #[allow(missing_docs)]
 pub struct PidsStats {
     pub current: Option<u64>,
@@ -1155,7 +1151,6 @@ pub struct PidsStats {
 
 /// I/O statistics for the container.
 #[derive(Debug, Clone, Deserialize)]
-#[serde(deny_unknown_fields)]
 #[allow(missing_docs)]
 pub struct BlkioStats {
     pub io_service_bytes_recursive: Option<Vec<BlkioStatsEntry>>,
@@ -1170,7 +1165,6 @@ pub struct BlkioStats {
 
 /// File I/O statistics for the container.
 #[derive(Debug, Copy, Clone, Deserialize)]
-#[serde(deny_unknown_fields)]
 #[allow(missing_docs)]
 pub struct StorageStats {
     pub read_count_normalized: Option<u64>,
@@ -1181,7 +1175,6 @@ pub struct StorageStats {
 
 /// Statistics for the container.
 #[derive(Debug, Clone, Deserialize)]
-#[serde(deny_unknown_fields)]
 #[allow(missing_docs)]
 pub struct Stats {
     pub read: DateTime<Utc>,
@@ -1201,7 +1194,6 @@ pub struct Stats {
 
 /// Network statistics for the container.
 #[derive(Debug, Copy, Clone, Deserialize)]
-#[serde(deny_unknown_fields)]
 #[allow(missing_docs)]
 pub struct NetworkStats {
     pub rx_dropped: u64,
@@ -1216,7 +1208,6 @@ pub struct NetworkStats {
 
 /// CPU usage statistics for the container.
 #[derive(Debug, Clone, Deserialize)]
-#[serde(deny_unknown_fields)]
 #[allow(missing_docs)]
 pub struct CPUUsage {
     pub percpu_usage: Option<Vec<u64>>,
@@ -1227,7 +1218,6 @@ pub struct CPUUsage {
 
 /// CPU throttling statistics.
 #[derive(Debug, Copy, Clone, Deserialize)]
-#[serde(deny_unknown_fields)]
 #[allow(missing_docs)]
 pub struct ThrottlingData {
     pub periods: u64,
@@ -1237,7 +1227,6 @@ pub struct ThrottlingData {
 
 /// General CPU statistics for the container.
 #[derive(Debug, Clone, Deserialize)]
-#[serde(deny_unknown_fields)]
 #[allow(missing_docs)]
 pub struct CPUStats {
     pub cpu_usage: CPUUsage,
@@ -1247,7 +1236,6 @@ pub struct CPUStats {
 }
 
 #[derive(Debug, Clone, Deserialize)]
-#[serde(deny_unknown_fields)]
 #[allow(missing_docs)]
 pub struct BlkioStatsEntry {
     pub major: u64,
@@ -1294,7 +1282,7 @@ impl<'a, T: AsRef<str>> KillContainerQueryParams<&'a str, T> for KillContainerOp
 
 /// Block IO weight (relative device weight).
 #[derive(Debug, Clone, Default, Serialize)]
-#[serde(rename_all = "PascalCase", deny_unknown_fields)]
+#[serde(rename_all = "PascalCase")]
 #[allow(missing_docs)]
 pub struct UpdateContainerOptionsBlkioWeight {
     pub path: String,
@@ -1303,7 +1291,7 @@ pub struct UpdateContainerOptionsBlkioWeight {
 
 /// Limit read/write rate (IO/bytes per second) from/to a device.
 #[derive(Debug, Clone, Default, Serialize)]
-#[serde(rename_all = "PascalCase", deny_unknown_fields)]
+#[serde(rename_all = "PascalCase")]
 #[allow(missing_docs)]
 pub struct UpdateContainerOptionsBlkioDeviceRate {
     pub path: String,
@@ -1312,7 +1300,7 @@ pub struct UpdateContainerOptionsBlkioDeviceRate {
 
 /// A list of devices to add to the container.
 #[derive(Debug, Clone, Default, Serialize)]
-#[serde(rename_all = "PascalCase", deny_unknown_fields)]
+#[serde(rename_all = "PascalCase")]
 #[allow(missing_docs)]
 pub struct UpdateContainerOptionsDevices {
     pub path_on_host: String,
@@ -1322,7 +1310,7 @@ pub struct UpdateContainerOptionsDevices {
 
 /// A list of resource limits to set in the container.
 #[derive(Debug, Clone, Default, Serialize)]
-#[serde(rename_all = "PascalCase", deny_unknown_fields)]
+#[serde(rename_all = "PascalCase")]
 #[allow(missing_docs)]
 pub struct UpdateContainerOptionsUlimits {
     pub name: String,
@@ -1335,7 +1323,7 @@ pub struct UpdateContainerOptionsUlimits {
 /// An ever increasing delay (double the previous delay, starting at 100ms) is added before each
 /// restart to prevent flooding the server.
 #[derive(Debug, Clone, Default, Serialize)]
-#[serde(rename_all = "PascalCase", deny_unknown_fields)]
+#[serde(rename_all = "PascalCase")]
 #[allow(missing_docs)]
 pub struct UpdateContainerOptionsRestartPolicy {
     pub name: String,
@@ -1357,7 +1345,7 @@ pub struct UpdateContainerOptionsRestartPolicy {
 /// };
 /// ```
 #[derive(Debug, Clone, Default, Serialize)]
-#[serde(rename_all = "PascalCase", deny_unknown_fields)]
+#[serde(rename_all = "PascalCase")]
 pub struct UpdateContainerOptions {
     /// An integer value representing this container's relative CPU weight versus other containers.
     pub cpu_shares: Option<isize>,
@@ -1526,7 +1514,7 @@ impl<'a, T: AsRef<str> + Eq + Hash + Serialize> PruneContainersQueryParams<&'a s
 
 /// Result type for the [Prune Containers API](../struct.Docker.html#method.prune_containers)
 #[derive(Debug, Clone, Deserialize)]
-#[serde(rename_all = "PascalCase", deny_unknown_fields)]
+#[serde(rename_all = "PascalCase")]
 #[allow(missing_docs)]
 pub struct PruneContainersResults {
     pub containers_deleted: Option<Vec<String>>,

--- a/src/container.rs
+++ b/src/container.rs
@@ -151,7 +151,7 @@ impl<'a, T: AsRef<str>> CreateContainerQueryParams<&'a str, T> for CreateContain
 
 /// A request for devices to be sent to device drivers
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
-#[serde(rename_all = "PascalCase", deny_unknown_fields)]
+#[serde(rename_all = "PascalCase")]
 #[allow(missing_docs)]
 pub struct DeviceRequest<T>
 where
@@ -169,7 +169,7 @@ where
 
 /// Bind options for mounts.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
-#[serde(rename_all = "PascalCase", deny_unknown_fields)]
+#[serde(rename_all = "PascalCase")]
 pub struct MountPointBindOptions<T>
 where
     T: AsRef<str>,
@@ -182,7 +182,7 @@ where
 
 /// Driver config for volume options
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
-#[serde(rename_all = "PascalCase", deny_unknown_fields)]
+#[serde(rename_all = "PascalCase")]
 pub struct VolumeOptionsDriverConfig<T>
 where
     T: AsRef<str> + Eq + Hash,
@@ -195,7 +195,7 @@ where
 
 /// Volume options for mounts.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
-#[serde(rename_all = "PascalCase", deny_unknown_fields)]
+#[serde(rename_all = "PascalCase")]
 pub struct MountPointVolumeOptions<T>
 where
     T: AsRef<str> + Eq + Hash,
@@ -210,7 +210,7 @@ where
 
 /// Tmpfs options for mounts.
 #[derive(Debug, Clone, Copy, Default, Serialize, Deserialize)]
-#[serde(rename_all = "PascalCase", deny_unknown_fields)]
+#[serde(rename_all = "PascalCase")]
 pub struct MountPointTmpfsOptions {
     /// The size for the tmpfs mount in bytes.
     pub size_bytes: u64,
@@ -220,7 +220,7 @@ pub struct MountPointTmpfsOptions {
 
 /// Specification for mounts to be added to the container.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
-#[serde(rename_all = "PascalCase", deny_unknown_fields)]
+#[serde(rename_all = "PascalCase")]
 #[allow(missing_docs)]
 pub struct MountPoint<T>
 where

--- a/src/docker.rs
+++ b/src/docker.rs
@@ -79,7 +79,7 @@ const DEFAULT_TIMEOUT: u64 = 120;
 /// Default Client Version to communicate with the server.
 pub const API_DEFAULT_VERSION: &'static ClientVersion = &ClientVersion {
     major_version: 1,
-    minor_version: 39,
+    minor_version: 40,
 };
 
 pub(crate) const TRUE_STR: &'static str = "true";

--- a/src/exec.rs
+++ b/src/exec.rs
@@ -19,7 +19,7 @@ use container::LogOutput;
 
 /// Exec configuration used in the [Create Exec API](../struct.Docker.html#method.create_exec)
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
-#[serde(rename_all = "PascalCase", deny_unknown_fields)]
+#[serde(rename_all = "PascalCase")]
 pub struct CreateExecOptions<T>
 where
     T: AsRef<str> + Serialize,
@@ -48,7 +48,7 @@ where
 
 /// Result type for the [Create Exec API](../struct.Docker.html#method.create_exec)
 #[derive(Debug, Clone, Deserialize)]
-#[serde(rename_all = "PascalCase", deny_unknown_fields)]
+#[serde(rename_all = "PascalCase")]
 #[allow(missing_docs)]
 pub struct CreateExecResults {
     pub id: String,
@@ -56,7 +56,7 @@ pub struct CreateExecResults {
 
 /// Exec configuration used in the [Create Exec API](../struct.Docker.html#method.create_exec)
 #[derive(Debug, Clone, Copy, Default, Serialize, Deserialize)]
-#[serde(rename_all = "PascalCase", deny_unknown_fields)]
+#[serde(rename_all = "PascalCase")]
 pub struct StartExecOptions {
     /// Detach from the command.
     pub detach: bool,
@@ -71,7 +71,6 @@ pub enum StartExecResults {
 }
 
 #[derive(Debug, Clone, Deserialize)]
-#[serde(deny_unknown_fields)]
 #[allow(missing_docs)]
 pub struct ExecProcessConfig {
     pub user: Option<String>,
@@ -83,7 +82,7 @@ pub struct ExecProcessConfig {
 
 /// Result type for the [Inspect Exec API](../struct.Docker.html#method.inspect_exec)
 #[derive(Debug, Clone, Deserialize)]
-#[serde(rename_all = "PascalCase", deny_unknown_fields)]
+#[serde(rename_all = "PascalCase")]
 #[allow(missing_docs)]
 pub struct ExecInspect {
     pub can_remove: bool,

--- a/src/image.rs
+++ b/src/image.rs
@@ -28,7 +28,7 @@ use std::hash::Hash;
 
 /// Image type returned by the [Inspect Image API](../struct.Docker.html#method.inspect_image)
 #[derive(Debug, Clone, Deserialize)]
-#[serde(rename_all = "PascalCase", deny_unknown_fields)]
+#[serde(rename_all = "PascalCase")]
 #[allow(missing_docs)]
 pub struct Image {
     #[serde(rename = "Id")]
@@ -56,7 +56,7 @@ pub struct Image {
 
 /// Metadata returned by the [Inspect Image API](../struct.Docker.html#method.inspect_image)
 #[derive(Debug, Copy, Clone, Deserialize)]
-#[serde(rename_all = "PascalCase", deny_unknown_fields)]
+#[serde(rename_all = "PascalCase")]
 #[allow(missing_docs)]
 pub struct Metadata {
     pub last_tag_time: DateTime<Utc>,
@@ -64,7 +64,7 @@ pub struct Metadata {
 
 /// Root FS returned by the [Inspect Image API](../struct.Docker.html#method.inspect_image)
 #[derive(Debug, Clone, Deserialize)]
-#[serde(rename_all = "PascalCase", deny_unknown_fields)]
+#[serde(rename_all = "PascalCase")]
 #[allow(missing_docs)]
 pub struct RootFS {
     #[serde(rename = "Type")]
@@ -74,7 +74,7 @@ pub struct RootFS {
 
 /// APIImages type returned by the [List Images API](../struct.Docker.html#method.list_images)
 #[derive(Debug, Clone, Deserialize)]
-#[serde(rename_all = "PascalCase", deny_unknown_fields)]
+#[serde(rename_all = "PascalCase")]
 #[allow(missing_docs)]
 pub struct APIImages {
     pub id: String,
@@ -171,7 +171,6 @@ impl<'a> CreateImageQueryParams<&'a str, String> for CreateImageOptions<String> 
 
 /// Subtype for the [Create Image Results](struct.CreateImagesResults.html) type.
 #[derive(Debug, Copy, Clone, Deserialize)]
-#[serde(deny_unknown_fields)]
 #[allow(missing_docs)]
 pub struct CreateImageProgressDetail {
     pub current: Option<u64>,
@@ -180,14 +179,13 @@ pub struct CreateImageProgressDetail {
 
 /// Subtype for the [Create Image Results](struct.CreateImagesResults.html) type.
 #[derive(Debug, Clone, Deserialize)]
-#[serde(deny_unknown_fields)]
 pub struct CreateImageErrorDetail {
     message: String,
 }
 
 /// Result type for the [Create Image API](../struct.Docker.html#method.create_image)
 #[derive(Debug, Clone, Deserialize)]
-#[serde(untagged, deny_unknown_fields)]
+#[serde(untagged)]
 #[allow(missing_docs)]
 pub enum CreateImageResults {
     #[serde(rename_all = "camelCase")]
@@ -336,7 +334,7 @@ impl<'a, T: AsRef<str> + Eq + Hash + Serialize> PruneImagesQueryParams<&'a str>
 
 /// Subtype for the [Prune Image Results](struct.PruneImagesResults.html) type.
 #[derive(Debug, Clone, Deserialize)]
-#[serde(rename_all = "PascalCase", deny_unknown_fields)]
+#[serde(rename_all = "PascalCase")]
 #[allow(missing_docs)]
 pub struct PruneImagesImagesDeleted {
     pub untagged: Option<String>,
@@ -345,7 +343,7 @@ pub struct PruneImagesImagesDeleted {
 
 /// Result type for the [Prune Images API](../struct.Docker.html#method.prune_images)
 #[derive(Debug, Clone, Deserialize)]
-#[serde(rename_all = "PascalCase", deny_unknown_fields)]
+#[serde(rename_all = "PascalCase")]
 #[allow(missing_docs)]
 pub struct PruneImagesResults {
     pub images_deleted: Option<Vec<PruneImagesImagesDeleted>>,
@@ -354,7 +352,7 @@ pub struct PruneImagesResults {
 
 /// Result type for the [Image History API](../struct.Docker.html#method.image_history)
 #[derive(Debug, Clone, Deserialize)]
-#[serde(rename_all = "PascalCase", deny_unknown_fields)]
+#[serde(rename_all = "PascalCase")]
 #[allow(missing_docs)]
 pub struct ImageHistory {
     pub id: String,
@@ -449,7 +447,6 @@ impl<'a> SearchImagesQueryParams<&'a str> for SearchImagesOptions<String> {
 
 /// Result type for the [Image Search API](../struct.Docker.html#method.image_search)
 #[derive(Debug, Clone, Deserialize)]
-#[serde(deny_unknown_fields)]
 #[allow(missing_docs)]
 pub struct APIImageSearch {
     pub description: String,
@@ -502,7 +499,7 @@ impl<'a> RemoveImageQueryParams<&'a str, &'a str> for RemoveImageOptions {
 
 /// Result type for the [Remove Image API](../struct.Docker.html#method.remove_image)
 #[derive(Debug, Clone, Deserialize)]
-#[serde(untagged, deny_unknown_fields)]
+#[serde(untagged)]
 #[allow(missing_docs)]
 pub enum RemoveImageResults {
     #[serde(rename_all = "PascalCase")]
@@ -679,7 +676,7 @@ impl<'a> CommitContainerQueryParams<&'a str, String> for CommitContainerOptions<
 
 /// Result type for the [Commit Container API](../struct.Docker.html#method.commit_container)
 #[derive(Debug, Clone, Deserialize)]
-#[serde(rename_all = "PascalCase", deny_unknown_fields)]
+#[serde(rename_all = "PascalCase")]
 #[allow(missing_docs)]
 pub struct CommitContainerResults {
     pub id: String,
@@ -854,7 +851,6 @@ impl<'a> BuildImageQueryParams<&'a str> for BuildImageOptions<String> {
 
 /// Subtype for the [Build Image Results](struct.BuildImageResults.html) type.
 #[derive(Debug, Clone, Deserialize)]
-#[serde(deny_unknown_fields)]
 #[allow(missing_docs)]
 pub struct BuildImageAuxDetail {
     #[serde(rename = "ID")]
@@ -863,7 +859,6 @@ pub struct BuildImageAuxDetail {
 
 /// Subtype for the [Build Image Results](struct.BuildImageResults.html) type.
 #[derive(Debug, Clone, Deserialize)]
-#[serde(deny_unknown_fields)]
 #[allow(missing_docs)]
 pub struct BuildImageErrorDetail {
     pub code: Option<u64>,
@@ -872,7 +867,6 @@ pub struct BuildImageErrorDetail {
 
 /// Subtype for the [Build Image Results](struct.BuildImageResults.html) type.
 #[derive(Debug, Clone, Copy, Deserialize)]
-#[serde(deny_unknown_fields)]
 #[allow(missing_docs)]
 pub struct BuildImageProgressDetail {
     pub current: Option<u64>,
@@ -881,10 +875,9 @@ pub struct BuildImageProgressDetail {
 
 /// Result type for the [Build Image API](../struct.Docker.html#method.build_image)
 #[derive(Debug, Clone, Deserialize)]
-#[serde(untagged, deny_unknown_fields)]
+#[serde(untagged)]
 #[allow(missing_docs)]
 pub enum BuildImageResults {
-    BuildImageNone {},
     BuildImageStream {
         stream: String,
     },
@@ -903,6 +896,7 @@ pub enum BuildImageResults {
         progress: Option<String>,
         id: Option<String>,
     },
+    BuildImageNone {},
 }
 
 impl Docker {

--- a/src/network.rs
+++ b/src/network.rs
@@ -19,7 +19,7 @@ use docker::{FALSE_STR, TRUE_STR};
 
 /// Network configuration used in the [Create Network API](../struct.Docker.html#method.create_network)
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
-#[serde(rename_all = "PascalCase", deny_unknown_fields)]
+#[serde(rename_all = "PascalCase")]
 pub struct CreateNetworkOptions<T>
 where
     T: AsRef<str> + Eq + Hash,
@@ -54,7 +54,7 @@ where
 
 /// IPAM represents IP Address Management
 #[derive(Debug, Default, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "PascalCase", deny_unknown_fields)]
+#[serde(rename_all = "PascalCase")]
 #[allow(missing_docs)]
 pub struct IPAM<T>
 where
@@ -70,7 +70,7 @@ where
 
 /// IPAMConfig represents IPAM configurations
 #[derive(Debug, Default, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "PascalCase", deny_unknown_fields)]
+#[serde(rename_all = "PascalCase")]
 #[allow(missing_docs)]
 pub struct IPAMConfig<T>
 where
@@ -85,7 +85,7 @@ where
 
 /// Result type for the [Create Network API](../struct.Docker.html#method.create_network)
 #[derive(Debug, Clone, Deserialize)]
-#[serde(rename_all = "PascalCase", deny_unknown_fields)]
+#[serde(rename_all = "PascalCase")]
 #[allow(missing_docs)]
 pub struct CreateNetworkResults {
     pub id: String,
@@ -113,7 +113,7 @@ pub struct CreateNetworkResults {
 /// };
 /// ```
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
-#[serde(rename_all = "PascalCase", deny_unknown_fields)]
+#[serde(rename_all = "PascalCase")]
 pub struct InspectNetworkOptions<T> {
     /// Detailed inspect output for troubleshooting.
     pub verbose: bool,
@@ -151,7 +151,7 @@ impl<'a> InspectNetworkQueryParams<'a, String> for InspectNetworkOptions<String>
 
 /// Result type for the [Inspect Network API](../struct.Docker.html#method.inspect_network)
 #[derive(Debug, Clone, Deserialize)]
-#[serde(rename_all = "PascalCase", deny_unknown_fields)]
+#[serde(rename_all = "PascalCase")]
 #[allow(missing_docs)]
 pub struct InspectNetworkResults {
     pub name: String,
@@ -175,7 +175,7 @@ pub struct InspectNetworkResults {
 
 /// Result type for the [Inspect Network API](../struct.Docker.html#method.inspect_network)
 #[derive(Debug, Clone, Deserialize)]
-#[serde(rename_all = "PascalCase", deny_unknown_fields)]
+#[serde(rename_all = "PascalCase")]
 #[allow(missing_docs)]
 pub struct InspectNetworkResultsContainers {
     pub name: String,
@@ -190,7 +190,7 @@ pub struct InspectNetworkResultsContainers {
 
 /// Result type for the [List Networks API](../struct.Docker.html#method.list_networks)
 #[derive(Debug, Clone, Deserialize)]
-#[serde(rename_all = "PascalCase", deny_unknown_fields)]
+#[serde(rename_all = "PascalCase")]
 #[allow(missing_docs)]
 pub struct ListNetworksResults {
     pub name: String,
@@ -238,7 +238,7 @@ pub struct ListNetworksResults {
 /// };
 /// ```
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
-#[serde(rename_all = "PascalCase", deny_unknown_fields)]
+#[serde(rename_all = "PascalCase")]
 pub struct ListNetworksOptions<T>
 where
     T: AsRef<str> + Eq + Hash,
@@ -275,7 +275,7 @@ impl<'a> ListNetworksQueryParams<&'a str, String> for ListNetworksOptions<&'a st
 
 /// Network configuration used in the [Connect Network API](../struct.Docker.html#method.connect_network)
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
-#[serde(rename_all = "PascalCase", deny_unknown_fields)]
+#[serde(rename_all = "PascalCase")]
 pub struct ConnectNetworkOptions<T>
 where
     T: AsRef<str> + Eq + Hash,
@@ -288,7 +288,7 @@ where
 
 /// Configuration for a network endpoint.
 #[derive(Debug, Default, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "PascalCase", deny_unknown_fields)]
+#[serde(rename_all = "PascalCase")]
 pub struct EndpointSettings<T>
 where
     T: AsRef<str> + Eq + Hash,
@@ -331,7 +331,6 @@ where
 }
 
 #[derive(Debug, Default, Clone, Serialize, Deserialize)]
-#[serde(deny_unknown_fields)]
 #[allow(missing_docs)]
 pub struct EndpointIPAMConfig<T>
 where
@@ -347,7 +346,7 @@ where
 
 /// Network configuration used in the [Disconnect Network API](../struct.Docker.html#method.disconnect_network)
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
-#[serde(rename_all = "PascalCase", deny_unknown_fields)]
+#[serde(rename_all = "PascalCase")]
 pub struct DisconnectNetworkOptions<T>
 where
     T: AsRef<str>,
@@ -419,7 +418,7 @@ impl<'a> PruneNetworksQueryParams<&'a str, String> for PruneNetworksOptions<&'a 
 
 /// Result type for the [Prune Networks API](../struct.Docker.html#method.prune_networks)
 #[derive(Debug, Clone, Deserialize)]
-#[serde(rename_all = "PascalCase", deny_unknown_fields)]
+#[serde(rename_all = "PascalCase")]
 #[allow(missing_docs)]
 pub struct PruneNetworksResults {
     pub networks_deleted: Option<Vec<String>>,

--- a/tests/container_test.rs
+++ b/tests/container_test.rs
@@ -556,8 +556,16 @@ fn mount_volume_container_test(docker: Docker) {
 
     let host_config = HostConfig {
         mounts: Some(vec![MountPoint {
-            target: "/tmp".to_string(),
-            source: "/tmp".to_string(),
+            target: if cfg!(windows) {
+                "C:\\Windows\\Temp".to_string()
+            } else {
+                "/tmp".to_string()
+            },
+            source: if cfg!(windows) {
+                "C:\\Windows\\Temp".to_string()
+            } else {
+                "/tmp".to_string()
+            },
             type_: "bind".to_string(),
             consistency: "default".to_string(),
             ..Default::default()
@@ -598,7 +606,11 @@ fn mount_volume_container_test(docker: Docker) {
         })
         .map(|(docker, result)| {
             assert_eq!(
-                "/tmp".to_string(),
+                if cfg!(windows) {
+                    "C:\\Windows\\Temp".to_string()
+                } else {
+                    "/tmp".to_string()
+                },
                 result.host_config.mounts.unwrap().first().unwrap().target
             );
             docker


### PR DESCRIPTION
- Updates the API stubs according to upstream changes. 
- Removes the `deny_unknown_fields` constraint (thanks @edigaryev )
- Adds mount option to creating containers