### PR TITLE
Omit changes parameter when not declared

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 jobs:
   test_ssl:
     docker:
-      - image: docker:19.03.1
+      - image: docker:19.03.4
     steps:
       - checkout
       - setup_remote_docker
@@ -15,7 +15,7 @@ jobs:
       - run: docker run -ti -e DOCKER_CERT_PATH=/certs -e DOCKER_HOST='tcp://test.example.com:2376' --volumes-from certs --rm --link test-docker-daemon:docker bollard cargo test --features ssl -- --test test_version_ssl
   test_tls:
     docker:
-      - image: docker:19.03.1
+      - image: docker:19.03.4
     steps:
       - checkout
       - setup_remote_docker
@@ -29,7 +29,7 @@ jobs:
       - run: docker run -ti -e DOCKER_CERT_PATH=/certs -e DOCKER_HOST='tcp://test.example.com:2376' --volumes-from certs --rm --link test-docker-daemon:docker bollard cargo test -- --test test_version_tls
   test_http:
     docker:
-      - image: docker:19.03.1
+      - image: docker:19.03.4
     steps:
       - checkout
       - setup_remote_docker
@@ -38,7 +38,7 @@ jobs:
       - run: docker run -ti -e DOCKER_HOST='tcp://test.example.com:2375' --rm --link test-docker-daemon:docker bollard cargo test --features test_http -- --test test_version_http
   test_unix:
     docker:
-      - image: docker:19.03.1
+      - image: docker:19.03.4
     steps:
       - checkout
       - setup_remote_docker
@@ -46,7 +46,7 @@ jobs:
       - run: dockerfiles/bin/run_integration_tests.sh
   test_doc:
     docker:
-      - image: docker:19.03.1
+      - image: docker:19.03.4
     steps:
       - checkout
       - setup_remote_docker

--- a/src/image.rs
+++ b/src/image.rs
@@ -646,7 +646,7 @@ pub struct CommitContainerOptions<T> {
     /// Whether to pause the container before committing.
     pub pause: bool,
     /// `Dockerfile` instructions to apply while committing
-    pub changes: T,
+    pub changes: Option<T>,
 }
 
 /// Trait providing implementations for [Commit Container Options](struct.CommitContainerOptions.html)
@@ -657,34 +657,40 @@ where
     K: AsRef<str>,
     V: AsRef<str>,
 {
-    fn into_array(self) -> Result<ArrayVec<[(K, V); 7]>, Error>;
+    fn into_array(self) -> Result<Vec<(K, V)>, Error>;
 }
 
 impl<'a> CommitContainerQueryParams<&'a str, &'a str> for CommitContainerOptions<&'a str> {
-    fn into_array(self) -> Result<ArrayVec<[(&'a str, &'a str); 7]>, Error> {
-        Ok(ArrayVec::from([
+    fn into_array(self) -> Result<Vec<(&'a str, &'a str)>, Error> {
+        let mut res = vec![
             ("container", self.container),
             ("repo", self.repo),
             ("tag", self.tag),
             ("comment", self.comment),
             ("author", self.author),
             ("pause", if self.pause { TRUE_STR } else { FALSE_STR }),
-            ("changes", self.changes),
-        ]))
+        ];
+        if let Some(c) = self.changes {
+            res.push(("changes", c));
+        }
+        Ok(res)
     }
 }
 
 impl<'a> CommitContainerQueryParams<&'a str, String> for CommitContainerOptions<String> {
-    fn into_array(self) -> Result<ArrayVec<[(&'a str, String); 7]>, Error> {
-        Ok(ArrayVec::from([
+    fn into_array(self) -> Result<Vec<(&'a str, String)>, Error> {
+        let mut res = vec![
             ("container", self.container),
             ("repo", self.repo),
             ("tag", self.tag),
             ("comment", self.comment),
             ("author", self.author),
             ("pause", self.pause.to_string()),
-            ("changes", self.changes),
-        ]))
+        ];
+        if let Some(c) = self.changes {
+            res.push(("changes", c));
+        }
+        Ok(res)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,7 @@
 //! [![license](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 //! [![circle-ci](https://circleci.com/gh/fussybeaver/bollard/tree/master.svg?style=svg)](https://circleci.com/gh/fussybeaver/bollard/tree/master)
 //! [![appveyor](https://ci.appveyor.com/api/projects/status/n5khebyfae0u1sbv/branch/master?svg=true)](https://ci.appveyor.com/project/fussybeaver/boondock)
-//! [![docs](https://docs.rs/bollard/badge.svg?version=0.1.0)](https://docs.rs/bollard/)
+//! [![docs](https://docs.rs/bollard/badge.svg)](https://docs.rs/bollard/)
 //!
 //! # Bollard: an asynchronous rust client library for the docker API
 //!


### PR DESCRIPTION
A new version of the docker server requires that the `changes` parameter is specified with real docker instructions. This changeset omits the changes parameter if this option is unspecified.

Fixes #37