### PR TITLE
Persist dockerchain instance in errors

### DIFF
--- a/examples/kafka.rs
+++ b/examples/kafka.rs
@@ -47,6 +47,7 @@ where
                 }),
             )
         })
+        .map_err(|(_, e)| e)
         .map(|(_, stream)| stream)
         .into_stream()
         .flatten()
@@ -120,6 +121,7 @@ fn main() {
         .and_then(move |(docker, _)| {
             docker.start_container("zookeeper", None::<StartContainerOptions<String>>)
         })
+        .map_err(|(_, e)| e)
         .map(|(docker, _)| {
             let stream1 = docker
                 .create_image(
@@ -129,6 +131,7 @@ fn main() {
                     }),
                     None,
                 )
+                .map_err(|(_, e)| e)
                 .map(move |(docker, _)| create_and_logs(docker, "kafka1", broker1_config))
                 .into_stream()
                 .flatten();
@@ -142,6 +145,7 @@ fn main() {
                     }),
                     None,
                 )
+                .map_err(|(_, e)| e)
                 .map(move |(docker, _)| create_and_logs(docker, "kafka2", broker2_config))
                 .into_stream()
                 .flatten();

--- a/examples/stats.rs
+++ b/examples/stats.rs
@@ -38,7 +38,7 @@ fn main() {
                     filters: filter,
                     ..Default::default()
                 }))
