### PR TITLE
Implement `std::err::Error` for library errors

### DIFF
--- a/examples/error.rs
+++ b/examples/error.rs
@@ -1,0 +1,21 @@
+/// Example of using `std::error::Error` with bollard
+extern crate bollard;
+
+use bollard::Docker;
+
+fn run() -> Result<(), Box<std::error::Error>> {
+    #[cfg(unix)]
+    let docker1 = Docker::connect_with_unix_defaults()?;
+    #[cfg(windows)]
+    let docker1 = Docker::connect_with_named_pipe_defaults()?;
+
+    let env_var = std::env::var("ZOOKEEPER_ADDR")?;
+
+    Ok(())
+}
+
+fn main() {
+    run();
+
+    ()
+}

--- a/examples/kafka.rs
+++ b/examples/kafka.rs
@@ -1,7 +1,6 @@
 //! This example will spin up Zookeeper and two Kafka brokers asynchronously.
 
 extern crate bollard;
-extern crate failure;
 extern crate futures;
 extern crate hyper;
 extern crate serde;
@@ -10,10 +9,10 @@ extern crate tokio;
 use bollard::container::{
     Config, CreateContainerOptions, HostConfig, LogOutput, LogsOptions, StartContainerOptions,
 };
+use bollard::errors::Error;
 use bollard::image::CreateImageOptions;
 use bollard::{Docker, DockerChain};
 
-use failure::Error;
 use serde::ser::Serialize;
 use tokio::prelude::*;
 use tokio::runtime::Runtime;

--- a/examples/stats.rs
+++ b/examples/stats.rs
@@ -38,6 +38,7 @@ fn main() {
                     filters: filter,
                     ..Default::default()
                 }))
