### PR TITLE
Allow the client to downgrade the version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ jobs:
       - run: docker run -h test.example.com --volumes-from certs -d --privileged --name test-docker-daemon docker:stable-dind --storage-driver=overlay --tlsverify --tlscacert=/certs/ca.pem --tlscert=/certs/cert.pem --tlskey=/certs/key.pem
       - run: docker run --rm --volumes-from certs --privileged --rm --entrypoint=chmod docker:stable-dind 644 /certs/key.pem /certs/ca-key.pem
       - run: docker build -t bollard .
-      - run: docker run -ti -e DOCKER_CERT_PATH=/certs -e DOCKER_HOST='tcp://test.example.com:2375' --volumes-from certs --rm --link test-docker-daemon:docker bollard cargo test --features ssl -- --test test_version_ssl
+      - run: docker run -ti -e DOCKER_CERT_PATH=/certs -e DOCKER_HOST='tcp://test.example.com:2376' --volumes-from certs --rm --link test-docker-daemon:docker bollard cargo test --features ssl -- --test test_version_ssl
   test_tls:
     docker:
       - image: docker:18.09.1
@@ -26,16 +26,16 @@ jobs:
       - run: docker run -h test.example.com --volumes-from certs -d --privileged --name test-docker-daemon docker:stable-dind --storage-driver=overlay --tlsverify --tlscacert=/certs/ca.pem --tlscert=/certs/cert.pem --tlskey=/certs/key.pem
       - run: docker run --rm --volumes-from certs --privileged --rm --entrypoint=chmod docker:stable-dind 644 /certs/key.pem /certs/ca-key.pem
       - run: docker build -t bollard .
-      - run: docker run -ti -e DOCKER_CERT_PATH=/certs -e DOCKER_HOST='tcp://test.example.com:2375' --volumes-from certs --rm --link test-docker-daemon:docker bollard cargo test -- --test test_version_tls
+      - run: docker run -ti -e DOCKER_CERT_PATH=/certs -e DOCKER_HOST='tcp://test.example.com:2376' --volumes-from certs --rm --link test-docker-daemon:docker bollard cargo test -- --test test_version_tls
   test_http:
     docker:
       - image: docker:18.09.1
     steps:
       - checkout
       - setup_remote_docker
-      - run: docker run --rm -h test.example.com -d --privileged --name test-docker-daemon docker:stable-dind --storage-driver=overlay
+      - run: docker run -e DOCKER_TLS_CERTDIR="" --rm -h test.example.com -d --privileged --name test-docker-daemon docker:stable-dind --storage-driver=overlay
       - run: docker build -t bollard .
-      - run: docker run -e -ti -e DOCKER_HOST='tcp://test.example.com:2375' --rm --link test-docker-daemon:docker bollard cargo test --features test_http -- --test test_version_http
+      - run: docker run -ti -e DOCKER_HOST='tcp://test.example.com:2375' --rm --link test-docker-daemon:docker bollard cargo test --features test_http -- --test test_version_http
   test_unix:
     docker:
       - image: docker:18.09.1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,7 +51,7 @@ jobs:
       - checkout
       - setup_remote_docker
       - run: docker build -t bollard .
-      - run: docker run -ti --rm bollard cargo test --doc --all-features
+      - run: docker run -ti --rm bollard cargo test --target x86_64-unknown-linux-gnu --doc
 
 workflows:
   version: 2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,6 @@ authors = ["Graham Lee <ghmlee@ghmlee.com>",
            "Eric Kidd <git@randomhacks.net>",
 	   "Niel Drummond <niel@drummond.lu>"]
 license = "Apache-2.0"
-license-file = "LICENSE"
 homepage = "https://github.com/fussybeaver/bollard"
 repository = "https://github.com/fussybeaver/bollard"
 documentation = "https://docs.rs/bollard"

--- a/src/container.rs
+++ b/src/container.rs
@@ -18,6 +18,8 @@ use std::fmt;
 use std::hash::Hash;
 
 use super::{Docker, DockerChain};
+#[cfg(test)]
+use docker::API_DEFAULT_VERSION;
 use docker::{FALSE_STR, TRUE_STR};
 use either::EitherStream;
 use network::EndpointIPAMConfig;
@@ -3537,7 +3539,9 @@ mod tests {
             "HTTP/1.1 200 OK\r\nServer: mock1\r\nContent-Type: application/json\r\nContent-Length: 89\r\n\r\n{\"Id\":\"696ce476e95d5122486cac5a446280c56aa0b02617690936e25243195992d3cc\",\"Warnings\":null}\r\n\r\n".to_string()
         );
 