-                .map_err(failure::Error::from)
+                .map_err(|(_, e)| failure::Error::from(e))
                 .and_then(move |(docker, containers)| {
                     if containers.is_empty() {
                         Err(bail!("no running containers"))

--- a/examples/top.rs
+++ b/examples/top.rs
@@ -35,6 +35,7 @@ fn top_processes(
     client
         .top_processes(&container.id, Some(TopOptions { ps_args: "ef" }))
         .map(|result| Some((name, result)))
+        .map_err(|(_, e)| e)
 }
 
 fn main() {
@@ -87,6 +88,7 @@ fn main() {
                 future::ok::<_, Error>(hashmap)
             })
         })
+        .map_err(|(_, e)| e)
         .flatten()
         .map_err(|e| println!("{:?}", e))
         .map(|hsh| {

--- a/src/docker.rs
+++ b/src/docker.rs
@@ -856,12 +856,14 @@ impl Docker {
 /// ```
 pub struct DockerChain {
     pub(super) inner: Docker,
+    pub(super) e_inner: Docker
 }
 
 impl Clone for DockerChain {
     fn clone(&self) -> DockerChain {
         DockerChain {
             inner: self.inner.clone(),
+            e_inner: self.e_inner.clone()
         }
     }
 }
@@ -878,7 +880,8 @@ impl Docker {
     /// docker.chain();
     /// ```
     pub fn chain(self) -> DockerChain {
-        DockerChain { inner: self }
+        let e_docker = self.clone();
+        DockerChain { inner: self, e_inner: e_docker }
     }
 
     pub(crate) fn process_into_value<T>(

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,6 +1,7 @@
 //! Errors for this module.
 use std::cmp;
 use std::fmt::{Display, Formatter, Result};
+use docker::DockerChain;
 
 use failure::Context;
 
@@ -8,6 +9,13 @@ use failure::Context;
 /// Generic Error type over all errors in the bollard library
 pub struct Error {
     inner: Context<ErrorKind>,
+}
+
+#[derive(Debug)]
+/// Error type with a reference to a chainable client instance
+pub struct ErrorChain {
+    inner: Context<ErrorKind>,
+    docker: DockerChain
 }
 
 /// The type of error embedded in an Error.

--- a/src/network.rs
+++ b/src/network.rs
@@ -813,13 +813,14 @@ impl DockerChain {
     pub fn create_network<T>(
         self,
         config: CreateNetworkOptions<T>,
-    ) -> impl Future<Item = (DockerChain, CreateNetworkResults), Error = Error>
+    ) -> impl Future<Item = (DockerChain, CreateNetworkResults), Error = (DockerChain, Error)>
     where
         T: AsRef<str> + Eq + Hash + Serialize,
     {
-        self.inner
-            .create_network(config)
-            .map(|result| (self, result))
+        self.inner.create_network(config).then(|res| match res {
+            Err(e) => Err((self, e)),
+            Ok(res) => Ok((self, res)),
+        })
     }
 
     /// ---
@@ -848,10 +849,13 @@ impl DockerChain {
     pub fn remove_network(
         self,
         network_name: &str,
-    ) -> impl Future<Item = (DockerChain, ()), Error = Error> {
+    ) -> impl Future<Item = (DockerChain, ()), Error = (DockerChain, Error)> {
         self.inner
             .remove_network(network_name)
-            .map(|result| (self, result))
+            .then(|res| match res {
+                Err(e) => Err((self, e)),
+                Ok(res) => Ok((self, res)),
+            })
     }
 
     /// ---
@@ -889,14 +893,17 @@ impl DockerChain {
         self,
         network_name: &str,
         options: Option<T>,
-    ) -> impl Future<Item = (DockerChain, InspectNetworkResults), Error = Error>
+    ) -> impl Future<Item = (DockerChain, InspectNetworkResults), Error = (DockerChain, Error)>
     where
         T: InspectNetworkQueryParams<'a, V>,
         V: AsRef<str>,
     {
         self.inner
             .inspect_network(network_name, options)
-            .map(|result| (self, result))
+            .then(|res| match res {
+                Err(e) => Err((self, e)),
+                Ok(res) => Ok((self, res)),
+            })
     }
 
     /// ---
@@ -936,15 +943,16 @@ impl DockerChain {
     pub fn list_networks<T, K, V>(
         self,
         options: Option<T>,
-    ) -> impl Future<Item = (DockerChain, Vec<ListNetworksResults>), Error = Error>
+    ) -> impl Future<Item = (DockerChain, Vec<ListNetworksResults>), Error = (DockerChain, Error)>
     where
         T: ListNetworksQueryParams<K, V>,
         K: AsRef<str>,
         V: AsRef<str>,
     {
-        self.inner
-            .list_networks(options)
-            .map(|result| (self, result))
+        self.inner.list_networks(options).then(|res| match res {
+            Err(e) => Err((self, e)),
+            Ok(res) => Ok((self, res)),
+        })
     }
 
     /// ---
@@ -989,13 +997,16 @@ impl DockerChain {
         self,
         network_name: &str,
         config: ConnectNetworkOptions<T>,
-    ) -> impl Future<Item = (DockerChain, ()), Error = Error>
+    ) -> impl Future<Item = (DockerChain, ()), Error = (DockerChain, Error)>
     where
         T: AsRef<str> + Eq + Hash + Serialize,
     {
         self.inner
             .connect_network(network_name, config)
-            .map(|result| (self, result))
+            .then(|res| match res {
+                Err(e) => Err((self, e)),
+                Ok(res) => Ok((self, res)),
+            })
     }
 
     /// ---
@@ -1033,13 +1044,16 @@ impl DockerChain {
         self,
         network_name: &str,
         config: DisconnectNetworkOptions<T>,
-    ) -> impl Future<Item = (DockerChain, ()), Error = Error>
+    ) -> impl Future<Item = (DockerChain, ()), Error = (DockerChain, Error)>
     where
         T: AsRef<str> + Serialize,
     {
         self.inner
             .disconnect_network(network_name, config)
-            .map(|result| (self, result))
+            .then(|res| match res {
+                Err(e) => Err((self, e)),
+                Ok(res) => Ok((self, res)),
+            })
     }
 
     /// ---
@@ -1079,15 +1093,16 @@ impl DockerChain {
     pub fn prune_networks<T, K, V>(
         self,
         options: Option<T>,
-    ) -> impl Future<Item = (DockerChain, PruneNetworksResults), Error = Error>
+    ) -> impl Future<Item = (DockerChain, PruneNetworksResults), Error = (DockerChain, Error)>
     where
         T: PruneNetworksQueryParams<K, V>,
         K: AsRef<str>,
         V: AsRef<str>,
     {
-        self.inner
-            .prune_networks(options)
-            .map(|result| (self, result))
+        self.inner.prune_networks(options).then(|res| match res {
+            Err(e) => Err((self, e)),
+            Ok(res) => Ok((self, res)),
+        })
     }
 }
 

--- a/src/system.rs
+++ b/src/system.rs
@@ -107,8 +107,13 @@ impl DockerChain {
     /// # let docker = Docker::connect_with_http_defaults().unwrap();
     /// docker.chain().version();
     /// ```
-    pub fn version(self) -> impl Future<Item = (DockerChain, Version), Error = Error> {
-        self.inner.version().map(|result| (self, result))
+    pub fn version(
+        self,
+    ) -> impl Future<Item = (DockerChain, Version), Error = (DockerChain, Error)> {
+        self.inner.version().then(|res| match res {
+            Err(e) => Err((self, e)),
+            Ok(res) => Ok((self, res)),
+        })
     }
 
     /// ---
@@ -131,8 +136,11 @@ impl DockerChain {
     ///
     /// docker.chain().ping();
     /// ```
-    pub fn ping(self) -> impl Future<Item = (DockerChain, String), Error = Error> {
-        self.inner.ping().map(|result| (self, result))
+    pub fn ping(self) -> impl Future<Item = (DockerChain, String), Error = (DockerChain, Error)> {
+        self.inner.ping().then(|res| match res {
+            Err(e) => Err((self, e)),
+            Ok(res) => Ok((self, res)),
+        })
     }
 }
 

--- a/tests/exec_test.rs
+++ b/tests/exec_test.rs
@@ -37,7 +37,12 @@ fn start_exec_test(docker: Docker) {
             )
         })
         .and_then(|(docker, message)| docker.start_exec(&message.id, None::<StartExecOptions>))
-        .and_then(|(docker, stream)| stream.take(2).collect().map(|v| (docker, v)))
+        .and_then(|(docker, stream)| {
+            stream.take(2).collect().then(|res| match res {
+                Ok(v) => Ok((docker, v)),
+                Err(e) => Err((docker, e)),
+            })
+        })
         .map(|(docker, lst)| {
             assert!(lst.into_iter().any(|line| {
                 println!("{:?}", line);

--- a/tests/image_test.rs
+++ b/tests/image_test.rs
@@ -262,21 +262,20 @@ fn commit_container_test(docker: Docker) {
             )
         })
         .map(move |(docker, stream)| {
-            stream
-                .take(1)
-                .into_future()
-                .map(|(head, _)| {
+            stream.take(1).into_future().then(|res| match res {
+                Ok((head, _)) => {
                     let first = head.unwrap();
                     if let Some(error) = first.error {
                         println!("{}", error.message);
                     }
                     assert_eq!(first.status_code, 0);
-                    docker
-                })
-                .or_else(|e| {
+                    Ok(docker)
+                }
+                Err(e) => {
                     println!("{}", e.0);
-                    Err(e.0)
-                })
+                    Err((docker, e.0))
+                }
+            })
         })
         .flatten()
         .and_then(move |docker| {
@@ -357,9 +356,12 @@ RUN touch bollard.txt
             Some(compressed.into()),
         )
         .and_then(move |(docker, stream)| {
-            stream.collect().map(|v| {
-                println!("{:?}", v);
-                (docker, v)
+            stream.collect().then(|res| match res {
+                Ok(v) => {
+                    println!("{:?}", v);
+                    Ok((docker, v))
+                }
+                Err(e) => Err((docker, e)),
             })
         })
         .and_then(|(docker, _)| {
@@ -391,21 +393,20 @@ RUN touch bollard.txt
             )
         })
         .map(move |(docker, stream)| {
-            stream
-                .take(1)
-                .into_future()
-                .map(|(head, _)| {
+            stream.take(1).into_future().then(|res| match res {
+                Ok((head, _)) => {
                     let first = head.unwrap();
                     if let Some(error) = first.error {
                         println!("{}", error.message);
                     }
                     assert_eq!(first.status_code, 0);
-                    docker
-                })
-                .or_else(|e| {
+                    Ok(docker)
+                }
+                Err(e) => {
                     println!("{}", e.0);
-                    Err(e.0)
-                })
+                    Err((docker, e.0))
+                }
+            })
         })
         .flatten()
         .and_then(move |docker| {


### PR DESCRIPTION
This changeset provides the original dockerchain instance in errors, so that tear-down calls may be used.