+                .map_err(failure::Error::from)
                 .and_then(move |(docker, containers)| {
                     if containers.is_empty() {
                         Err(bail!("no running containers"))

--- a/src/either.rs
+++ b/src/either.rs
@@ -1,7 +1,8 @@
-use failure::Error;
 use futures::Poll;
 use futures::{future, Future, Stream};
 use hyper::{Body, Response};
+
+use errors::Error;
 
 // https://github.com/rust-lang-nursery/futures-rs/pull/756
 #[derive(Debug)]

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -2,90 +2,200 @@
 use std::cmp;
 use std::fmt::{Display, Formatter, Result};
 
-/// Error emitted during client instantiation when the `DOCKER_CERT_PATH` environment variable is
-/// invalid.
-#[derive(Fail, Copy, Clone, Debug)]
-#[fail(display = "could not find DOCKER_CERT_PATH")]
-#[allow(missing_docs)]
-pub struct NoCertPathError {}
+use failure::Context;
 
-/// Error emitted by the docker server, when it responds with a 404.
-#[derive(Fail, Debug)]
-#[fail(display = "API responded with a 404 not found: {}", message)]
-#[allow(missing_docs)]
-pub struct DockerResponseNotFoundError {
-    pub message: String,
+#[derive(Debug)]
+/// Generic Error type over all errors in the bollard library
+pub struct Error {
+    inner: Context<ErrorKind>,
 }
 
-/// Generic error emitted by the docker server.
-#[derive(Fail, Debug)]
-#[fail(
-    display = "Docker responded with status code {}: {}",
-    status_code, message
-)]
-#[allow(missing_docs)]
-pub struct DockerResponseServerError {
-    pub status_code: u16,
-    pub message: String,
+/// The type of error embedded in an Error.
+#[derive(Debug, Fail)]
+pub enum ErrorKind {
+    #[fail(display = "could not find DOCKER_CERT_PATH")]
+    /// Error emitted during client instantiation when the `DOCKER_CERT_PATH` environment variable
+    /// is invalid.
+    NoCertPathError,
+    #[fail(display = "API responded with a 404 not found: {}", message)]
+    /// Error emitted by the docker server, when it responds with a 404.
+    DockerResponseNotFoundError {
+        /// Message returned by the docker server.
+        message: String,
+    },
+    #[fail(
+        display = "Docker responded with status code {}: {}",
+        status_code, message
+    )]
+    /// Generic error emitted by the docker server.
+    DockerResponseServerError {
+        /// Status code returned by the docker server.
+        status_code: u16,
+        /// Message returned by the docker server.
+        message: String,
+    },
+    #[fail(display = "API queried with a bad parameter: {}", message)]
+    /// Error emitted by the docker server, when it responds with a 400.
+    DockerResponseBadParameterError {
+        /// Message returned by the docker server.
+        message: String,
+    },
+    #[fail(display = "API responded with a 409 conflict: {}", message)]
+    /// Error emitted by the docker server, when it responds with a 409.
+    DockerResponseConflictError {
+        /// Message returned by the docker server.
+        message: String,
+    },
+    #[fail(
+        display = "API responded with a 304, resource was not modified: {}",
+        message
+    )]
+    /// Error emitted by the docker server, when it responds with a 304.
+    DockerResponseNotModifiedError {
+        /// Message returned by the docker server.
+        message: String,
+    },
+    #[fail(display = "Failed to deserialize JSON: {}", message)]
+    /// Error facilitating debugging failed JSON parsing.
+    JsonDataError {
+        /// Short section of the json close to the error.
+        message: String,
+        /// Entire JSON payload.
+        contents: String,
+        /// Character sequence at error location.
+        column: usize,
+    },
+    #[fail(display = "Failed to parse API version: {}", api_version)]
+    /// Error emitted when the server version cannot be parsed when negotiating a version
+    APIVersionParseError {
+        /// The api version returned by the server.
+        api_version: String,
+    },
+    #[fail(display = "Failed to serialize JSON: {:?}", err)]
+    /// Error emitted when JSON fails to serialize.
+    JsonSerializeError {
+        /// The original error emitted by serde.
+        err: serde_json::Error,
+    },
+    #[fail(display = "Failed to deserialize JSON: {}: {:?}", content, err)]
+    /// Error emitted when JSON fails to deserialize.
+    JsonDeserializeError {
+        /// The original string that was being deserialized.
+        content: String,
+        /// The original error emitted by serde.
+        err: serde_json::Error,
+    },
+    #[fail(display = "UTF8 error: {}: {:?}", content, err)]
+    /// Error emitted when log output generates an I/O error.
+    StrParseError {
+        /// the bytes that failed
+        content: String,
+        /// The original error emitted.
+        err: std::str::Utf8Error,
+    },
+    #[fail(display = "I/O error: {:?}", err)]
+    /// Error emitted from an I/O error.
+    IOError {
+        /// The original error emitted.
+        err: std::io::Error,
+    },
+    #[fail(display = "Format error: {}: {:?}", content, err)]
+    /// Error emitted from a formatting error.
+    StrFmtError {
+        /// The original string that failed to format.
+        content: String,
+        /// The original error emitted.
+        err: std::fmt::Error,
+    },
+    #[fail(display = "HTTP error: {}: {:?}", builder, err)]
+    /// Error emitted from an HTTP error.
+    HttpClientError {
+        /// The client builder, formatted as a debug string.
+        builder: String,
+        /// The original error emitted.
+        err: http::Error,
+    },
+    #[fail(display = "Hyper error: {:?}", err)]
+    /// Error emitted from an HTTP error.
+    HyperResponseError {
+        /// The original error emitted.
+        err: hyper::Error,
+    },
+    /// Error emitted when a request times out.
+    #[fail(display = "Timeout error: {:?}", err)]
+    RequestTimeoutError {
+        /// The original error emitted.
+        err: tokio_timer::timeout::Error<hyper::Error>,
+    },
 }
 
