### PR TITLE
Support uploading tar archives to create new images 

### DIFF
--- a/examples/image_from_scratch.rs
+++ b/examples/image_from_scratch.rs
@@ -1,0 +1,93 @@
+/// Example of creating an image from scratch with a file system in a raw Tar (or tar.gz) archive.
+/// Run with `cargo run --example image_from_scratch <path to archive>.tar.gz
+/// This implementation streams the archive file piece by piece to the Docker daemon,
+/// but does so inefficiently. For best results, use `tokio::fs` instead of `std::fs`.
+
+use bollard::{Docker, image::CreateImageOptions, image::CreateImageResults};
+use tokio::runtime::Runtime;
+use hyper::body::Body;
+use futures_util::stream::{TryStreamExt, Stream};
+use futures_util::task::{Poll, Context};
+use std::env::args;
+use std::fs::File;
+use std::io::{Read, Result as IOResult};
+use std::pin::Pin;
+
+/*
+  Image file system archives can be very large, so we don't want to load the entire thing
+  into memory in order to send it to Docker. Since `bollard::Docker::create_image` takes
+  a `hyper::Body` struct, which can be created from a `futures_util::stream::Stream`, we will
+  implement `Stream` on our own type `FileStreamer`.
+*/
+const BUFFER_SIZE: usize = 1048576; // 1 MB
+
+struct FileStreamer {
+  file: File,
+  done: bool
+}
+
+// just an example...
+impl Stream for FileStreamer {
+  type Item = IOResult<Vec<u8>>;
+
+  fn poll_next(mut self: Pin<&mut Self>, _: &mut Context) -> Poll<Option<Self::Item>> {
+    if self.done {
+      return Poll::Ready(None);
+    }
+    let mut buffer: [u8; BUFFER_SIZE] = [0; BUFFER_SIZE];
+    // The `std::fs::File.read` method here is blocking. For best results, use a non-blocking implementation
+    match self.file.read(&mut buffer[..]) {
+      Ok(BUFFER_SIZE) => {
+        Poll::Ready(Some(Ok(buffer.to_vec())))
+      },
+      // If less than `BUFFER_SIZE` bytes are read from the file, that means the whole file has been read.
+      // The next time this stream is polled, return `None`.
+      Ok(n) => {
+        self.done = true;
+        Poll::Ready(Some(Ok(buffer[0..n].to_vec())))
+      },
+      Err(e) => {
+        Poll::Ready(Some(Err(e)))
+      }
+    }
+  }
+}
+
+async fn run(file: File) -> Result<(), failure::Error> {
+    #[cfg(unix)]
+    let docker = Docker::connect_with_unix_defaults().unwrap();
+    #[cfg(windows)]
+    let docker = Docker::connect_with_named_pipe_defaults().unwrap();
+
+    let options = CreateImageOptions {
+        from_src: "-", // from_src must be "-" when sending the archive in the request body
+        repo: "bollard_image_scratch_example", // The name of the image in the docker daemon.
+        tag: "1.0.0", // The tag of this particular image.
+        ..Default::default()
+    };
+    // Create FileReader struct
+    let reader = FileStreamer { file, done: false};
+    // A `Body` can be created from a `Stream<Item = Result<...>>`
+    let req_body: Body = Body::wrap_stream(reader);
+
+    // Finally, call Docker::create_image with the options and the body
+    let result: Vec<CreateImageResults> = docker
+        .create_image(Some(options), Some(req_body), None)
+        .try_collect().await?;
+    // If all went well, the ID of the new image will be printed
+    dbg!(&result[0]);
+    Ok(())
+}
+
+fn main() {
+    let arguments: Vec<String> = args().collect();
+    if arguments.len() == 1 || arguments.len() > 2 {
+      println!("Usage: image_from_scratch <path to tar archive>");
+      return;
+    }
+
+    let archive = File::open(&arguments[1]).expect("Could not find archive.");
+
+    let mut rt = Runtime::new().unwrap();
+    rt.block_on(run(archive)).unwrap();
+}

--- a/examples/kafka.rs
+++ b/examples/kafka.rs
@@ -76,6 +76,7 @@ async fn run() -> Result<(), failure::Error> {
                 ..Default::default()
             }),
             None,
+            None,
         )
         .try_collect::<Vec<_>>()
         .await?;
@@ -97,6 +98,7 @@ async fn run() -> Result<(), failure::Error> {
                 from_image: KAFKA_IMAGE,
                 ..Default::default()
             }),
+            None,
             None,
         )
         .try_collect::<Vec<_>>()
@@ -129,6 +131,7 @@ async fn run() -> Result<(), failure::Error> {
                 from_image: KAFKA_IMAGE,
                 ..Default::default()
             }),
+            None,
             None,
         )
         .try_collect::<Vec<_>>()

--- a/examples/stats.rs
+++ b/examples/stats.rs
@@ -7,10 +7,8 @@ use bollard::container::{ListContainersOptions, StatsOptions};
 use bollard::Docker;
 use failure::Error;
 
-use futures_util::stream;
 use futures_util::stream::StreamExt;
 use futures_util::stream::TryStreamExt;
-use tokio::prelude::*;
 use tokio::runtime::Runtime;
 
 use std::collections::HashMap;