-        let docker = Docker::connect_with_host_to_reply(connector, "_".to_string(), 5).unwrap();
+        let docker =
+            Docker::connect_with_host_to_reply(connector, "_".to_string(), 5, API_DEFAULT_VERSION)
+                .unwrap();
 
         let options = Some(CreateContainerOptions {
             name: "unit-test".to_string(),
@@ -3576,7 +3580,9 @@ mod tests {
             "HTTP/1.1 200 OK\r\nServer: mock1\r\nContent-Type: application/json\r\nContent-Length: 0\r\n\r\n".to_string()
         );
 
-        let docker = Docker::connect_with_host_to_reply(connector, "_".to_string(), 5).unwrap();
+        let docker =
+            Docker::connect_with_host_to_reply(connector, "_".to_string(), 5, API_DEFAULT_VERSION)
+                .unwrap();
 
         let results = docker.start_container("hello-world", None::<StartContainerOptions<String>>);
 
@@ -3601,7 +3607,9 @@ mod tests {
             "HTTP/1.1 200 OK\r\nServer: mock1\r\nContent-Type: application/json\r\nContent-Length: 0\r\n\r\n".to_string()
         );
 
-        let docker = Docker::connect_with_host_to_reply(connector, "_".to_string(), 5).unwrap();
+        let docker =
+            Docker::connect_with_host_to_reply(connector, "_".to_string(), 5, API_DEFAULT_VERSION)
+                .unwrap();
 
         let results = docker.stop_container("hello-world", None::<StopContainerOptions>);
 
@@ -3628,7 +3636,9 @@ mod tests {
             "HTTP/1.1 200 OK\r\nServer: mock1\r\nContent-Type: application/json\r\nContent-Length: 0\r\n\r\n".to_string()
         );
 
-        let docker = Docker::connect_with_host_to_reply(connector, "_".to_string(), 5).unwrap();
+        let docker =
+            Docker::connect_with_host_to_reply(connector, "_".to_string(), 5, API_DEFAULT_VERSION)
+                .unwrap();
 
         let options = Some(RemoveContainerOptions {
             force: true,
@@ -3658,7 +3668,9 @@ mod tests {
             "HTTP/1.1 200 OK\r\nServer: mock1\r\nContent-Type: application/json\r\nContent-Length: 33\r\n\r\n{\"Error\":null,\"StatusCode\":0}\r\n\r\n".to_string()
         );
 
-        let docker = Docker::connect_with_host_to_reply(connector, "_".to_string(), 5).unwrap();
+        let docker =
+            Docker::connect_with_host_to_reply(connector, "_".to_string(), 5, API_DEFAULT_VERSION)
+                .unwrap();
 
         let options = Some(WaitContainerOptions {
             condition: String::from("not-running"),
@@ -3689,7 +3701,9 @@ mod tests {
             "HTTP/1.1 200 OK\r\nServer: mock1\r\nContent-Type: application/json\r\nContent-Length: 0\r\n\r\n".to_string()
         );
 
-        let docker = Docker::connect_with_host_to_reply(connector, "_".to_string(), 5).unwrap();
+        let docker =
+            Docker::connect_with_host_to_reply(connector, "_".to_string(), 5, API_DEFAULT_VERSION)
+                .unwrap();
 
         let options = Some(RestartContainerOptions { t: 30 });
 
@@ -3717,7 +3731,9 @@ mod tests {
             "HTTP/1.1 200 OK\r\nServer: mock1\r\nContent-Type: application/json\r\nContent-Length: 2759\r\n\r\n{\"Id\":\"156ffa6b4233d93b91dc3185b9de7225c22350d55a6db250549039a7e53efda7\",\"Created\":\"2018-10-06T15:15:43.525300512Z\",\"Path\":\"/usr/sbin/run_uhttpd\",\"Args\":[],\"State\":{\"Status\":\"running\",\"Running\":true,\"Paused\":false,\"Restarting\":false,\"OOMKilled\":false,\"Dead\":false,\"Pid\":28837,\"ExitCode\":0,\"Error\":\"\",\"StartedAt\":\"2018-10-06T15:15:54.444625149Z\",\"FinishedAt\":\"2018-10-06T15:15:53.958358249Z\",\"Health\":{\"Status\":\"healthy\",\"FailingStreak\":0,\"Log\":[{\"Start\":\"2019-05-03T15:19:37.238626547Z\",\"End\":\"2019-05-03T15:19:37.362289957Z\",\"ExitCode\":0,\"Output\":\"\"}]}},\"Image\":\"sha256:df0db1779d4d71e169756bbcc7757f3d3d8b99032f4022c44509bf9b8f297997\",\"ResolvConfPath\":\"/home/docker/containers/156ffa6b4233d93b91dc3185b9de7225c22350d55a6db250549039a7e53efda7/resolv.conf\",\"HostnamePath\":\"/home/docker/containers/156ffa6b4233d93b91dc3185b9de7225c22350d55a6db250549039a7e53efda7/hostname\",\"HostsPath\":\"/home/docker/containers/156ffa6b4233d93b91dc3185b9de7225c22350d55a6db250549039a7e53efda7/hosts\",\"LogPath\":\"/home/docker/containers/156ffa6b4233d93b91dc3185b9de7225c22350d55a6db250549039a7e53efda7/156ffa6b4233d93b91dc3185b9de7225c22350d55a6db250549039a7e53efda7-json.log\",\"Name\":\"/integration_test_restart_container\",\"RestartCount\":0,\"Driver\":\"overlay2\",\"Platform\":\"linux\",\"MountLabel\":\"\",\"ProcessLabel\":\"\",\"AppArmorProfile\":\"docker-default\",\"ExecIDs\":null,\"HostConfig\":{},\"GraphDriver\":{\"Data\":null,\"Name\":\"overlay2\"},\"Mounts\":[],\"Config\":{\"Hostname\":\"156ffa6b4233\",\"Domainname\":\"\",\"User\":\"\",\"AttachStdin\":false,\"AttachStdout\":false,\"AttachStderr\":false,\"ExposedPorts\":{\"80/tcp\":{}},\"Tty\":false,\"OpenStdin\":false,\"StdinOnce\":false,\"Env\":[],\"Cmd\":null,\"Image\":\"fnichol/uhttpd\",\"Volumes\":{\"/www\":{}},\"WorkingDir\":\"\",\"Entrypoint\":[\"/usr/sbin/run_uhttpd\",\"-f\",\"-p\",\"80\",\"-h\",\"/www\"],\"OnBuild\":null,\"Labels\":{}},\"NetworkSettings\":{\"Bridge\":\"\",\"SandboxID\":\"20cd513ef83bc14934be89953d22aab5a54c7769b07c8e93e90f0227d0aba96b\",\"HairpinMode\":false,\"LinkLocalIPv6Address\":\"\",\"LinkLocalIPv6PrefixLen\":0,\"Ports\":{\"80/tcp\":null},\"SandboxKey\":\"/var/run/docker/netns/20cd513ef83b\",\"SecondaryIPAddresses\":null,\"SecondaryIPv6Addresses\":null,\"EndpointID\":\"992f7e94fd721f627d9d1611c27b477d39b959c209286c38426215ea764f6d63\",\"Gateway\":\"172.17.0.1\",\"GlobalIPv6Address\":\"\",\"GlobalIPv6PrefixLen\":0,\"IPAddress\":\"172.17.0.3\",\"IPPrefixLen\":16,\"IPv6Gateway\":\"\",\"MacAddress\":\"02:42:ac:11:00:03\",\"Networks\":{\"bridge\":{\"IPAMConfig\":null,\"Links\":null,\"Aliases\":null,\"NetworkID\":\"424a1638d72f8984c670bc8bf269102360f24bd356188635ab359cb0b0792b20\",\"EndpointID\":\"992f7e94fd721f627d9d1611c27b477d39b959c209286c38426215ea764f6d63\",\"Gateway\":\"172.17.0.1\",\"IPAddress\":\"172.17.0.3\",\"IPPrefixLen\":16,\"IPv6Gateway\":\"\",\"GlobalIPv6Address\":\"\",\"GlobalIPv6PrefixLen\":0,\"MacAddress\":\"02:42:ac:11:00:03\",\"DriverOpts\":null}}}}\r\n\r\n".to_string()
         );
 
-        let docker = Docker::connect_with_host_to_reply(connector, "_".to_string(), 5).unwrap();
+        let docker =
+            Docker::connect_with_host_to_reply(connector, "_".to_string(), 5, API_DEFAULT_VERSION)
+                .unwrap();
 
         let results = docker.inspect_container("uhttpd", None::<InspectContainerOptions>);
 
@@ -3744,7 +3760,9 @@ mod tests {
             "HTTP/1.1 200 OK\r\nServer: mock1\r\nContent-Type: application/json\r\nContent-Length: 243\r\n\r\n{\"Processes\":[[\"root\",\"3773\",\"0.0\",\"0.0\",\"11056\",\"348\",\"?\",\"Ss\",\"19:42\",\"0:00\",\"/usr/sbin/uhttpd -f -p 80 -h /www /usr/sbin/run_uhttpd -f -p 80 -h /www\"]],\"Titles\":[\"USER\",\"PID\",\"%CPU\",\"%MEM\",\"VSZ\",\"RSS\",\"TTY\",\"STAT\",\"START\",\"TIME\",\"COMMAND\"]}\r\n\r\n".to_string()
         );
 
-        let docker = Docker::connect_with_host_to_reply(connector, "_".to_string(), 5).unwrap();
+        let docker =
+            Docker::connect_with_host_to_reply(connector, "_".to_string(), 5, API_DEFAULT_VERSION)
+                .unwrap();
 
         let results = docker.top_processes(
             "uhttpd",
@@ -3775,7 +3793,9 @@ mod tests {
             "HTTP/1.1 200 OK\r\nServer: mock1\r\nContent-Type: application/json\r\nContent-Length: 28\r\n\r\n\u{1}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{13}Hello from Docker!\n\n".to_string()
         );
 
-        let docker = Docker::connect_with_host_to_reply(connector, "_".to_string(), 5).unwrap();
+        let docker =
+            Docker::connect_with_host_to_reply(connector, "_".to_string(), 5, API_DEFAULT_VERSION)
+                .unwrap();
 
         let stream = docker.logs(
             "hello-world",
@@ -3812,7 +3832,9 @@ mod tests {
             "HTTP/1.1 200 OK\r\nServer: mock1\r\nContent-Type: application/json\r\nContent-Length: 4\r\n\r\nnull\r\n\r\n".to_string()
         );
 
-        let docker = Docker::connect_with_host_to_reply(connector, "_".to_string(), 5).unwrap();
+        let docker =
+            Docker::connect_with_host_to_reply(connector, "_".to_string(), 5, API_DEFAULT_VERSION)
+                .unwrap();
 
         let result = docker.container_changes("hello-world");
 
@@ -3838,7 +3860,9 @@ mod tests {
             "HTTP/1.1 200 OK\r\nServer: mock1\r\nContent-Type: application/json\r\nContent-Length: 1879\r\n\r\n{\"read\":\"2018-10-19T06:11:22.220728356Z\",\"preread\":\"2018-10-19T06:11:21.218466258Z\",\"pids_stats\":{\"current\":1,\"limit\":1000},\"blkio_stats\":{\"io_service_bytes_recursive\":[],\"io_serviced_recursive\":[],\"io_queue_recursive\":[],\"io_service_time_recursive\":[],\"io_wait_time_recursive\":[],\"io_merged_recursive\":[],\"io_time_recursive\":[],\"sectors_recursive\":[]},\"num_procs\":0,\"storage_stats\":{},\"cpu_stats\":{\"cpu_usage\":{\"total_usage\":23097208,\"percpu_usage\":[709093,1595689,5032998,15759428],\"usage_in_kernelmode\":0,\"usage_in_usermode\":10000000},\"system_cpu_usage\":4447677200000000,\"online_cpus\":4,\"throttling_data\":{\"periods\":0,\"throttled_periods\":0,\"throttled_time\":0}},\"precpu_stats\":{\"cpu_usage\":{\"total_usage\":23097208,\"percpu_usage\":[709093,1595689,5032998,15759428],\"usage_in_kernelmode\":0,\"usage_in_usermode\":10000000},\"system_cpu_usage\":4447673150000000,\"online_cpus\":4,\"throttling_data\":{\"periods\":0,\"throttled_periods\":0,\"throttled_time\":0}},\"memory_stats\":{\"usage\":962560,\"max_usage\":5406720,\"stats\":{\"active_anon\":86016,\"active_file\":0,\"cache\":0,\"dirty\":0,\"hierarchical_memory_limit\":9223372036854771712,\"hierarchical_memsw_limit\":0,\"inactive_anon\":0,\"inactive_file\":0,\"mapped_file\":0,\"pgfault\":1485,\"pgmajfault\":0,\"pgpgin\":1089,\"pgpgout\":1084,\"rss\":0,\"rss_huge\":0,\"total_active_anon\":86016,\"total_active_file\":0,\"total_cache\":0,\"total_dirty\":0,\"total_inactive_anon\":0,\"total_inactive_file\":0,\"total_mapped_file\":0,\"total_pgfault\":1485,\"total_pgmajfault\":0,\"total_pgpgin\":1089,\"total_pgpgout\":1084,\"total_rss\":0,\"total_rss_huge\":0,\"total_unevictable\":0,\"total_writeback\":0,\"unevictable\":0,\"writeback\":0},\"limit\":16750219264},\"name\":\"/integration_test_stats\",\"id\":\"66667eab5737dda2da2f578e9496e45c074d1bc5badc0484314f1c3afccfaeb0\",\"networks\":{\"eth0\":{\"rx_bytes\":1635,\"rx_packets\":14,\"rx_errors\":0,\"rx_dropped\":0,\"tx_bytes\":0,\"tx_packets\":0,\"tx_errors\":0,\"tx_dropped\":0}}}\r\n\r\n".to_string()
         );
 
-        let docker = Docker::connect_with_host_to_reply(connector, "_".to_string(), 5).unwrap();
+        let docker =
+            Docker::connect_with_host_to_reply(connector, "_".to_string(), 5, API_DEFAULT_VERSION)
+                .unwrap();
 
         let stream = docker.stats("hello-world", Some(StatsOptions { stream: false }));
 
@@ -3865,7 +3889,9 @@ mod tests {
             "HTTP/1.1 200 OK\r\nServer: mock1\r\nContent-Type: application/json\r\nContent-Length: 0\r\n\r\n".to_string()
         );
 
-        let docker = Docker::connect_with_host_to_reply(connector, "_".to_string(), 5).unwrap();
+        let docker =
+            Docker::connect_with_host_to_reply(connector, "_".to_string(), 5, API_DEFAULT_VERSION)
+                .unwrap();
 
         let options = Some(KillContainerOptions {
             signal: "SIGKILL".to_string(),
@@ -3894,7 +3920,9 @@ mod tests {
             "HTTP/1.1 200 OK\r\nServer: mock1\r\nContent-Type: application/json\r\nContent-Length: 0\r\n\r\n".to_string()
         );
 
-        let docker = Docker::connect_with_host_to_reply(connector, "_".to_string(), 5).unwrap();
+        let docker =
+            Docker::connect_with_host_to_reply(connector, "_".to_string(), 5, API_DEFAULT_VERSION)
+                .unwrap();
 
         let config = UpdateContainerOptions {
             memory: Some(314572800),
@@ -3925,7 +3953,9 @@ mod tests {
             "HTTP/1.1 200 OK\r\nServer: mock1\r\nContent-Type: application/json\r\nContent-Length: 0\r\n\r\n".to_string()
         );
 
-        let docker = Docker::connect_with_host_to_reply(connector, "_".to_string(), 5).unwrap();
+        let docker =
+            Docker::connect_with_host_to_reply(connector, "_".to_string(), 5, API_DEFAULT_VERSION)
+                .unwrap();
 
         let options = RenameContainerOptions {
             name: "my_new_container_name".to_string(),
@@ -3954,7 +3984,9 @@ mod tests {
             "HTTP/1.1 200 OK\r\nServer: mock1\r\nContent-Type: application/json\r\nContent-Length: 0\r\n\r\n".to_string()
         );
 
-        let docker = Docker::connect_with_host_to_reply(connector, "_".to_string(), 5).unwrap();
+        let docker =
+            Docker::connect_with_host_to_reply(connector, "_".to_string(), 5, API_DEFAULT_VERSION)
+                .unwrap();
 
         let results = docker.pause_container("postgres");
 
@@ -3979,7 +4011,9 @@ mod tests {
             "HTTP/1.1 200 OK\r\nServer: mock1\r\nContent-Type: application/json\r\nContent-Length: 0\r\n\r\n".to_string()
         );
 
-        let docker = Docker::connect_with_host_to_reply(connector, "_".to_string(), 5).unwrap();
+        let docker =
+            Docker::connect_with_host_to_reply(connector, "_".to_string(), 5, API_DEFAULT_VERSION)
+                .unwrap();
 
         let results = docker.unpause_container("postgres");
 
@@ -4004,7 +4038,9 @@ mod tests {
             "HTTP/1.1 200 OK\r\nServer: mock1\r\nContent-Type: application/json\r\nContent-Length: 45\r\n\r\n{\"ContainersDeleted\":null,\"SpaceReclaimed\":0}\r\n\r\n".to_string()
         );
 
-        let docker = Docker::connect_with_host_to_reply(connector, "_".to_string(), 5).unwrap();
+        let docker =
+            Docker::connect_with_host_to_reply(connector, "_".to_string(), 5, API_DEFAULT_VERSION)
+                .unwrap();
 
         let results = docker.prune_containers(None::<PruneContainersOptions<String>>);
 

--- a/src/docker.rs
+++ b/src/docker.rs
@@ -1,3 +1,4 @@
+use std::cmp;
 use std::env;
 use std::fmt;
 #[cfg(any(feature = "ssl", feature = "tls"))]
@@ -7,9 +8,12 @@ use std::io::prelude::*;
 #[cfg(any(feature = "ssl", feature = "tls"))]
 use std::path::{Path, PathBuf};
 use std::str::from_utf8;
+use std::sync::atomic::AtomicUsize;
+use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
+use arrayvec::ArrayVec;
 #[cfg(any(feature = "ssl", feature = "tls"))]
 use dirs;
 use failure::Error;
@@ -19,7 +23,7 @@ use http::header::CONTENT_TYPE;
 use http::request::Builder;
 use hyper::client::HttpConnector;
 use hyper::rt::Future;
-use hyper::{self, Body, Chunk, Client, Request, Response, StatusCode};
+use hyper::{self, Body, Chunk, Client, Method, Request, Response, StatusCode};
 #[cfg(feature = "openssl")]
 use hyper_openssl::HttpsConnector;
 #[cfg(feature = "tls")]
@@ -44,6 +48,7 @@ use errors::{
 #[cfg(windows)]
 use named_pipe::NamedPipeConnector;
 use read::{JsonLineDecoder, NewlineLogOutputDecoder, StreamReader};
+use system::Version;
 use uri::Uri;
 
 use serde::de::DeserializeOwned;
@@ -70,8 +75,11 @@ const DEFAULT_NUM_THREADS: usize = 1;
 /// Default timeout for all requests is 2 minutes.
 const DEFAULT_TIMEOUT: u64 = 120;
 
-/// Docker API version
-pub(crate) const API_VERSION: &'static str = "v1.39";
+/// Default Client Version to communicate with the server.
+pub const API_DEFAULT_VERSION: &'static ClientVersion = &ClientVersion {
+    major_version: 1,
+    minor_version: 39,
+};
 
 pub(crate) const TRUE_STR: &'static str = "true";
 pub(crate) const FALSE_STR: &'static str = "false";
@@ -151,6 +159,55 @@ impl fmt::Debug for Transport {
     }
 }
 
+#[derive(Debug, Copy, Clone, PartialEq)]
+/// Advisory version stub to use for communicating with the Server. The docker server will error if
+/// a higher client version is used than is compatible with the server. Beware also, that the
+/// docker server will return stubs for a higher version than the version set when communicating.
+///
+/// See also [negotiate_version](struct.Docker.html#method.negotiate_version), and the `client_version` argument when instantiating the
+/// [Docker](struct.Docker.html) client instance.
+pub struct ClientVersion {
+    /// The major version number.
+    pub major_version: usize,
+    /// The minor version number.
+    pub minor_version: usize,
+}
+
+impl From<String> for ClientVersion {
+    fn from(s: String) -> ClientVersion {
+        let a: Vec<&str> = s.split(".").collect();
+        ClientVersion {
+            major_version: a[0].parse::<usize>().unwrap(),
+            minor_version: a[1].parse::<usize>().unwrap(),
+        }
+    }
+}
+
+impl fmt::Display for ClientVersion {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}.{}", self.major_version, self.minor_version)
+    }
+}
+
+impl PartialOrd for ClientVersion {
+    fn partial_cmp(&self, other: &Self) -> Option<cmp::Ordering> {
+        match self.major_version.partial_cmp(&other.major_version) {
+            Some(cmp::Ordering::Equal) => self.minor_version.partial_cmp(&other.minor_version),
+            res => res,
+        }
+    }
+}
+
+impl From<&(AtomicUsize, AtomicUsize)> for ClientVersion {
+    fn from(tpl: &(AtomicUsize, AtomicUsize)) -> ClientVersion {
+        ClientVersion {
+            major_version: tpl.0.load(Ordering::Relaxed),
+            minor_version: tpl.1.load(Ordering::Relaxed),
+        }
+    }
+}
+
+#[derive(Debug)]
 /// ---
 ///
 /// # Docker
@@ -163,12 +220,12 @@ impl fmt::Debug for Transport {
 ///  - [`Docker::connect_with_unix_defaults`](struct.Docker.html#method.connect_with_unix_defaults)
 ///  - [`Docker::connect_with_tls_defaults`](struct.Docker.html#method.connect_with_tls_defaults)
 ///  - [`Docker::connect_with_local_defaults`](struct.Docker.html#method.connect_with_local_defaults)
-#[derive(Debug)]
 pub struct Docker {
     pub(crate) transport: Arc<Transport>,
     pub(crate) client_type: ClientType,
     pub(crate) client_addr: String,
     pub(crate) client_timeout: u64,
+    pub(crate) version: Arc<(AtomicUsize, AtomicUsize)>,
 }
 
 impl Clone for Docker {
@@ -178,6 +235,7 @@ impl Clone for Docker {
             client_type: self.client_type.clone(),
             client_addr: self.client_addr.clone(),
             client_timeout: self.client_timeout,
+            version: self.version.clone(),
         }
     }
 }
@@ -222,6 +280,7 @@ impl Docker {
                 &cert_path.join("ca.pem"),
                 DEFAULT_NUM_THREADS,
                 DEFAULT_TIMEOUT,
+                API_DEFAULT_VERSION,
             )
         } else {
             Docker::connect_with_ssl(
@@ -231,6 +290,7 @@ impl Docker {
                 &cert_path.join("ca.pem"),
                 DEFAULT_NUM_THREADS,
                 DEFAULT_TIMEOUT,
+                API_DEFAULT_VERSION,
             )
         }
     }
@@ -245,6 +305,7 @@ impl Docker {
     ///  - `ssl_ca`: the certificate chain path.
     ///  - `num_threads`: the number of threads for the HTTP connection pool.
     ///  - `timeout`: the read/write timeout (seconds) to use for every hyper connection
+    ///  - `client_version`: the client version to communicate with the server.
     ///
     /// # Examples
     ///
@@ -276,6 +337,7 @@ impl Docker {
         ssl_ca: &Path,
         num_threads: usize,
         timeout: u64,
+        client_version: &ClientVersion,
     ) -> Result<Docker, Error> {
         // This ensures that using docker-machine-esque addresses work with Hyper.
         let client_addr = addr.replacen("tcp://", "", 1);
@@ -300,6 +362,10 @@ impl Docker {
             client_type: ClientType::SSL,
             client_addr: client_addr.to_owned(),
             client_timeout: timeout,
+            version: Arc::new((
+                AtomicUsize::new(client_version.major_version),
+                AtomicUsize::new(client_version.minor_version),
+            )),
         };
 
         Ok(docker)
@@ -334,7 +400,12 @@ impl Docker {
     /// ```
     pub fn connect_with_http_defaults() -> Result<Docker, Error> {
         let host = env::var("DOCKER_HOST").unwrap_or(DEFAULT_DOCKER_HOST.to_string());
-        Docker::connect_with_http(&host, DEFAULT_NUM_THREADS, DEFAULT_TIMEOUT)
+        Docker::connect_with_http(
+            &host,
+            DEFAULT_NUM_THREADS,
+            DEFAULT_TIMEOUT,
+            API_DEFAULT_VERSION,
+        )
     }
 
     /// Connect using unsecured HTTP.  
@@ -344,6 +415,7 @@ impl Docker {
     ///  - `addr`: connection url including scheme and port.
     ///  - `num_threads`: the number of threads for the HTTP connection pool.
     ///  - `timeout`: the read/write timeout (seconds) to use for every hyper connection
+    ///  - `client_version`: the client version to communicate with the server.
     ///
     /// # Examples
     ///
@@ -366,6 +438,7 @@ impl Docker {
         addr: &str,
         num_threads: usize,
         timeout: u64,
+        client_version: &ClientVersion,
     ) -> Result<Docker, Error> {
         // This ensures that using docker-machine-esque addresses work with Hyper.
         let client_addr = addr.replacen("tcp://", "", 1);
@@ -380,6 +453,10 @@ impl Docker {
             client_type: ClientType::Http,
             client_addr: client_addr.to_owned(),
             client_timeout: timeout,
+            version: Arc::new((
+                AtomicUsize::new(client_version.major_version),
+                AtomicUsize::new(client_version.minor_version),
+            )),
         };
 
         Ok(docker)
@@ -411,7 +488,7 @@ impl Docker {
     /// # }
     /// ```
     pub fn connect_with_unix_defaults() -> Result<Docker, Error> {
-        Docker::connect_with_unix(DEFAULT_SOCKET, DEFAULT_TIMEOUT)
+        Docker::connect_with_unix(DEFAULT_SOCKET, DEFAULT_TIMEOUT, API_DEFAULT_VERSION)
     }
 
     /// Connect using a Unix socket.
@@ -420,6 +497,7 @@ impl Docker {
     ///
     ///  - `addr`: connection socket path.
     ///  - `timeout`: the read/write timeout (seconds) to use for every hyper connection
+    ///  - `client_version`: the client version to communicate with the server.
     ///
     /// # Examples
     ///
@@ -435,7 +513,11 @@ impl Docker {
     /// connection.ping().and_then(|_| Ok(println!("Connected!")));
     /// # }
     /// ```
-    pub fn connect_with_unix(addr: &str, timeout: u64) -> Result<Docker, Error> {
+    pub fn connect_with_unix(
+        addr: &str,
+        timeout: u64,
+        client_version: &ClientVersion,
+    ) -> Result<Docker, Error> {
         let client_addr = addr.replacen("unix://", "", 1);
 
         let unix_connector = UnixConnector::new();
@@ -450,6 +532,10 @@ impl Docker {
             client_type: ClientType::Unix,
             client_addr: client_addr.to_owned(),
             client_timeout: timeout,
+            version: Arc::new((
+                AtomicUsize::new(client_version.major_version),
+                AtomicUsize::new(client_version.minor_version),
+            )),
         };
 
         Ok(docker)
@@ -484,7 +570,7 @@ impl Docker {
     /// # }
     /// ```
     pub fn connect_with_named_pipe_defaults() -> Result<Docker, Error> {
-        Docker::connect_with_named_pipe(DEFAULT_NAMED_PIPE, DEFAULT_TIMEOUT)
+        Docker::connect_with_named_pipe(DEFAULT_NAMED_PIPE, DEFAULT_TIMEOUT, API_DEFAULT_VERSION)
     }
 
     /// Connect using a Windows Named Pipe.
@@ -493,6 +579,7 @@ impl Docker {
     ///
     ///  - `addr`: socket location.
     ///  - `timeout`: the read/write timeout (seconds) to use for every hyper connection
+    ///  - `client_version`: the client version to communicate with the server.
     ///
     /// # Examples
     ///
@@ -511,7 +598,11 @@ impl Docker {
     ///
     /// # }
     /// ```
-    pub fn connect_with_named_pipe(addr: &str, timeout: u64) -> Result<Docker, Error> {
+    pub fn connect_with_named_pipe(
+        addr: &str,
+        timeout: u64,
+        client_version: &ClientVersion,
+    ) -> Result<Docker, Error> {
         let client_addr = addr.replacen("npipe://", "", 1);
 
         let named_pipe_connector = NamedPipeConnector::new();
@@ -526,6 +617,10 @@ impl Docker {
             client_type: ClientType::NamedPipe,
             client_addr: client_addr.to_owned(),
             client_timeout: timeout,
+            version: Arc::new((
+                AtomicUsize::new(API_DEFAULT_VERSION.major_version),
+                AtomicUsize::new(API_DEFAULT_VERSION.minor_version),
+            )),
         };
 
         Ok(docker)
@@ -558,11 +653,15 @@ impl Docker {
     ///
     /// [`Docker::connect_with_unix`]: struct.Docker.html#method.connect_with_unix
     /// [`Docker::connect_with_named_pipe`]: struct.Docker.html#method.connect_with_named_pipe
-    pub fn connect_with_local(addr: &str, timeout: u64) -> Result<Docker, Error> {
+    pub fn connect_with_local(
+        addr: &str,
+        timeout: u64,
+        client_version: &ClientVersion,
+    ) -> Result<Docker, Error> {
         #[cfg(unix)]
-        return Docker::connect_with_unix(addr, timeout);
+        return Docker::connect_with_unix(addr, timeout, client_version);
         #[cfg(windows)]
-        return Docker::connect_with_named_pipe(addr, timeout);
+        return Docker::connect_with_named_pipe(addr, timeout, client_version);
     }
 }
 
@@ -616,6 +715,7 @@ impl Docker {
                 "",
                 DEFAULT_NUM_THREADS,
                 DEFAULT_TIMEOUT,
+                API_DEFAULT_VERSION,
             )
         } else {
             Docker::connect_with_tls(
@@ -625,6 +725,7 @@ impl Docker {
                 "",
                 DEFAULT_NUM_THREADS,
                 DEFAULT_TIMEOUT,
+                API_DEFAULT_VERSION,
             )
         }
     }
@@ -639,6 +740,7 @@ impl Docker {
     ///  - `pkcs12_password`: the password to the PKCS #12 archive.
     ///  - `num_threads`: the number of threads for the HTTP connection pool.
     ///  - `timeout`: the read/write timeout (seconds) to use for every hyper connection
+    ///  - `client_version`: the client version to communicate with the server.
     ///
     ///  # PKCS12
     ///
@@ -680,6 +782,7 @@ impl Docker {
         pkcs12_password: &str,
         num_thread: usize,
         timeout: u64,
+        client_version: &ClientVersion,
     ) -> Result<Docker, Error> {
         let client_addr = addr.replacen("tcp://", "", 1);
 
@@ -712,6 +815,10 @@ impl Docker {
             client_type: ClientType::SSL,
             client_addr: client_addr.to_owned(),
             client_timeout: timeout,
+            version: Arc::new((
+                AtomicUsize::new(client_version.major_version),
+                AtomicUsize::new(client_version.minor_version),
+            )),
         };
 
         Ok(docker)
@@ -729,6 +836,7 @@ impl Docker {
     ///  - `connector`: the HostToReplyConnector.
     ///  - `client_addr`: location to connect to.
     ///  - `timeout`: the read/write timeout (seconds) to use for every hyper connection
+    ///  - `client_version`: the client version to communicate with the server.
     ///
     /// # Examples
     ///
@@ -755,6 +863,7 @@ impl Docker {
         connector: HostToReplyConnector,
         client_addr: String,
         timeout: u64,
+        client_version: &ClientVersion,
     ) -> Result<Docker, Error> {
         let client_builder = Client::builder();
         let client = client_builder.build(connector);
@@ -770,12 +879,17 @@ impl Docker {
             client_type: client_type,
             client_addr,
             client_timeout: timeout,
+            version: Arc::new((
+                AtomicUsize::new(client_version.major_version),
+                AtomicUsize::new(client_version.minor_version),
+            )),
         };
 
         Ok(docker)
     }
 }
 
+#[derive(Debug)]
 /// ---
 /// # DockerChain
 ///
@@ -790,7 +904,6 @@ impl Docker {
 /// let docker = Docker::connect_with_http_defaults().unwrap();
 /// docker.chain();
 /// ```
-#[derive(Debug)]
 pub struct DockerChain {
     pub(super) inner: Docker,
 }
@@ -906,6 +1019,44 @@ impl Docker {
         })
     }
 
+    /// Return the currently set client version.
+    pub fn client_version(&self) -> ClientVersion {
+        self.version.as_ref().into()
+    }
+
+    /// Check with the server for a supported version, and downgrade the client version if
+    /// appropriate.
+    ///
+    /// # Examples:
+    ///
+    /// ```rust,norun
+    /// let docker = Docker::connect_with_unix_defaults().unwrap();
+    /// let future = docker.negotiate_version().map(|docker| {
+    ///     docker.version()
+    /// });
+    /// ```
+    pub fn negotiate_version(self) -> impl Future<Item = Self, Error = Error> {
+        let req = self.build_request::<_, String, String>(
+            "/version",
+            Builder::new().method(Method::GET),
+            Ok(None::<ArrayVec<[(_, _); 0]>>),
+            Ok(Body::empty()),
+        );
+
+        self.process_into_value::<Version>(req).map(move |res| {
+            let server_version: ClientVersion = res.api_version.into();
+            if server_version < self.client_version() {
+                self.version
+                    .0
+                    .store(server_version.major_version, Ordering::Relaxed);
+                self.version
+                    .1
+                    .store(server_version.minor_version, Ordering::Relaxed);
+            }
+            self
+        })
+    }
+
     fn process_request(
         &self,
         req: Result<Request<Body>, Error>,
@@ -981,7 +1132,13 @@ impl Docker {
         query
             .and_then(|q| payload.map(|body| (q, body)))
             .and_then(|(q, body)| {
-                let uri = Uri::parse(&self.client_addr, &self.client_type, path, q)?;
+                let uri = Uri::parse(
+                    &self.client_addr,
+                    &self.client_type,
+                    path,
+                    q,
+                    &self.client_version(),
+                )?;
                 let request_uri: hyper::Uri = uri.into();
                 Ok(builder
                     .uri(request_uri)

--- a/src/docker.rs
+++ b/src/docker.rs
@@ -423,12 +423,12 @@ impl Docker {
     /// # extern crate bollard;
     /// # extern crate futures;
     /// # fn main () {
-    /// use bollard::Docker;
+    /// use bollard::{API_DEFAULT_VERSION, Docker};
     ///
     /// use futures::future::Future;
     ///
     /// let connection = Docker::connect_with_http(
-    ///                    "http://my-custom-docker-server:2735", 4, 20)
+    ///                    "http://my-custom-docker-server:2735", 4, 20, API_DEFAULT_VERSION)
     ///                    .unwrap();
     /// connection.ping()
     ///   .and_then(|_| Ok(println!("Connected!")));
@@ -505,11 +505,11 @@ impl Docker {
     /// # extern crate bollard;
     /// # extern crate futures;
     /// # fn main () {
-    /// use bollard::Docker;
+    /// use bollard::{API_DEFAULT_VERSION, Docker};
     ///
     /// use futures::future::Future;
     ///
-    /// let connection = Docker::connect_with_unix("/var/run/docker.sock", 120).unwrap();
+    /// let connection = Docker::connect_with_unix("/var/run/docker.sock", 120, API_DEFAULT_VERSION).unwrap();
     /// connection.ping().and_then(|_| Ok(println!("Connected!")));
     /// # }
     /// ```
@@ -587,13 +587,13 @@ impl Docker {
     /// # extern crate bollard;
     /// # extern crate futures;
     /// # fn main () {
-    /// use bollard::Docker;
+    /// use bollard::{API_DEFAULT_VERSION, Docker};
     ///
     /// use futures::future::Future;
     ///
     ///
     /// let connection = Docker::connect_with_named_pipe(
-    ///     "//./pipe/docker_engine", 120).unwrap();
+    ///     "//./pipe/docker_engine", 120, API_DEFAULT_VERSION).unwrap();
     /// connection.ping().and_then(|_| Ok(println!("Connected!")));
     ///
     /// # }
@@ -1030,10 +1030,18 @@ impl Docker {
     /// # Examples:
     ///
     /// ```rust,norun
-    /// let docker = Docker::connect_with_unix_defaults().unwrap();
-    /// let future = docker.negotiate_version().map(|docker| {
-    ///     docker.version()
-    /// });
+    /// # extern crate bollard;
+    /// # extern crate futures;
+    /// # fn main () {
+    ///     use bollard::Docker;
+    ///
+    ///     use futures::future::Future;
+    ///
+    ///     let docker = Docker::connect_with_http_defaults().unwrap();
+    ///     docker.negotiate_version().map(|docker| {
+    ///         docker.version()
+    ///     });
+    /// # }
     /// ```
     pub fn negotiate_version(self) -> impl Future<Item = Self, Error = Error> {
         let req = self.build_request::<_, String, String>(

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -81,3 +81,11 @@ impl Display for JsonDataError {
         )
     }
 }
+
+/// Error emitted when the server version cannot be parsed when negotiating a version
+#[derive(Fail, Debug)]
+#[fail(display = "Failed to parse API version: {}", api_version)]
+#[allow(missing_docs)]
+pub struct APIVersionParseError {
+    pub api_version: String,
+}

--- a/src/exec.rs
+++ b/src/exec.rs
@@ -11,6 +11,8 @@ use hyper::Method;
 use serde::ser::Serialize;
 
 use super::{Docker, DockerChain};
+#[cfg(test)]
+use docker::API_DEFAULT_VERSION;
 use either::EitherStream;
 
 use container::LogOutput;
@@ -408,7 +410,9 @@ mod tests {
             "HTTP/1.1 101 UPGRADED\r\nServer: mock1\r\nContent-Type: application/vnd.docker.raw-stream\r\nConnection: Upgrade\r\nUpgrade: tcp\r\n\r\n# Server configuration\nconfig uhttpd main".to_string()
         );
 
-        let docker = Docker::connect_with_host_to_reply(connector, "_".to_string(), 5).unwrap();
+        let docker =
+            Docker::connect_with_host_to_reply(connector, "_".to_string(), 5, API_DEFAULT_VERSION)
+                .unwrap();
 
         let options = Some(StartExecOptions { detach: false });
 
@@ -443,7 +447,9 @@ mod tests {
             "HTTP/1.1 200 OK\r\nServer: mock1\r\nContent-Type: application/json\r\nContent-Length: 393\r\n\r\n{\"ID\":\"6b8cf3d95b64cf32d140836f4a3b8f03c1b895398f6fdbd33b69db06fa04d897\",\"Running\":true,\"ExitCode\":null,\"ProcessConfig\":{\"tty\":false,\"entrypoint\":\"/bin/cat\",\"arguments\":[\"/etc/config/uhttpd\"],\"privileged\":false},\"OpenStdin\":false,\"OpenStderr\":false,\"OpenStdout\":true,\"CanRemove\":false,\"ContainerID\":\"a181d0e0bf4bbf0e37d8eb1d68677e0abef838f1aa4d8757c43c1216cfdaa965\",\"DetachKeys\":\"\",\"Pid\":7169}\r\n".to_string()
         );
 
-        let docker = Docker::connect_with_host_to_reply(connector, "_".to_string(), 5).unwrap();
+        let docker =
+            Docker::connect_with_host_to_reply(connector, "_".to_string(), 5, API_DEFAULT_VERSION)
+                .unwrap();
 
         let results = docker.inspect_exec("68099c450e6a");
 

--- a/src/image.rs
+++ b/src/image.rs
@@ -17,6 +17,8 @@ use serde_json;
 use super::{Docker, DockerChain};
 use auth::DockerCredentials;
 use container::{Config, GraphDriver};
+#[cfg(test)]
+use docker::API_DEFAULT_VERSION;
 use docker::{FALSE_STR, TRUE_STR};
 use either::EitherStream;
 
@@ -2105,7 +2107,9 @@ mod tests {
             "HTTP/1.1 200 OK\r\nServer: mock1\r\nContent-Type: application/json\r\nContent-Length: 310\r\n\r\n[{\"Containers\":-1,\"Created\":1484347856,\"Id\":\"sha256:48b5124b2768d2b917edcb640435044a97967015485e812545546cbed5cf0233\",\"Labels\":{},\"ParentId\":\"\",\"RepoDigests\":[\"hello-world@sha256:c5515758d4c5e1e838e9cd307f6c6a0d620b5e07e6f927b07d05f6d12a1ac8d7\"],\"RepoTags\":null,\"SharedSize\":-1,\"Size\":1840,\"VirtualSize\":1840}]\r\n\r\n".to_string()
      );
 
-        let docker = Docker::connect_with_host_to_reply(connector, "_".to_string(), 5).unwrap();
+        let docker =
+            Docker::connect_with_host_to_reply(connector, "_".to_string(), 5, API_DEFAULT_VERSION)
+                .unwrap();
 
         let mut filters = HashMap::new();
         filters.insert("dangling", vec!["true"]);
@@ -2140,7 +2144,9 @@ mod tests {
             "HTTP/1.1 200 OK\r\nServer: mock1\r\nContent-Type: application/json\r\nContent-Length: 542\r\n\r\n{\"status\":\"Pulling from library/hello-world\",\"id\":\"latest\"}\r\n{\"status\":\"Digest: sha256:0add3ace90ecb4adbf7777e9aacf18357296e799f81cabc9fde470971e499788\"}\r\n{\"status\":\"Pulling from library/hello-world\",\"id\":\"linux\"}\r\n{\"status\":\"Digest: sha256:d5c7d767f5ba807f9b363aa4db87d75ab030404a670880e16aedff16f605484b\"}\r\n{\"status\":\"Pulling from library/hello-world\",\"id\":\"nanoserver-1709\"}\r\n{\"errorDetail\":{\"message\":\"no matching manifest for unknown in the manifest list entries\"},\"error\":\"no matching manifest for unknown in the manifest list entries\"}\r\n\r\n".to_string()
         );
 
-        let docker = Docker::connect_with_host_to_reply(connector, "_".to_string(), 5).unwrap();
+        let docker =
+            Docker::connect_with_host_to_reply(connector, "_".to_string(), 5, API_DEFAULT_VERSION)
+                .unwrap();
 
         let options = Some(CreateImageOptions {
             from_image: String::from("hello-world"),
@@ -2172,7 +2178,9 @@ mod tests {
             "HTTP/1.1 200 OK\r\nServer: mock1\r\nContent-Type: application/json\r\nContent-Length: 1744\r\n\r\n{\"Id\":\"sha256:4ab4c602aa5eed5528a6620ff18a1dc4faef0e1ab3a5eddeddb410714478c67f\",\"RepoTags\":[\"hello-world:latest\",\"hello-world:linux\"],\"RepoDigests\":[\"hello-world@sha256:0add3ace90ecb4adbf7777e9aacf18357296e799f81cabc9fde470971e499788\",\"hello-world@sha256:d5c7d767f5ba807f9b363aa4db87d75ab030404a670880e16aedff16f605484b\"],\"Parent\":\"\",\"Comment\":\"\",\"Created\":\"2018-09-07T19:25:39.809797627Z\",\"Container\":\"15c5544a385127276a51553acb81ed24a9429f9f61d6844db1fa34f46348e420\",\"ContainerConfig\":{\"Hostname\":\"15c5544a3851\",\"Domainname\":\"\",\"User\":\"\",\"AttachStdin\":false,\"AttachStdout\":false,\"AttachStderr\":false,\"Tty\":false,\"OpenStdin\":false,\"StdinOnce\":false,\"Env\":[\"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin\"],\"Cmd\":[\"/bin/sh\",\"-c\",\"#(nop) \",\"CMD [\\\"/hello\\\"]\"],\"ArgsEscaped\":true,\"Image\":\"sha256:9a5813f1116c2426ead0a44bbec252bfc5c3d445402cc1442ce9194fc1397027\",\"Volumes\":null,\"WorkingDir\":\"\",\"Entrypoint\":null,\"OnBuild\":null,\"Labels\":{}},\"DockerVersion\":\"17.06.2-ce\",\"Author\":\"\",\"Config\":{\"Hostname\":\"\",\"Domainname\":\"\",\"User\":\"\",\"AttachStdin\":false,\"AttachStdout\":false,\"AttachStderr\":false,\"Tty\":false,\"OpenStdin\":false,\"StdinOnce\":false,\"Env\":[\"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin\"],\"Cmd\":[\"/hello\"],\"ArgsEscaped\":true,\"Image\":\"sha256:9a5813f1116c2426ead0a44bbec252bfc5c3d445402cc1442ce9194fc1397027\",\"Volumes\":null,\"WorkingDir\":\"\",\"Entrypoint\":null,\"OnBuild\":null,\"Labels\":null},\"Architecture\":\"amd64\",\"Os\":\"linux\",\"Size\":1840,\"VirtualSize\":1840,\"GraphDriver\":{\"Data\":{\"MergedDir\":\"\",\"UpperDir\":\"\",\"WorkDir\":\"\"},\"Name\":\"overlay2\"},\"RootFS\":{\"Type\":\"layers\",\"Layers\":[\"sha256:428c97da766c4c13b19088a471de6b622b038f3ae8efa10ec5a37d6d31a2df0b\"]},\"Metadata\":{\"LastTagTime\":\"0001-01-01T00:00:00Z\"}}\r\n\r\n".to_string()
         );
 
-        let docker = Docker::connect_with_host_to_reply(connector, "_".to_string(), 5).unwrap();
+        let docker =
+            Docker::connect_with_host_to_reply(connector, "_".to_string(), 5, API_DEFAULT_VERSION)
+                .unwrap();
 
         let image = docker.inspect_image("hello-world");
 
@@ -2197,7 +2205,9 @@ mod tests {
             "HTTP/1.1 200 OK\r\nServer: mock1\r\nContent-Type: application/json\r\nContent-Length: 42\r\n\r\n{\"ImagesDeleted\":null,\"SpaceReclaimed\":40}\r\n\r\n".to_string()
         );
 
-        let docker = Docker::connect_with_host_to_reply(connector, "_".to_string(), 5).unwrap();
+        let docker =
+            Docker::connect_with_host_to_reply(connector, "_".to_string(), 5, API_DEFAULT_VERSION)
+                .unwrap();
 
         let prune_images_results = docker.prune_images(None::<PruneImagesOptions<String>>);
 
@@ -2222,7 +2232,9 @@ mod tests {
             "HTTP/1.1 200 OK\r\nServer: mock1\r\nContent-Type: application/json\r\nContent-Length: 415\r\n\r\n[{\"Comment\":\"\",\"Created\":1536348339,\"CreatedBy\":\"/bin/sh -c #(nop)  CMD [\\\"/hello\\\"]\",\"Id\":\"sha256:4ab4c602aa5eed5528a6620ff18a1dc4faef0e1ab3a5eddeddb410714478c67f\",\"Size\":0,\"Tags\":[\"hello-world:latest\",\"hello-world:linux\"]},{\"Comment\":\"\",\"Created\":1536348339,\"CreatedBy\":\"/bin/sh -c #(nop) COPY file:9824c33ef192ac944822908370af9f04ab049bfa5c10724e4f727206f5167094 in / \",\"Id\":\"<missing>\",\"Size\":1840,\"Tags\":null}]\r\n\r\n".to_string()
       );
 
-        let docker = Docker::connect_with_host_to_reply(connector, "_".to_string(), 5).unwrap();
+        let docker =
+            Docker::connect_with_host_to_reply(connector, "_".to_string(), 5, API_DEFAULT_VERSION)
+                .unwrap();
 
         let image_history_results = docker.image_history("hello-world");
 
@@ -2253,7 +2265,9 @@ mod tests {
             "HTTP/1.1 200 OK\r\nServer: mock1\r\nContent-Type: application/json\r\nContent-Length: 148\r\n\r\n[{\"star_count\":660,\"is_official\":true,\"name\":\"hello-world\",\"is_automated\":false,\"description\":\"Hello World! (an example of minimal Dockerization)\"}]\r\n\r\n".to_string()
         );
 
-        let docker = Docker::connect_with_host_to_reply(connector, "_".to_string(), 5).unwrap();
+        let docker =
+            Docker::connect_with_host_to_reply(connector, "_".to_string(), 5, API_DEFAULT_VERSION)
+                .unwrap();
 
         let search_options = SearchImagesOptions {
             term: "hello-world".to_string(),
@@ -2287,7 +2301,9 @@ mod tests {
             "HTTP/1.1 200 OK\r\nServer: mock1\r\nContent-Type: application/json\r\nContent-Length: 35\r\n\r\n[{\"Untagged\":\"hello-world:latest\"}]\r\n\r\n".to_string()
         );
 
-        let docker = Docker::connect_with_host_to_reply(connector, "_".to_string(), 5).unwrap();
+        let docker =
+            Docker::connect_with_host_to_reply(connector, "_".to_string(), 5, API_DEFAULT_VERSION)
+                .unwrap();
 
         let remove_options = RemoveImageOptions {
             noprune: true,
@@ -2324,7 +2340,9 @@ mod tests {
             "HTTP/1.1 200 OK\r\nServer: mock1\r\nContent-Type: application/json\r\nContent-Length: 0\r\n\r\n".to_string()
         );
 
-        let docker = Docker::connect_with_host_to_reply(connector, "_".to_string(), 5).unwrap();
+        let docker =
+            Docker::connect_with_host_to_reply(connector, "_".to_string(), 5, API_DEFAULT_VERSION)
+                .unwrap();
 
         let push_options = PushImageOptions {
             tag: "v1.0.1".to_string(),
@@ -2359,7 +2377,9 @@ mod tests {
             "HTTP/1.1 200 OK\r\nServer: mock1\r\nContent-Type: application/json\r\nContent-Length: 0\r\n\r\n".to_string()
         );
 
-        let docker = Docker::connect_with_host_to_reply(connector, "_".to_string(), 5).unwrap();
+        let docker =
+            Docker::connect_with_host_to_reply(connector, "_".to_string(), 5, API_DEFAULT_VERSION)
+                .unwrap();
 
         let tag_options = TagImageOptions {
             tag: "v1.0.1".to_string(),
@@ -2389,7 +2409,9 @@ mod tests {
             "HTTP/1.1 200 OK\r\nServer: mock1\r\nContent-Type: application/json\r\nContent-Length: 80\r\n\r\n{\"Id\":\"sha256:c69d56ed58eb9b519bb3de569de7e83f5c3eff57858eaa7883a9e206cf7ca5eb\"}\r\n\r\n".to_string()
         );
 
-        let docker = Docker::connect_with_host_to_reply(connector, "_".to_string(), 5).unwrap();
+        let docker =
+            Docker::connect_with_host_to_reply(connector, "_".to_string(), 5, API_DEFAULT_VERSION)
+                .unwrap();
 
         let commit_container_options = CommitContainerOptions {
             container: "my-running-container",
@@ -2425,7 +2447,9 @@ mod tests {
             "HTTP/1.1 200 OK\r\nServer: mock1\r\nContent-Type: application/x-tar\r\nContent-Length: 520\r\n\r\n{\"stream\":\"Step 1/2 : FROM alpine\"}\r\n{\"stream\":\"\\n\"}\r\n{\"stream\":\" ---\\u003e 3f53bb00af94\\n\"}\r\n{\"stream\":\"Step 2/2 : RUN touch bollard.txt\"}\r\n{\"stream\":\"\\n\"}\r\n{\"stream\":\" ---\\u003e Running in 853fceb48e80\\n\"}\r\n{\"stream\":\"Removing intermediate container 853fceb48e80\\n\"}\r\n{\"stream\":\" ---\\u003e 5949ad5433c9\\n\"}\r\n{\"aux\":{\"ID\":\"sha256:5949ad5433c96bb38c6a60acc84653600ccb06f1bdd7216acdba752bc2da7460\"}}\r\n{\"stream\":\"Successfully built 5949ad5433c9\\n\"}\r\n{\"stream\":\"Successfully tagged integration_test_build_image:latest\\n\"}\r\n".to_string()
         );
 
-        let docker = Docker::connect_with_host_to_reply(connector, "_".to_string(), 5).unwrap();
+        let docker =
+            Docker::connect_with_host_to_reply(connector, "_".to_string(), 5, API_DEFAULT_VERSION)
+                .unwrap();
 
         let build_image_options = BuildImageOptions {
             t: "my-image",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -427,4 +427,4 @@ mod uri;
 extern crate yup_hyper_mock as hyper_mock;
 
 // publicly re-export
-pub use docker::{Docker, DockerChain};
+pub use docker::{ClientVersion, Docker, DockerChain, API_DEFAULT_VERSION};

--- a/src/network.rs
+++ b/src/network.rs
@@ -13,6 +13,8 @@ use std::collections::HashMap;
 use std::hash::Hash;
 
 use super::{Docker, DockerChain};
+#[cfg(test)]
+use docker::API_DEFAULT_VERSION;
 use docker::{FALSE_STR, TRUE_STR};
 
 /// Network configuration used in the [Create Network API](../struct.Docker.html#method.create_network)
@@ -1103,7 +1105,9 @@ mod tests {
             "HTTP/1.1 200 OK\r\nServer: mock1\r\nContent-Type: application/json\r\nContent-Length: 86\r\n\r\n{\"Id\":\"d1022f34e396473dd2a1e39abe0816b6e3465cdb44b78d094606f122933d8da3\",\"Warning\":\"\"}\r\n".to_string()
         );
 
-        let docker = Docker::connect_with_host_to_reply(connector, "_".to_string(), 5).unwrap();
+        let docker =
+            Docker::connect_with_host_to_reply(connector, "_".to_string(), 5, API_DEFAULT_VERSION)
+                .unwrap();
 
         let ipam_config = IPAMConfig {
             subnet: Some("10.10.10.10/24"),
@@ -1149,7 +1153,9 @@ mod tests {
             "HTTP/1.1 200 OK\r\nServer: mock1\r\nContent-Type: application/json\r\nContent-Length: 428\r\n\r\n{\"Name\":\"integration_test_create_network\",\"Id\":\"c1c29f1f4265b413cad016eddb2ce25b9c55a59d7e1241f8a6c9bfa55b865a43\",\"Created\":\"2019-02-23T09:23:10.60267Z\",\"Scope\":\"local\",\"Driver\":\"bridge\",\"EnableIPv6\":false,\"IPAM\":{\"Driver\":\"default\",\"Options\":null,\"Config\":[{\"Subnet\":\"10.10.10.10/24\"}]},\"Internal\":false,\"Attachable\":false,\"Ingress\":false,\"ConfigFrom\":{\"Network\":\"\"},\"ConfigOnly\":false,\"Containers\":{},\"Options\":{},\"Labels\":{}}\r\n".to_string()
         );
 
-        let docker = Docker::connect_with_host_to_reply(connector, "_".to_string(), 5).unwrap();
+        let docker =
+            Docker::connect_with_host_to_reply(connector, "_".to_string(), 5, API_DEFAULT_VERSION)
+                .unwrap();
 
         let results = docker.inspect_network(
             "c1c29f1f4265b413cad016eddb2ce25b9c55a59d7e1241f8a6c9bfa55b865a43",
@@ -1188,7 +1194,9 @@ mod tests {
             "HTTP/1.1 200 OK\r\nServer: mock1\r\nContent-Type: application/json\r\nContent-Length: 0\r\n\r\n".to_string()
         );
 
-        let docker = Docker::connect_with_host_to_reply(connector, "_".to_string(), 5).unwrap();
+        let docker =
+            Docker::connect_with_host_to_reply(connector, "_".to_string(), 5, API_DEFAULT_VERSION)
+                .unwrap();
 
         let results = docker.remove_network("my_network_name");
 
@@ -1214,7 +1222,9 @@ mod tests {
             "HTTP/1.1 200 OK\r\nServer: mock1\r\nContent-Type: application/json\r\nContent-Length: 463\r\n\r\n[{\"Name\":\"integration_test_list_network\",\"Id\":\"594423d1fbc3d894f8dc5a5b6565fffe4b4b5c379ceb23e1daf6ead4e3397fe3\",\"Created\":\"2019-02-23T09:54:21.8154268Z\",\"Scope\":\"local\",\"Driver\":\"bridge\",\"EnableIPv6\":false,\"IPAM\":{\"Driver\":\"default\",\"Options\":null,\"Config\":[{\"Subnet\":\"10.10.10.10/24\"}]},\"Internal\":false,\"Attachable\":false,\"Ingress\":false,\"ConfigFrom\":{\"Network\":\"\"},\"ConfigOnly\":false,\"Containers\":{},\"Options\":{},\"Labels\":{\"maintainer\":\"bollard-maintainer\"}}]\r\n".to_string()
         );
 
-        let docker = Docker::connect_with_host_to_reply(connector, "_".to_string(), 5).unwrap();
+        let docker =
+            Docker::connect_with_host_to_reply(connector, "_".to_string(), 5, API_DEFAULT_VERSION)
+                .unwrap();
 
         let mut list_networks_filters = HashMap::new();
         list_networks_filters.insert("label", vec!["maintainer=bollard-maintainer"]);
@@ -1252,7 +1262,9 @@ mod tests {
             "HTTP/1.1 200 OK\r\nServer: mock1\r\nContent-Type: application/json\r\nContent-Length: 0\r\n\r\n".to_string()
         );
 
-        let docker = Docker::connect_with_host_to_reply(connector, "_".to_string(), 5).unwrap();
+        let docker =
+            Docker::connect_with_host_to_reply(connector, "_".to_string(), 5, API_DEFAULT_VERSION)
+                .unwrap();
 
         let connect_network_options = ConnectNetworkOptions {
             container: "my_running_container",
@@ -1292,7 +1304,9 @@ mod tests {
             "HTTP/1.1 200 OK\r\nServer: mock1\r\nContent-Type: application/json\r\nContent-Length: 0\r\n\r\n".to_string()
         );
 
-        let docker = Docker::connect_with_host_to_reply(connector, "_".to_string(), 5).unwrap();
+        let docker =
+            Docker::connect_with_host_to_reply(connector, "_".to_string(), 5, API_DEFAULT_VERSION)
+                .unwrap();
 
         let results = docker.disconnect_network(
             "f3f9ef4375ca3ada374b9ecd6d8a1ebd501a59f0b2eedd0b93cd0502d7a009dc",
@@ -1324,11 +1338,14 @@ mod tests {
             "HTTP/1.1 200 OK\r\nServer: mock1\r\nContent-Type: application/json\r\nContent-Length: 44\r\n\r\n{\"NetworksDeleted\":[\"my_running_container\"]}\r\n".to_string()
         );
 
-        let docker = Docker::connect_with_host_to_reply(connector, "_".to_string(), 5).unwrap();
+        let docker =
+            Docker::connect_with_host_to_reply(connector, "_".to_string(), 5, API_DEFAULT_VERSION)
+                .unwrap();
 
         let results = docker.prune_networks(None::<PruneNetworksOptions<&str>>);
 
-        let future = results.map(|v| assert_eq!("my_running_container", v.networks_deleted.unwrap()[0]));
+        let future =
+            results.map(|v| assert_eq!("my_running_container", v.networks_deleted.unwrap()[0]));
 
         rt.block_on(future)
             .or_else(|e| {

--- a/tests/version_test.rs
+++ b/tests/version_test.rs
@@ -143,7 +143,7 @@ fn test_threadpool() {
     pool.shutdown_on_idle().wait().unwrap();
 }
 
-#[cfg(all(unix))]
+#[cfg(unix)]
 #[test]
 fn test_downversioning() {
     let mut rt = Runtime::new().unwrap();


### PR DESCRIPTION
Adds a version negotiation method to the `Docker` instance, in order to allow the client to downgrade the version if the server does not support it.

Also add manual version overrides to each of the server connection methods.