-/// Error emitted by the docker server, when it responds with a 400.
-#[derive(Fail, Debug)]
-#[fail(display = "API queried with a bad parameter: {}", message)]
-#[allow(missing_docs)]
-pub struct DockerResponseBadParameterError {
-    pub message: String,
-}
-
-/// Error emitted by the docker server, when it responds with a 409.
-#[derive(Fail, Debug)]
-#[fail(display = "API responded with a 409 conflict: {}", message)]
-#[allow(missing_docs)]
-pub struct DockerResponseConflictError {
-    pub message: String,
-}
-
-/// Error emitted by the docker server, when it responds with a 304.
-#[derive(Fail, Debug)]
-#[fail(
-    display = "API responded with a 304, resource was not modified: {}",
-    message
-)]
-#[allow(missing_docs)]
-pub struct DockerResponseNotModifiedError {
-    pub message: String,
-}
-
-/// Error facilitating debugging failed JSON parsing.
-#[derive(Fail, Debug)]
-#[allow(missing_docs)]
-pub struct JsonDataError {
-    pub message: String,
-    pub contents: String,
-    pub column: usize,
-}
-
-impl Display for JsonDataError {
-    fn fmt(&self, f: &mut Formatter) -> Result {
-        let backtrack_len: usize = 24;
-        let peek_len: usize = 32;
-        let description = "Failed to deserialize near ...";
-        let from_start_length = self.column.checked_sub(backtrack_len).unwrap_or(0);
-        write!(
-            f,
-            "{}{}...\n{}",
-            description,
-            &self.contents
-                [from_start_length..cmp::min(self.contents.len(), self.column + peek_len)],
-            self.message
-        )
+impl Display for Error {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+        match self.inner.get_context() {
+            ErrorKind::JsonDataError {
+                message,
+                contents,
+                column,
+            } => {
+                let backtrack_len: usize = 24;
+                let peek_len: usize = 32;
+                let description = "Failed to deserialize near ...";
+                let from_start_length = column.checked_sub(backtrack_len).unwrap_or(0);
+                write!(
+                    f,
+                    "{}{}...\n{}",
+                    description,
+                    &contents[from_start_length..cmp::min(contents.len(), column + peek_len)],
+                    message
+                )
+            }
+            _ => Display::fmt(&self.inner, f),
+        }
     }
 }
 
-/// Error emitted when the server version cannot be parsed when negotiating a version
-#[derive(Fail, Debug)]
-#[fail(display = "Failed to parse API version: {}", api_version)]
-#[allow(missing_docs)]
-pub struct APIVersionParseError {
-    pub api_version: String,
+impl std::error::Error for Error {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self.inner.get_context() {
+            ErrorKind::JsonSerializeError { err, .. } => Some(err),
+            ErrorKind::JsonDeserializeError { err, .. } => Some(err),
+            ErrorKind::StrParseError { err, .. } => Some(err),
+            ErrorKind::IOError { err, .. } => Some(err),
+            ErrorKind::StrFmtError { err, .. } => Some(err),
+            ErrorKind::HttpClientError { err, .. } => Some(err),
+            ErrorKind::HyperResponseError { err, .. } => Some(err),
+            ErrorKind::RequestTimeoutError { err, .. } => Some(err),
+            _ => None,
+        }
+    }
+}
+
+impl Error {
+    /// yield the underlying error kind of this error.
+    pub fn kind(&self) -> &ErrorKind {
+        self.inner.get_context()
+    }
+}
+
+impl From<ErrorKind> for Error {
+    fn from(kind: ErrorKind) -> Error {
+        Error {
+            inner: Context::new(kind),
+        }
+    }
+}
+
+impl From<Context<ErrorKind>> for Error {
+    fn from(inner: Context<ErrorKind>) -> Error {
+        Error { inner: inner }
+    }
+}
+
+/// Needed due to tokio's Decoder implementation
+impl From<std::io::Error> for Error {
+    fn from(err: std::io::Error) -> Error {
+        Error {
+            inner: ErrorKind::IOError { err: err }.into(),
+        }
+    }
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -127,6 +127,13 @@ pub enum ErrorKind {
         /// The original error emitted.
         err: tokio_timer::timeout::Error<hyper::Error>,
     },
+    /// Error emitted when an SSL context fails to configure.
+    #[cfg(feature = "openssl")]
+    #[fail(display = "SSL error: {:?}", err)]
+    SSLError {
+        /// The original error emitted.
+        err: openssl::error::ErrorStack,
+    },
 }
 
 impl Display for Error {

--- a/src/exec.rs
+++ b/src/exec.rs
@@ -1,7 +1,6 @@
 //! Exec API: Run new commands inside running containers
 
 use arrayvec::ArrayVec;
-use failure::Error;
 use futures::{stream, Stream};
 use http::header::{CONNECTION, UPGRADE};
 use http::request::Builder;
@@ -16,6 +15,7 @@ use docker::API_DEFAULT_VERSION;
 use either::EitherStream;
 
 use container::LogOutput;
+use errors::Error;
 
 /// Exec configuration used in the [Create Exec API](../struct.Docker.html#method.create_exec)
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]

--- a/src/network.rs
+++ b/src/network.rs
@@ -1,7 +1,6 @@
 //! Network API: Networks are user-defined networks that containers can be attached to.
 
 use arrayvec::ArrayVec;
-use failure::Error;
 use http::request::Builder;
 use hyper::rt::Future;
 use hyper::{Body, Method};
@@ -16,6 +15,8 @@ use super::{Docker, DockerChain};
 #[cfg(test)]
 use docker::API_DEFAULT_VERSION;
 use docker::{FALSE_STR, TRUE_STR};
+use errors::Error;
+use errors::ErrorKind::JsonSerializeError;
 
 /// Network configuration used in the [Create Network API](../struct.Docker.html#method.create_network)
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -268,7 +269,8 @@ impl<'a> ListNetworksQueryParams<&'a str, String> for ListNetworksOptions<&'a st
     fn into_array(self) -> Result<ArrayVec<[(&'a str, String); 1]>, Error> {
         Ok(ArrayVec::from([(
             "filters",
-            serde_json::to_string(&self.filters)?,
+            serde_json::to_string(&self.filters)
+                .map_err::<Error, _>(|e| JsonSerializeError { err: e }.into())?,
         )]))
     }
 }
@@ -411,7 +413,8 @@ impl<'a> PruneNetworksQueryParams<&'a str, String> for PruneNetworksOptions<&'a 
     fn into_array(self) -> Result<ArrayVec<[(&'a str, String); 1]>, Error> {
         Ok(ArrayVec::from([(
             "filters",
-            serde_json::to_string(&self.filters)?,
+            serde_json::to_string(&self.filters)
+                .map_err::<Error, _>(|e| JsonSerializeError { err: e }.into())?,
         )]))
     }
 }

--- a/src/read.rs
+++ b/src/read.rs
@@ -53,7 +53,6 @@ impl Decoder for NewlineLogOutputDecoder {
                         message: String::new(),
                     })),
                     1 => from_utf8(&slice[8..]).map(|s| {
-                        println!("{}", s);
                         Some(LogOutput::StdOut {
                             message: s.to_string(),
                         })
@@ -69,7 +68,6 @@ impl Decoder for NewlineLogOutputDecoder {
                     _ =>
                     // `start_exec` API on unix socket will emit values without a header
                     {
-                        println!("{}", from_utf8(&slice)?);
                         Ok(Some(LogOutput::Console {
                             message: from_utf8(&slice)?.to_string(),
                         }))

--- a/src/system.rs
+++ b/src/system.rs
@@ -1,6 +1,5 @@
 //! System API: interface for interacting with the Docker server and/or Registry.
 use arrayvec::ArrayVec;
-use failure::Error;
 use http::request::Builder;
 use hyper::rt::Future;
 use hyper::{Body, Method};
@@ -8,6 +7,7 @@ use hyper::{Body, Method};
 use super::{Docker, DockerChain};
 #[cfg(test)]
 use docker::API_DEFAULT_VERSION;
+use errors::Error;
 
 /// Result type for the [Version API](../struct.Docker.html#method.version)
 #[derive(Debug, Serialize, Deserialize)]

--- a/src/uri.rs
+++ b/src/uri.rs
@@ -1,4 +1,3 @@
-use failure::Error;
 #[cfg(windows)]
 use hex::FromHex;
 use hex::ToHex;
@@ -11,6 +10,8 @@ use std::borrow::Cow;
 use std::ffi::OsStr;
 
 use docker::{ClientType, ClientVersion};
+use errors::Error;
+use errors::ErrorKind::StrFmtError;
 
 #[derive(Debug)]
 pub struct Uri<'a> {
@@ -80,7 +81,11 @@ impl<'a> Uri<'a> where {
                     .as_ref()
                     .to_string_lossy()
                     .as_bytes()
-                    .write_hex(&mut host)?;
+                    .write_hex(&mut host)
+                    .map_err(|e| StrFmtError {
+                        content: socket.as_ref().to_string_lossy().into_owned(),
+                        err: e,
+                    })?;
                 Ok(host)
             }
             #[cfg(windows)]

--- a/src/uri.rs
+++ b/src/uri.rs
@@ -95,7 +95,11 @@ impl<'a> Uri<'a> where {
                     .as_ref()
                     .to_string_lossy()
                     .as_bytes()
-                    .write_hex(&mut host)?;
+                    .write_hex(&mut host)
+                    .map_err(|e| StrFmtError {
+                        content: socket.as_ref().to_string_lossy().into_owned(),
+                        err: e,
+                    })?;
                 Ok(host)
             }
         }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,7 +1,6 @@
 extern crate failure;
 extern crate futures;
 
-use self::failure::Error;
 use self::futures::future;
 use hyper::rt::{Future, Stream};
 use tokio::runtime::Runtime;
@@ -11,6 +10,7 @@ use std::collections::HashMap;
 
 use bollard::auth::DockerCredentials;
 use bollard::container::*;
+use bollard::errors::Error;
 use bollard::image::*;
 use bollard::DockerChain;
 


### PR DESCRIPTION
Closes #31 

This is a larger change that requires a major version.