@@ -33,7 +31,7 @@ async fn run<'a>() -> Result<(), Error> {
             .await?;
 
         if containers.is_empty() {
-            return Err(bail!("no running containers"));
+            bail!("no running containers");
         } else {
             for container in containers {
                 &docker

--- a/src/image.rs
+++ b/src/image.rs
@@ -1023,7 +1023,7 @@ impl Docker {
     ///   ..Default::default()
     /// });
     ///
-    /// docker.create_image(options, None);
+    /// docker.create_image(options, None, None);
     ///
     /// // do some other work while the image is pulled from the docker hub...
     /// ```

--- a/src/image.rs
+++ b/src/image.rs
@@ -1001,6 +1001,8 @@ impl Docker {
     /// # Arguments
     ///
     ///  - An optional [Create Image Options](image/struct.CreateImageOptions.html) struct.
+    ///  - An optional request body consisting of a tar or tar.gz archive with the root file system
+    ///    for the image. If this argument is used, the value of the `from_src` option must be "-".
     ///
     /// # Returns
     ///
@@ -1033,6 +1035,7 @@ impl Docker {
     pub fn create_image<T, K, V>(
         &self,
         options: Option<T>,
+        root_fs: Option<Body>,
         credentials: Option<DockerCredentials>,
     ) -> impl Stream<Item = Result<CreateImageResults, Error>>
     where
@@ -1052,7 +1055,10 @@ impl Docker {
                         .method(Method::POST)
                         .header("X-Registry-Auth", base64::encode(&ser_cred)),
                     Docker::transpose_option(options.map(|o| o.into_array())),
-                    Ok(Body::empty()),
+                    match root_fs {
+                        Some(body) => Ok(body),
+                        None => Ok(Body::empty())
+                    }
                 );
                 self.process_into_stream(req).boxed()
             }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -126,6 +126,7 @@ pub async fn create_container_hello_world(
                 from_image: &image[..],
                 ..Default::default()
             }),
+            None,
             if cfg!(windows) {
                 None
             } else {
@@ -195,6 +196,7 @@ pub async fn create_daemon(docker: &Docker, container_name: &'static str) -> Res
                 from_image: &image[..],
                 ..Default::default()
             }),
+            None,
             if cfg!(windows) {
                 None
             } else {
@@ -258,6 +260,7 @@ pub async fn create_image_hello_world(docker: &Docker) -> Result<(), Error> {
                 from_image: &image[..],
                 ..Default::default()
             }),
+            None,
             if cfg!(windows) {
                 None
             } else {

--- a/tests/container_test.rs
+++ b/tests/container_test.rs
@@ -55,6 +55,7 @@ async fn image_push_test(docker: Docker) -> Result<(), Error> {
                 from_image: &image[..],
                 ..Default::default()
             }),
+            None,
             if cfg!(windows) {
                 None
             } else {
@@ -424,6 +425,7 @@ async fn archive_container_test(docker: Docker) -> Result<(), Error> {
                 from_image: &image[..],
                 ..Default::default()
             }),
+            None,
             if cfg!(windows) {
                 None
             } else {
@@ -563,6 +565,7 @@ async fn mount_volume_container_test(docker: Docker) -> Result<(), Error> {
             from_image: &image[..],
             ..Default::default()
         }),
+        None,
         if cfg!(windows) {
             None
         } else {

--- a/tests/network_test.rs
+++ b/tests/network_test.rs
@@ -62,7 +62,7 @@ async fn create_network_test(docker: Docker) -> Result<(), Error> {
 
 async fn list_networks_test(docker: Docker) -> Result<(), Error> {
     let ipam_config = IPAMConfig {
-        subnet: Some("10.10.10.11/24"),
+        subnet: Some("10.10.10.10/24"),
         ..Default::default()
     };
 

--- a/tests/network_test.rs
+++ b/tests/network_test.rs
@@ -62,7 +62,7 @@ async fn create_network_test(docker: Docker) -> Result<(), Error> {
 
 async fn list_networks_test(docker: Docker) -> Result<(), Error> {
     let ipam_config = IPAMConfig {
-        subnet: Some("10.10.10.10/24"),
+        subnet: Some("10.10.10.11/24"),
         ..Default::default()
     };
 

--- a/tests/system_test.rs
+++ b/tests/system_test.rs
@@ -34,6 +34,7 @@ async fn events_test(docker: Docker) -> Result<(), Error> {
             from_image: &image[..],
             ..Default::default()
         }),
+        None,
         if cfg!(windows) {
             None
         } else {


### PR DESCRIPTION
Docker allows users to send a tar or tar.gz archive in the body of a `/images/create` API call. This can create completely custom images with any file system without using a Dockerfile. Bollard previously didn't support this API, since it always sends an empty body with requests to `/images/create` (`Docker::create_image`). This commit adds an optional argument to include the request body
with a new image.

There is also an example, `/examples/image_from_scratch.rs`, which shows how to upload a custom tar file with a new image.

The commit breaks backwards compatibility for the library since it adds a new argument to the `Docker::create_image` function that must be specified (although existing users would just need `None`). If there is a better way to add the functionality without causing an API change, let me know.