### PR TITLE
Fix docs.rs badge to display the latest version

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![license](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![circle-ci](https://circleci.com/gh/fussybeaver/bollard/tree/master.svg?style=svg)](https://circleci.com/gh/fussybeaver/bollard/tree/master)
 [![appveyor](https://ci.appveyor.com/api/projects/status/n5khebyfae0u1sbv/branch/master?svg=true)](https://ci.appveyor.com/project/fussybeaver/boondock)
-[![docs](https://docs.rs/bollard/badge.svg?version=0.1.0)](https://docs.rs/bollard/)
+[![docs](https://docs.rs/bollard/badge.svg)](https://docs.rs/bollard/)
 
 ## Bollard: an asynchronous rust client library for the docker API
 


### PR DESCRIPTION
It's currently frozen at 0.1.0 due to link parameter.