### PR TITLE
[WIP] Services support

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ bollard = "0.4"
 ```
 
 ## API
+
 ### Documentation
 
 [API docs](https://docs.rs/bollard/)
@@ -67,6 +68,7 @@ The client will connect to the OS specific handler it is compiled for.
 This is a convenience for localhost environment that should run on multiple
 operating systems.
 Use the `Docker::connect_with_local` method API to parameterise the interface.
+
 ```rust
 use bollard::Docker;
 Docker::connect_with_local_defaults();
@@ -134,7 +136,7 @@ Tokio is further below.
 
 First, check that the API is working with your server:
 
-```rust, no_run
+````rust, no_run
 use bollard::Docker;
 
 use futures_util::future::FutureExt;
@@ -174,7 +176,7 @@ async move {
         println!("-> {:?}", image);
     }
 };
-```
+````
 
 ### Streaming Stats
 
@@ -268,6 +270,7 @@ docker tag alpine localhost:5000/alpine
 docker push localhost:5000/hello-world:linux
 docker push localhost:5000/fussybeaver/uhttpd
 docker push localhost:5000/alpine
+docker swarm init
 REGISTRY_HTTP_ADDR=localhost:5000 cargo test -- --test-threads 1
 ```
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,14 +15,14 @@ build_script:
   - ps: Get-VMNetworkAdapter -VMName MobyLinuxVM | Set-VMNetworkAdapter -MacAddressSpoofing On
   - ps: Get-NetAdapter
   - ps: |
-        $ipv4 = (Test-Connection -ComputerName $env:ComputerName -Count 1).IPV4Address.IPAddressToString
-        Set-Item -path env:HOST_IP -value $ipv4
+      $ipv4 = (Test-Connection -ComputerName $env:ComputerName -Count 1).IPV4Address.IPAddressToString
+      Set-Item -path env:HOST_IP -value $ipv4
   - ipconfig
   - echo %HOST_IP%
   - ps: |
-        cd dockerfiles/windows/registry
-        docker build -t stefanscherer/registry-windows -f Dockerfile .
-        cd ../../../
+      cd dockerfiles/windows/registry
+      docker build -t stefanscherer/registry-windows -f Dockerfile .
+      cd ../../../
   - docker run -d -p 5000:5000 --restart=always --name registry stefanscherer/registry-windows
   - docker pull hello-world:nanoserver-sac2016
   - docker pull nanoserver/iis
@@ -33,6 +33,7 @@ build_script:
   - docker push localhost:5000/hello-world:nanoserver
   - docker push localhost:5000/nanoserver/iis
   - docker push localhost:5000/microsoft/nanoserver
+  - docker swarm init --advertise-addr "10.0.75.1"
   - cargo build --verbose
 
 test_script:

--- a/dockerfiles/bin/run_integration_tests.sh
+++ b/dockerfiles/bin/run_integration_tests.sh
@@ -19,4 +19,5 @@ docker tag alpine localhost:5000/alpine
 docker push localhost:5000/hello-world:linux
 docker push localhost:5000/fussybeaver/uhttpd
 docker push localhost:5000/alpine
+docker swarm init
 docker run -e RUST_LOG=bollard=debug -e REGISTRY_PASSWORD -e REGISTRY_HTTP_ADDR=localhost:5000 -v /var/run/docker.sock:/var/run/docker.sock -ti --rm bollard cargo test -- --test-threads 1

--- a/src/docker.rs
+++ b/src/docker.rs
@@ -15,13 +15,13 @@ use arrayvec::ArrayVec;
 use dirs;
 use futures_core::Stream;
 use futures_util::future::FutureExt;
-use futures_util::stream;
 use futures_util::future::TryFutureExt;
+use futures_util::stream;
 use futures_util::stream::TryStreamExt;
 use http::header::CONTENT_TYPE;
 use http::request::Builder;
 use hyper::client::HttpConnector;
-use hyper::{self, Body, body::Bytes, Client, Method, Request, Response, StatusCode};
+use hyper::{self, body::Bytes, Body, Client, Method, Request, Response, StatusCode};
 #[cfg(feature = "openssl")]
 use hyper_openssl::HttpsConnector;
 #[cfg(feature = "tls")]

--- a/src/image.rs
+++ b/src/image.rs
@@ -7,7 +7,7 @@ use futures_core::Stream;
 use futures_util::{stream, stream::StreamExt};
 use http::header::CONTENT_TYPE;
 use http::request::Builder;
-use hyper::{Body, body::Bytes, Method};
+use hyper::{body::Bytes, Body, Method};
 use serde::Serialize;
 use serde_json;
 
@@ -1057,8 +1057,8 @@ impl Docker {
                     Docker::transpose_option(options.map(|o| o.into_array())),
                     match root_fs {
                         Some(body) => Ok(body),
-                        None => Ok(Body::empty())
-                    }
+                        None => Ok(Body::empty()),
+                    },
                 );
                 self.process_into_stream(req).boxed()
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -321,6 +321,8 @@ pub mod image;
 mod named_pipe;
 pub mod network;
 mod read;
+pub mod service;
+pub mod service_models;
 pub mod system;
 mod uri;
 pub mod volume;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -322,7 +322,7 @@ mod named_pipe;
 pub mod network;
 mod read;
 pub mod service;
-pub mod service_models;
+mod service_models;
 pub mod system;
 mod uri;
 pub mod volume;

--- a/src/service.rs
+++ b/src/service.rs
@@ -142,10 +142,10 @@ impl<'a> InspectServiceQueryParams<&'a str, &'a str> for InspectServiceOptions {
 #[derive(Debug, Copy, Clone, Default)]
 pub struct UpdateServiceOptions {
     /// The version number of the service object being updated. This is required to avoid conflicting writes. This version number should be the value as currently set on the service before the update.
-    pub version: u64,
+    pub version: ObjectVersion,
     /// If the X-Registry-Auth header is not specified, this parameter indicates whether to use registry authorization credentials from the current or the previous spec.
     pub registry_auth_from_previous: bool,
-    /// Set to this parameter to true to cause a server-side rollback to the previous service spec. The supplied spec will be ignored in this case.
+    /// Set this parameter to true to cause a server-side rollback to the previous service spec. The supplied spec will be ignored in this case.
     pub rollback: bool,
 }
 
@@ -162,7 +162,7 @@ where
 impl<'a> UpdateServiceQueryParams<&'a str, String> for UpdateServiceOptions {
     fn into_array(self) -> Result<ArrayVec<[(&'a str, String); 3]>, Error> {
         Ok(ArrayVec::from([
-            ("version", self.version.to_string()),
+            ("version", self.version.index.to_string()),
             (
                 "registryAuthFrom",
                 if self.registry_auth_from_previous {
@@ -446,7 +446,7 @@ impl Docker {
     ///     let current_version = docker.inspect_service(
     ///         service_name,
     ///         None::<InspectServiceOptions>
-    ///     ).await?.version.index;
+    ///     ).await?.version;
     ///     let service = ServiceSpec::<&str> {
     ///         mode: Some(ServiceSpecMode::Replicated {
     ///             replicas: 0,

--- a/src/service.rs
+++ b/src/service.rs
@@ -1,0 +1,150 @@
+use super::Docker;
+use crate::errors::Error;
+use crate::errors::ErrorKind::JsonSerializeError;
+use crate::service_models::Service;
+use crate::service_models::ServiceSpec;
+use arrayvec::ArrayVec;
+use http::request::Builder;
+use hyper::{Body, Method};
+use serde_json;
+use std::{collections::HashMap, hash::Hash};
+
+/// Parameters used in the [List Service API](../struct.Docker.html#method.list_services)
+///
+/// ## Examples
+///
+/// ```rust
+/// use bollard::container::ListServicesOptions;
+///
+/// use std::collections::HashMap;
+/// use std::default::Default;
+///
+/// let mut filters = HashMap::new();
+/// filters.insert("mode", vec!("global"));
+///
+/// ListServicesOptions{
+///     filters: filters,
+///     ..Default::default()
+/// };
+/// ```
+///
+/// ```rust
+/// # use bollard::container::ListContainersOptions;
+/// # use std::default::Default;
+/// ListContainersOptions::<String>{
+///     ..Default::default()
+/// };
+/// ```
+#[derive(Debug, Clone, Default)]
+pub struct ListServicesOptions<T>
+where
+    T: AsRef<str> + Eq + Hash,
+{
+    /// Filters to process on the service list, encoded as JSON. Available filters:
+    ///  - `id`=`<ID>` a services's ID
+    ///  - `label`=`key` or `label`=`"key=value"` of a service label
+    ///  - `mode`=`["replicated"|"global"] a service's scheduling mode
+    ///  - `name`=`<name>` a services's name
+    pub filters: HashMap<T, Vec<T>>,
+    /// hidden field to restrict to usage with `..Default::default()`
+    /// so that additional fields could be added later without breaking api
+    hidden: (),
+}
+
+#[allow(missing_docs)]
+/// Trait providing implementations for [List Services Options](struct.ListContainersOptions.html)
+/// struct.
+pub trait ListServicesQueryParams<K, V>
+where
+    K: AsRef<str>,
+    V: AsRef<str>,
+{
+    fn into_array(self) -> Result<ArrayVec<[(K, V); 1]>, Error>;
+}
+
+impl<'a, T: AsRef<str> + Eq + Hash> ListServicesQueryParams<&'a str, String>
+    for ListServicesOptions<T>
+where
+    T: ::serde::Serialize,
+{
+    fn into_array(self) -> Result<ArrayVec<[(&'a str, String); 1]>, Error> {
+        Ok(ArrayVec::from([(
+            "filters",
+            serde_json::to_string(&self.filters).map_err(|e| JsonSerializeError { err: e })?,
+        )]))
+    }
+}
+
+impl Docker {
+    /// ---
+    ///
+    /// # List Services
+    ///
+    /// Returns a list of services.
+    ///
+    /// # Arguments
+    ///
+    ///  - Optional [ListServicesOptions](service/struct.ListServicesOptions.html) struct.
+    ///
+    /// # Returns
+    ///
+    ///  - Vector of [APIServices](service/struct.APIServices.html), wrapped in a Future.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use bollard::Docker;
+    /// # let docker = Docker::connect_with_http_defaults().unwrap();
+    /// use bollard::container::{ListServicesOptions};
+    ///
+    /// use std::collections::HashMap;
+    /// use std::default::Default;
+    ///
+    /// let mut filters = HashMap::new();
+    /// filters.insert("mode", vec!("global"));
+    ///
+    /// let options = Some(ListServicesOptions{
+    ///     filters: filters,
+    ///     ..Default::default()
+    /// });
+    ///
+    /// docker.list_services(options);
+    /// ```
+    pub async fn list_services<T, K>(&self, options: Option<T>) -> Result<Vec<Service>, Error>
+    where
+        T: ListServicesQueryParams<K, String>,
+        K: AsRef<str>,
+    {
+        let url = "/services";
+
+        let req = self.build_request(
+            url,
+            Builder::new().method(Method::GET),
+            Docker::transpose_option(options.map(|o| o.into_array())),
+            Ok(Body::empty()),
+        );
+
+        self.process_into_value(req).await
+    }
+
+    pub async fn create_service<T, K>(
+        &self,
+        service_spec: ServiceSpec,
+        options: Option<T>,
+    ) -> Result<Vec<Service>, Error>
+    where
+        T: ListServicesQueryParams<K, String>,
+        K: AsRef<str>,
+    {
+        let url = "/services/create";
+
+        let req = self.build_request(
+            url,
+            Builder::new().method(Method::POST),
+            Docker::transpose_option(options.map(|o| o.into_array())),
+            Docker::serialize_payload(Some(service_spec)),
+        );
+
+        self.process_into_value(req).await
+    }
+}

--- a/src/service.rs
+++ b/src/service.rs
@@ -81,7 +81,7 @@ where
 pub struct ServiceCreateResponse {
     /// The ID of the created service.
     #[serde(rename = "ID")]
-    pub id: Option<String>,
+    pub id: String,
 
     /// Optional warning message
     pub warning: Option<String>,

--- a/src/service.rs
+++ b/src/service.rs
@@ -1,15 +1,17 @@
 //! Service API: manage and inspect docker services within a swarm
 
+pub use crate::service_models::*;
+
 use super::Docker;
 use crate::auth::DockerCredentials;
+use crate::docker::{FALSE_STR, TRUE_STR};
 use crate::errors::Error;
 use crate::errors::ErrorKind::JsonSerializeError;
-use crate::service_models::Service;
-use crate::service_models::{ServiceCreateResponse, ServiceSpec};
 use arrayvec::ArrayVec;
 use http::header::CONTENT_TYPE;
 use http::request::Builder;
 use hyper::{Body, Method};
+use serde::Serialize;
 use serde_json;
 use std::{collections::HashMap, hash::Hash};
 
@@ -18,26 +20,23 @@ use std::{collections::HashMap, hash::Hash};
 /// ## Examples
 ///
 /// ```rust
-/// use bollard::container::ListServicesOptions;
-///
-/// use std::collections::HashMap;
-/// use std::default::Default;
+/// # use std::collections::HashMap;
+/// # use std::default::Default;
+/// use bollard::service::ListServicesOptions;
 ///
 /// let mut filters = HashMap::new();
 /// filters.insert("mode", vec!("global"));
 ///
 /// ListServicesOptions{
 ///     filters: filters,
-///     ..Default::default()
 /// };
 /// ```
 ///
 /// ```rust
-/// # use bollard::container::ListContainersOptions;
+/// # use bollard::service::ListServicesOptions;
 /// # use std::default::Default;
-/// ListContainersOptions::<String>{
-///     ..Default::default()
-/// };
+///
+/// let options: ListServicesOptions<&str> = Default::default();
 /// ```
 #[derive(Debug, Clone, Default)]
 pub struct ListServicesOptions<T>
@@ -50,9 +49,6 @@ where
     ///  - `mode`=`["replicated"|"global"] a service's scheduling mode
     ///  - `name`=`<name>` a services's name
     pub filters: HashMap<T, Vec<T>>,
-    /// hidden field to restrict to usage with `..Default::default()`
-    /// so that additional fields could be added later without breaking api
-    hidden: (),
 }
 
 #[allow(missing_docs)]
@@ -79,6 +75,119 @@ where
     }
 }
 
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+#[allow(missing_docs)]
+pub struct ServiceCreateResponse {
+    /// The ID of the created service.
+    #[serde(rename = "ID")]
+    pub id: Option<String>,
+
+    /// Optional warning message
+    pub warning: Option<String>,
+}
+
+/// Parameters used in the [Inspect Service API](../struct.Docker.html#method.inspect_service)
+///
+/// ## Examples
+///
+/// ```rust
+/// use bollard::service::InspectServiceOptions;
+///
+/// InspectServiceOptions{
+///     insert_defaults: true,
+/// };
+/// ```
+#[derive(Debug, Copy, Clone, Default)]
+pub struct InspectServiceOptions {
+    /// Fill empty fields with default values.
+    pub insert_defaults: bool,
+}
+
+/// Trait providing implementations for [Inspect Service Options](struct.InspectServiceOptions.html).
+#[allow(missing_docs)]
+pub trait InspectServiceQueryParams<K, V>
+where
+    K: AsRef<str>,
+    V: AsRef<str>,
+{
+    fn into_array(self) -> Result<ArrayVec<[(K, V); 1]>, Error>;
+}
+
+impl<'a> InspectServiceQueryParams<&'a str, &'a str> for InspectServiceOptions {
+    fn into_array(self) -> Result<ArrayVec<[(&'a str, &'a str); 1]>, Error> {
+        Ok(ArrayVec::from([(
+            "insertDefaults",
+            if self.insert_defaults {
+                TRUE_STR
+            } else {
+                FALSE_STR
+            },
+        )]))
+    }
+}
+
+/// Parameters used in the [Update Service API](../struct.Docker.html#method.update_service)
+///
+/// ## Examples
+///
+/// ```rust
+/// use bollard::service::UpdateServiceOptions;
+///
+/// UpdateServiceOptions{
+///     version: 1234,
+///     ..Default::default()
+/// };
+/// ```
+#[derive(Debug, Copy, Clone, Default)]
+pub struct UpdateServiceOptions {
+    /// The version number of the service object being updated. This is required to avoid conflicting writes. This version number should be the value as currently set on the service before the update.
+    pub version: u64,
+    /// If the X-Registry-Auth header is not specified, this parameter indicates whether to use registry authorization credentials from the current or the previous spec.
+    pub registry_auth_from_previous: bool,
+    /// Set to this parameter to true to cause a server-side rollback to the previous service spec. The supplied spec will be ignored in this case.
+    pub rollback: bool,
+}
+
+/// Trait providing implementations for [Update Service Options](struct.UpdateServiceOptions.html).
+#[allow(missing_docs)]
+pub trait UpdateServiceQueryParams<K, V>
+where
+    K: AsRef<str>,
+    V: AsRef<str>,
+{
+    fn into_array(self) -> Result<ArrayVec<[(K, V); 3]>, Error>;
+}
+
+impl<'a> UpdateServiceQueryParams<&'a str, String> for UpdateServiceOptions {
+    fn into_array(self) -> Result<ArrayVec<[(&'a str, String); 3]>, Error> {
+        Ok(ArrayVec::from([
+            ("version", self.version.to_string()),
+            (
+                "registryAuthFrom",
+                if self.registry_auth_from_previous {
+                    "previous-spec"
+                } else {
+                    "spec"
+                }
+                .to_string(),
+            ),
+            (
+                "rollback",
+                if self.rollback { "previous" } else { "" }.to_string(),
+            ),
+        ]))
+    }
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+#[allow(missing_docs)]
+pub struct ServiceUpdateResponse {
+    /// Optional warning message
+    pub warning: Option<String>,
+}
+
 impl Docker {
     /// ---
     ///
@@ -99,7 +208,7 @@ impl Docker {
     /// ```rust
     /// # use bollard::Docker;
     /// # let docker = Docker::connect_with_http_defaults().unwrap();
-    /// use bollard::container::{ListServicesOptions};
+    /// use bollard::service::ListServicesOptions;
     ///
     /// use std::collections::HashMap;
     /// use std::default::Default;
@@ -114,7 +223,10 @@ impl Docker {
     ///
     /// docker.list_services(options);
     /// ```
-    pub async fn list_services<T, K>(&self, options: Option<T>) -> Result<Vec<Service>, Error>
+    pub async fn list_services<T, K>(
+        &self,
+        options: Option<T>,
+    ) -> Result<Vec<Service<String>>, Error>
     where
         T: ListServicesQueryParams<K, String>,
         K: AsRef<str>,
@@ -140,7 +252,6 @@ impl Docker {
     /// # Arguments
     ///
     ///  - [ServiceSpec](service_models/struct.ServiceSpec.html) struct.
-    ///  - Optional [ListServicesOptions](service/struct.ListServicesOptions.html) struct.
     ///  - Optional [Docker Credentials](auth/struct.DockerCredentials.html) struct.
     ///
     /// # Returns
@@ -152,31 +263,41 @@ impl Docker {
     ///
     /// ```rust
     /// # use bollard::Docker;
+    /// # use std::collections::HashMap;
+    /// # use std::default::Default;
     /// # let docker = Docker::connect_with_http_defaults().unwrap();
-    /// use bollard::container::{ListServicesOptions};
+    /// use bollard::service::{
+    ///     ServiceSpec,
+    ///     ServiceSpecMode,
+    ///     TaskSpec,
+    ///     TaskSpecContainerSpec
+    /// };
     ///
-    /// use std::collections::HashMap;
-    /// use std::default::Default;
-    ///
-    /// let mut filters = HashMap::new();
-    /// filters.insert("mode", vec!("global"));
-    ///
-    /// let options = Some(ListServicesOptions{
-    ///     filters: filters,
+    /// let service = ServiceSpec {
+    ///     name: "my-service",
+    ///     mode: Some(ServiceSpecMode::Replicated {
+    ///         replicas: 2
+    ///     }),
+    ///     task_template: TaskSpec {
+    ///         container_spec: Some(TaskSpecContainerSpec {
+    ///             image: Some("hello-world"),
+    ///             ..Default::default()
+    ///         }),
+    ///         ..Default::default()
+    ///     },
     ///     ..Default::default()
-    /// });
+    /// };
+    /// let credentials = None;
     ///
-    /// docker.create_service(options);
+    /// docker.create_service(service, credentials);
     /// ```
-    pub async fn create_service<T, K>(
+    pub async fn create_service<Z>(
         &self,
-        service_spec: ServiceSpec,
-        options: Option<T>,
+        service_spec: ServiceSpec<Z>,
         credentials: Option<DockerCredentials>,
     ) -> Result<ServiceCreateResponse, Error>
     where
-        T: ListServicesQueryParams<K, String>,
-        K: AsRef<str>,
+        Z: AsRef<str> + Eq + Hash + Serialize,
     {
         let url = "/services/create";
 
@@ -184,13 +305,188 @@ impl Docker {
             ..Default::default()
         })) {
             Ok(ser_cred) => {
-                let req = self.build_request(
+                let req = self.build_request::<_, String, String>(
                     url,
                     Builder::new()
                         .method(Method::POST)
                         .header(CONTENT_TYPE, "application/json")
                         .header("X-Registry-Auth", base64::encode(&ser_cred)),
-                    Docker::transpose_option(options.map(|o| o.into_array())),
+                    Ok(None::<ArrayVec<[(_, _); 0]>>),
+                    Docker::serialize_payload(Some(service_spec)),
+                );
+
+                self.process_into_value(req).await
+            }
+            Err(e) => Err(JsonSerializeError { err: e }.into()),
+        }
+    }
+
+    /// ---
+    ///
+    /// # Inspect Service
+    ///
+    /// Inspect a service.
+    ///
+    /// # Arguments
+    ///
+    ///  - Service name or id as a string slice.
+    ///  - Optional [Inspect Service Options](service_models/struct.InspectServiceOptions.struct) struct.
+    ///
+    /// # Returns
+    ///
+    ///  - [Service](service_models/struct.Service.html), wrapped in a Future.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use bollard::Docker;
+    /// # let docker = Docker::connect_with_http_defaults().unwrap();
+    /// use bollard::service::InspectServiceOptions;
+    ///
+    /// let options = Some(InspectServiceOptions{
+    ///     insert_defaults: true,
+    /// });
+    ///
+    /// docker.inspect_service("my-service", options);
+    /// ```
+    pub async fn inspect_service<T, K, V>(
+        &self,
+        service_name: &str,
+        options: Option<T>,
+    ) -> Result<Service<String>, Error>
+    where
+        T: InspectServiceQueryParams<K, V>,
+        K: AsRef<str>,
+        V: AsRef<str>,
+    {
+        let url = format!("/services/{}", service_name);
+
+        let req = self.build_request(
+            &url,
+            Builder::new().method(Method::GET),
+            Docker::transpose_option(options.map(|o| o.into_array())),
+            Ok(Body::empty()),
+        );
+
+        self.process_into_value(req).await
+    }
+
+    /// ---
+    ///
+    /// # Delete Service
+    ///
+    /// Delete a service.
+    ///
+    /// # Arguments
+    ///
+    /// - Service name or id as a string slice.
+    ///
+    /// # Returns
+    ///
+    ///  - unit type `()`, wrapped in a Future.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use bollard::Docker;
+    /// # let docker = Docker::connect_with_http_defaults().unwrap();
+    ///
+    /// docker.delete_service("my-service");
+    /// ```
+    pub async fn delete_service(&self, service_name: &str) -> Result<(), Error> {
+        let url = format!("/services/{}", service_name);
+
+        let req = self.build_request::<_, String, String>(
+            &url,
+            Builder::new().method(Method::DELETE),
+            Ok(None::<ArrayVec<[(_, _); 0]>>),
+            Ok(Body::empty()),
+        );
+
+        self.process_into_unit(req).await
+    }
+
+    /// ---
+    ///
+    /// # Update Service
+    ///
+    /// Update an existing service
+    ///
+    /// # Arguments
+    ///
+    ///  - Service name or id as a string slice.
+    ///  - [ServiceSpec](service_models/struct.ServiceSpec.html) struct.
+    ///  - [UpdateServiceOptions](service/struct.UpdateServiceOptions.html) struct.
+    ///  - Optional [Docker Credentials](auth/struct.DockerCredentials.html) struct.
+    ///
+    /// # Returns
+    ///
+    ///  - A [Service Update Response](service_models/struct.ServiceUpdateResponse.html) struct,
+    ///  wrapped in a Future.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use bollard::Docker;
+    /// # let docker = Docker::connect_with_http_defaults().unwrap();
+    /// use bollard::service::{
+    ///     InspectServiceOptions,
+    ///     ServiceSpec,
+    ///     ServiceSpecMode,
+    ///     TaskSpec,
+    ///     TaskSpecContainerSpec,
+    ///     UpdateServiceOptions,
+    /// };
+    ///
+    /// use std::collections::HashMap;
+    /// use std::default::Default;
+    ///
+    /// let result = async move {
+    ///     let service_name = "my-service";
+    ///     let current_version = docker.inspect_service(
+    ///         service_name,
+    ///         None::<InspectServiceOptions>
+    ///     ).await?.version.index;
+    ///     let service = ServiceSpec::<&str> {
+    ///         mode: Some(ServiceSpecMode::Replicated {
+    ///             replicas: 0,
+    ///         }),
+    ///         ..Default::default()
+    ///     };
+    ///     let options = UpdateServiceOptions {
+    ///         version: current_version,
+    ///         ..Default::default()
+    ///     };
+    ///     let credentials = None;
+    ///
+    ///     docker.update_service("my-service", service, options, credentials).await
+    /// };
+    /// ```
+    pub async fn update_service<T, K, Z>(
+        &self,
+        service_name: &str,
+        service_spec: ServiceSpec<Z>,
+        options: T,
+        credentials: Option<DockerCredentials>,
+    ) -> Result<ServiceUpdateResponse, Error>
+    where
+        T: UpdateServiceQueryParams<K, String>,
+        K: AsRef<str>,
+        Z: AsRef<str> + Eq + Hash + Serialize,
+    {
+        let url = format!("/services/{}/update", service_name);
+
+        match serde_json::to_string(&credentials.unwrap_or_else(|| DockerCredentials {
+            ..Default::default()
+        })) {
+            Ok(ser_cred) => {
+                let req = self.build_request(
+                    &url,
+                    Builder::new()
+                        .method(Method::POST)
+                        .header(CONTENT_TYPE, "application/json")
+                        .header("X-Registry-Auth", base64::encode(&ser_cred)),
+                    Docker::transpose_option(Some(options.into_array())),
                     Docker::serialize_payload(Some(service_spec)),
                 );
 

--- a/src/service.rs
+++ b/src/service.rs
@@ -132,10 +132,10 @@ impl<'a> InspectServiceQueryParams<&'a str, &'a str> for InspectServiceOptions {
 /// ## Examples
 ///
 /// ```rust
-/// use bollard::service::UpdateServiceOptions;
+/// use bollard::service::{ObjectVersion, UpdateServiceOptions};
 ///
-/// UpdateServiceOptions{
-///     version: 1234,
+/// UpdateServiceOptions {
+///     version: ObjectVersion { index: 1234 },
 ///     ..Default::default()
 /// };
 /// ```

--- a/src/service_models.rs
+++ b/src/service_models.rs
@@ -1,3 +1,5 @@
+//! Service API object definitions
+
 use chrono::Utc;
 use chrono::{serde::ts_seconds, DateTime};
 use std::collections::HashMap;
@@ -648,4 +650,16 @@ pub enum ServiceUpdateStatusState {
     Updating,
     Paused,
     Completed,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+#[allow(missing_docs)]
+pub struct ServiceCreateResponse {
+    /// The ID of the created service.
+    #[serde(rename = "ID")]
+    pub id: Option<String>,
+
+    /// Optional warning message
+    pub warning: Option<String>,
 }

--- a/src/service_models.rs
+++ b/src/service_models.rs
@@ -1,7 +1,7 @@
 //! Service API object definitions
 
+use chrono::DateTime;
 use chrono::Utc;
-use chrono::{serde::ts_seconds, DateTime};
 use std::{collections::HashMap, hash::Hash};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -731,9 +731,7 @@ where
     T: AsRef<str> + Eq + Hash,
 {
     pub state: ServiceUpdateStatusState,
-    #[serde(with = "ts_seconds")]
     pub started_at: DateTime<Utc>,
-    #[serde(with = "ts_seconds")]
     pub completed_at: DateTime<Utc>,
     pub message: T,
 }
@@ -746,4 +744,3 @@ pub enum ServiceUpdateStatusState {
     Paused,
     Completed,
 }
-

--- a/src/service_models.rs
+++ b/src/service_models.rs
@@ -1,0 +1,651 @@
+use chrono::Utc;
+use chrono::{serde::ts_seconds, DateTime};
+use std::collections::HashMap;
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+#[allow(missing_docs)]
+pub struct Service {
+    #[serde(rename = "ID")]
+    pub id: String,
+    pub version: ObjectVersion,
+    #[serde(with = "ts_seconds")]
+    pub created_at: DateTime<Utc>,
+    #[serde(with = "ts_seconds")]
+    pub updated_at: DateTime<Utc>,
+    pub spec: ServiceSpec,
+    pub endpoint: ServiceEndpoint,
+    pub update_status: ServiceUpdateStatus,
+}
+
+/// The version number of the object such as node, service, etc. This is needed to avoid conflicting writes. The client must send the version number along with the modified specification when updating these objects. This approach ensures safe concurrency and determinism in that the change on the object may not be applied if the version number has changed from the last read. In other words, if two update requests specify the same base version, only one of the requests can succeed. As a result, two separate update requests that happen at the same time will not unintentionally overwrite each other.
+#[derive(Debug, Copy, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+#[allow(missing_docs)]
+pub struct ObjectVersion {
+    pub index: u64,
+}
+
+/// User modifiable configuration for a service.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+#[allow(missing_docs)]
+pub struct ServiceSpec {
+    /// Name of the service.
+    pub name: Option<String>,
+    /// User-defined key/value metadata.
+    pub labels: Option<HashMap<String, String>>,
+    pub task_template: Option<TaskSpec>,
+    pub mode: Option<ServiceSpecMode>,
+    pub update_config: Option<ServiceSpecUpdateConfig>,
+    pub rollback_config: Option<ServiceSpecUpdateConfig>,
+    /// Specifies which networks the service should attach to.
+    pub networks: Option<Vec<NetworkAttachmentConfig>>,
+    pub endpoint_spec: Option<EndpointSpec>,
+}
+
+/// User modifiable task configuration.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+#[allow(missing_docs)]
+pub struct TaskSpec {
+    pub plugin_spec: Option<TaskSpecPluginSpec>,
+    pub container_spec: Option<TaskSpecContainerSpec>,
+    pub network_attachment_spec: Option<TaskSpecNetworkAttachmentSpec>,
+    pub resources: Option<TaskSpecResources>,
+    pub restart_policy: Option<TaskSpecRestartPolicy>,
+    pub placement: Option<TaskSpecPlacement>,
+    /// A counter that triggers an update even if no relevant parameters have been changed.
+    pub force_update: Option<isize>,
+    /// Runtime is the type of runtime specified for the task executor.
+    pub runtime: Option<String>,
+    /// Specifies which networks the service should attach to.
+    pub networks: Option<Vec<NetworkAttachmentConfig>>,
+    pub log_driver: Option<TaskSpecLogDriver>,
+}
+
+/// Plugin spec for the service.  *(Experimental release only.)*  <p><br /></p>  > **Note**: ContainerSpec, NetworkAttachmentSpec, and PluginSpec are > mutually exclusive. PluginSpec is only used when the Runtime field > is set to `plugin`. NetworkAttachmentSpec is used when the Runtime > field is set to `attachment`.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+#[allow(missing_docs)]
+pub struct TaskSpecPluginSpec {
+    /// The name or 'alias' to use for the plugin.
+    pub name: Option<String>,
+    /// The plugin image reference to use.
+    pub remote: Option<String>,
+    /// Disable the plugin once scheduled.
+    pub disabled: Option<bool>,
+    pub plugin_privilege: Option<Vec<Body>>,
+}
+
+/// Describes a permission accepted by the user upon installing the plugin.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+#[allow(missing_docs)]
+pub struct Body {
+    pub name: Option<String>,
+    pub description: Option<String>,
+    pub value: Option<Vec<String>>,
+}
+
+/// Container spec for the service.  <p><br /></p>  > **Note**: ContainerSpec, NetworkAttachmentSpec, and PluginSpec are > mutually exclusive. PluginSpec is only used when the Runtime field > is set to `plugin`. NetworkAttachmentSpec is used when the Runtime > field is set to `attachment`.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+#[allow(missing_docs)]
+pub struct TaskSpecContainerSpec {
+    /// The image name to use for the container
+    pub image: Option<String>,
+    /// User-defined key/value data.
+    pub labels: Option<HashMap<String, String>>,
+    /// The command to be run in the image.
+    pub command: Option<Vec<String>>,
+    /// Arguments to the command.
+    pub args: Option<Vec<String>>,
+    /// The hostname to use for the container, as a valid RFC 1123 hostname.
+    pub hostname: Option<String>,
+    /// A list of environment variables in the form `VAR=value`.
+    pub env: Option<Vec<String>>,
+    /// The working directory for commands to run in.
+    pub dir: Option<String>,
+    /// The user inside the container.
+    pub user: Option<String>,
+    /// A list of additional groups that the container process will run as.
+    pub groups: Option<Vec<String>>,
+    pub privileges: Option<TaskSpecContainerSpecPrivileges>,
+    /// Whether a pseudo-TTY should be allocated.
+    #[serde(rename = "TTY")]
+    pub tty: Option<bool>,
+    /// Open `stdin`
+    pub open_stdin: Option<bool>,
+    /// Mount the container's root filesystem as read only.
+    pub read_only: Option<bool>,
+    /// Specification for mounts to be added to containers created as part of the service.
+    pub mounts: Option<Vec<Mount>>,
+    /// Signal to stop the container.
+    pub stop_signal: Option<String>,
+    /// Amount of time to wait for the container to terminate before forcefully killing it.
+    pub stop_grace_period: Option<i64>,
+    pub health_check: Option<HealthConfig>,
+    /// A list of hostname/IP mappings to add to the container's `hosts` file. The format of extra hosts is specified in the [hosts(5)](http://man7.org/linux/man-pages/man5/hosts.5.html) man page:      IP_address canonical_hostname [aliases...]
+    pub hosts: Option<Vec<String>>,
+    #[serde(rename = "DNSConfig")]
+    pub dns_config: Option<TaskSpecContainerSpecDnsConfig>,
+    /// Secrets contains references to zero or more secrets that will be exposed to the service.
+    pub secrets: Option<Vec<TaskSpecContainerSpecSecrets>>,
+    /// Configs contains references to zero or more configs that will be exposed to the service.
+    pub configs: Option<Vec<TaskSpecContainerSpecConfigs>>,
+    /// Isolation technology of the containers running the service. (Windows only)
+    pub isolation: Option<TaskSpecContainerSpecIsolation>,
+    /// Run an init inside the container that forwards signals and reaps processes. This field is omitted if empty, and the default (as configured on the daemon) is used.
+    pub init: Option<bool>,
+    /// Set kernel namedspaced parameters (sysctls) in the container. The Sysctls option on services accepts the same sysctls as the are supported on containers. Note that while the same sysctls are supported, no guarantees or checks are made about their suitability for a clustered environment, and it's up to the user to determine whether a given sysctl will work properly in a Service.
+    pub sysctls: Option<HashMap<String, String>>,
+}
+
+/// Isolation technology of the containers running the service. (Windows only)
+#[derive(Debug, Copy, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+#[allow(missing_docs)]
+pub enum TaskSpecContainerSpecIsolation {
+    Default,
+    Process,
+    Hyperv,
+}
+
+/// Security options for the container
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+#[allow(missing_docs)]
+pub struct TaskSpecContainerSpecPrivileges {
+    pub credential_spec: Option<TaskSpecContainerSpecPrivilegesCredentialSpec>,
+    #[serde(rename = "SELinuxContext")]
+    pub se_linux_context: Option<TaskSpecContainerSpecPrivilegesSeLinuxContext>,
+}
+
+/// CredentialSpec for managed service account (Windows only)
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+#[allow(missing_docs)]
+pub struct TaskSpecContainerSpecPrivilegesCredentialSpec {
+    /// Load credential spec from a Swarm Config with the given ID. The specified config must also be present in the Configs field with the Runtime property set.  <p><br /></p>   > **Note**: `CredentialSpec.File`, `CredentialSpec.Registry`, and `CredentialSpec.Config` are mutually exclusive.
+    pub config: Option<String>,
+    /// Load credential spec from this file. The file is read by the daemon, and must be present in the `CredentialSpecs` subdirectory in the docker data directory, which defaults to `C:\\ProgramData\\Docker\\` on Windows.  For example, specifying `spec.json` loads `C:\\ProgramData\\Docker\\CredentialSpecs\\spec.json`.  <p><br /></p>  > **Note**: `CredentialSpec.File`, `CredentialSpec.Registry`, and `CredentialSpec.Config` are mutually exclusive.
+    pub file: Option<String>,
+    /// Load credential spec from this value in the Windows registry. The specified registry value must be located in:  `HKLM\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Virtualization\\Containers\\CredentialSpecs`  <p><br /></p>   > **Note**: `CredentialSpec.File`, `CredentialSpec.Registry`, and `CredentialSpec.Config` are mutually exclusive.
+    pub registry: Option<String>,
+}
+
+/// SELinux labels of the container
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+#[allow(missing_docs)]
+pub struct TaskSpecContainerSpecPrivilegesSeLinuxContext {
+    /// Disable SELinux
+    pub disable: Option<bool>,
+    /// SELinux user label
+    pub user: Option<String>,
+    /// SELinux role label
+    pub role: Option<String>,
+    /// SELinux type label
+    #[serde(rename = "Type")]
+    pub _type: Option<String>,
+    /// SELinux level label
+    pub level: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+#[allow(missing_docs)]
+pub struct Mount {
+    /// Container path.
+    pub target: Option<String>,
+    /// Mount source (e.g. a volume name, a host path).
+    pub source: Option<String>,
+    /// The mount type. Available types:  - `bind` Mounts a file or directory from the host into the container. Must exist prior to creating the container. - `volume` Creates a volume with the given name and options (or uses a pre-existing volume with the same name and options). These are **not** removed when the container is removed. - `tmpfs` Create a tmpfs with the given options. The mount source cannot be specified for tmpfs. - `npipe` Mounts a named pipe from the host into the container. Must exist prior to creating the container.
+    #[serde(rename = "Type")]
+    pub _type: Option<MountType>,
+    /// Whether the mount should be read-only.
+    pub read_only: Option<bool>,
+    /// The consistency requirement for the mount: `default`, `consistent`, `cached`, or `delegated`.
+    pub consistency: Option<String>,
+    pub bind_options: Option<MountBindOptions>,
+    pub volume_options: Option<MountVolumeOptions>,
+    pub tmpfs_options: Option<MountTmpfsOptions>,
+}
+
+/// The mount type. Available types:  - `bind` Mounts a file or directory from the host into the container. Must exist prior to creating the container. - `volume` Creates a volume with the given name and options (or uses a pre-existing volume with the same name and options). These are **not** removed when the container is removed. - `tmpfs` Create a tmpfs with the given options. The mount source cannot be specified for tmpfs. - `npipe` Mounts a named pipe from the host into the container. Must exist prior to creating the container.
+#[derive(Debug, Copy, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+#[allow(missing_docs)]
+pub enum MountType {
+    Bind,
+    Volume,
+    Tmpfs,
+    Npipe,
+}
+
+/// Optional configuration for the `bind` type.
+#[derive(Debug, Copy, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+#[allow(missing_docs)]
+pub struct MountBindOptions {
+    /// A propagation mode with the value `[r]private`, `[r]shared`, or `[r]slave`.
+    pub propagation: Option<MountBindOptionsPropagation>,
+    /// Disable recursive bind mount.
+    pub non_recursive: Option<bool>,
+}
+
+/// A propagation mode with the value `[r]private`, `[r]shared`, or `[r]slave`.
+#[derive(Debug, Copy, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+#[allow(missing_docs)]
+pub enum MountBindOptionsPropagation {
+    Private,
+    #[serde(rename = "rprivate")]
+    RPrivate,
+    Shared,
+    #[serde(rename = "rshared")]
+    RShared,
+    Slave,
+    #[serde(rename = "rslave")]
+    RSlave,
+}
+
+/// Optional configuration for the `volume` type.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+#[allow(missing_docs)]
+pub struct MountVolumeOptions {
+    /// Populate volume with data from the target.
+    pub no_copy: Option<bool>,
+    /// User-defined key/value metadata.
+    pub labels: Option<HashMap<String, String>>,
+    pub driver_config: Option<MountVolumeOptionsDriverConfig>,
+}
+
+/// Map of driver specific options
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+#[allow(missing_docs)]
+pub struct MountVolumeOptionsDriverConfig {
+    /// Name of the driver to use to create the volume.
+    pub name: Option<String>,
+    /// key/value map of driver specific options.
+    pub options: Option<HashMap<String, String>>,
+}
+
+/// Optional configuration for the `tmpfs` type.
+#[derive(Debug, Copy, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+#[allow(missing_docs)]
+pub struct MountTmpfsOptions {
+    /// The size for the tmpfs mount in bytes.
+    pub size_bytes: Option<i64>,
+    /// The permission mode for the tmpfs mount in an integer.
+    pub mode: Option<isize>,
+}
+
+/// A test to perform to check that the container is healthy.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+#[allow(missing_docs)]
+pub struct HealthConfig {
+    /// The test to perform. Possible values are:  - `[]` inherit healthcheck from image or parent image - `[\"NONE\"]` disable healthcheck - `[\"CMD\", args...]` exec arguments directly - `[\"CMD-SHELL\", command]` run command with system's default shell
+    pub test: Option<Vec<String>>,
+    /// The time to wait between checks in nanoseconds. It should be 0 or at least 1000000 (1 ms). 0 means inherit.
+    pub interval: Option<isize>,
+    /// The time to wait before considering the check to have hung. It should be 0 or at least 1000000 (1 ms). 0 means inherit.
+    pub timeout: Option<isize>,
+    /// The number of consecutive failures needed to consider a container as unhealthy. 0 means inherit.
+    pub retries: Option<isize>,
+    /// Start period for the container to initialize before starting health-retries countdown in nanoseconds. It should be 0 or at least 1000000 (1 ms). 0 means inherit.
+    pub start_period: Option<isize>,
+}
+
+/// Specification for DNS related configurations in resolver configuration file (`resolv.conf`).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+#[allow(missing_docs)]
+pub struct TaskSpecContainerSpecDnsConfig {
+    /// The IP addresses of the name servers.
+    pub nameservers: Option<Vec<String>>,
+    /// A search list for host-name lookup.
+    pub search: Option<Vec<String>>,
+    /// A list of internal resolver variables to be modified (e.g., `debug`, `ndots:3`, etc.).
+    pub options: Option<Vec<String>>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+#[allow(missing_docs)]
+pub struct TaskSpecContainerSpecSecrets {
+    pub file: Option<TaskSpecContainerSpecFile>,
+    /// SecretID represents the ID of the specific secret that we're referencing.
+    #[serde(rename = "SecretID")]
+    pub secret_id: Option<String>,
+    /// SecretName is the name of the secret that this references, but this is just provided for lookup/display purposes. The secret in the reference will be identified by its ID.
+    pub secret_name: Option<String>,
+}
+
+/// File represents a specific target that is backed by a file.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+#[allow(missing_docs)]
+pub struct TaskSpecContainerSpecFile {
+    /// Name represents the final filename in the filesystem.
+    pub name: Option<String>,
+    /// UID represents the file UID.
+    #[serde(rename = "UID")]
+    pub uid: Option<String>,
+    /// GID represents the file GID.
+    #[serde(rename = "GID")]
+    pub gid: Option<String>,
+    /// Mode represents the FileMode of the file.
+    pub mode: Option<u32>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+#[allow(missing_docs)]
+pub struct TaskSpecContainerSpecConfigs {
+    pub file: Option<TaskSpecContainerSpecFile>,
+    /// Runtime represents a target that is not mounted into the container but is used by the task  <p><br /><p>  > **Note**: `Configs.File` and `Configs.Runtime` are mutually exclusive
+    pub runtime: Option<HashMap<(), ()>>,
+    /// ConfigID represents the ID of the specific config that we're referencing.
+    #[serde(rename = "ConfigID")]
+    pub config_id: Option<String>,
+    /// ConfigName is the name of the config that this references, but this is just provided for lookup/display purposes. The config in the reference will be identified by its ID.
+    pub config_name: Option<String>,
+}
+
+/// Read-only spec type for non-swarm containers attached to swarm overlay networks.  <p><br /></p>  > **Note**: ContainerSpec, NetworkAttachmentSpec, and PluginSpec are > mutually exclusive. PluginSpec is only used when the Runtime field > is set to `plugin`. NetworkAttachmentSpec is used when the Runtime > field is set to `attachment`.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+#[allow(missing_docs)]
+pub struct TaskSpecNetworkAttachmentSpec {
+    /// ID of the container represented by this task
+    #[serde(rename = "ContainerID")]
+    pub container_id: Option<String>,
+}
+
+/// Resource requirements which apply to each individual container created as part of the service.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+#[allow(missing_docs)]
+pub struct TaskSpecResources {
+    /// Define resources limits.
+    pub limits: Option<ResourceObject>,
+    /// Define resources reservation.
+    pub reservation: Option<ResourceObject>,
+}
+
+/// An object describing the resources which can be advertised by a node and requested by a task
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+#[allow(missing_docs)]
+pub struct ResourceObject {
+    #[serde(rename = "NanoCPUs")]
+    pub nano_cpus: Option<i64>,
+    pub memory_bytes: Option<i64>,
+    pub generic_resources: Option<Vec<GenericResources>>,
+}
+
+/// User-defined resources can be either Integer resources (e.g, `SSD=3`) or String resources (e.g, `GPU=UUID1`)
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+#[allow(missing_docs)]
+pub struct GenericResources {
+    pub named_resource_spec: Option<GenericResourcesNamedResourceSpec>,
+    pub discrete_resource_spec: Option<GenericResourcesDiscreteResourceSpec>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+#[allow(missing_docs)]
+pub struct GenericResourcesNamedResourceSpec {
+    pub kind: Option<String>,
+    pub value: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+#[allow(missing_docs)]
+pub struct GenericResourcesDiscreteResourceSpec {
+    pub kind: Option<String>,
+    pub value: Option<i64>,
+}
+
+/// Specification for the restart policy which applies to containers created as part of this service.
+#[derive(Debug, Copy, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+#[allow(missing_docs)]
+pub struct TaskSpecRestartPolicy {
+    /// Condition for restart.
+    pub condition: Option<TaskSpecRestartPolicyCondition>,
+    /// Delay between restart attempts.
+    pub delay: Option<i64>,
+    /// Maximum attempts to restart a given container before giving up (default value is 0, which is ignored).
+    pub max_attempts: Option<i64>,
+    /// Windows is the time window used to evaluate the restart policy (default value is 0, which is unbounded).
+    pub window: Option<i64>,
+}
+
+/// Condition for restart.
+#[derive(Debug, Copy, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+#[allow(missing_docs)]
+pub enum TaskSpecRestartPolicyCondition {
+    None,
+    OnFailure,
+    Any,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+#[allow(missing_docs)]
+pub struct TaskSpecPlacement {
+    /// An array of constraints.
+    pub constraints: Option<Vec<String>>,
+    /// Preferences provide a way to make the scheduler aware of factors such as topology. They are provided in order from highest to lowest precedence.
+    pub preferences: Option<Vec<TaskSpecPlacementPreferences>>,
+    /// Maximum number of replicas for per node (default value is 0, which is unlimited)
+    pub max_replicas: Option<i64>,
+    /// Platforms stores all the platforms that the service's image can run on. This field is used in the platform filter for scheduling. If empty, then the platform filter is off, meaning there are no scheduling restrictions.
+    pub platforms: Option<Vec<Platform>>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+#[allow(missing_docs)]
+pub struct TaskSpecPlacementPreferences {
+    pub spread: Option<TaskSpecPlacementSpread>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+#[allow(missing_docs)]
+pub struct TaskSpecPlacementSpread {
+    /// label descriptor, such as engine.labels.az
+    pub spread_descriptor: Option<String>,
+}
+
+/// Platform represents the platform (Arch/OS).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+#[allow(missing_docs)]
+pub struct Platform {
+    /// Architecture represents the hardware architecture (for example, `x86_64`).
+    pub architecture: Option<String>,
+    /// OS represents the Operating System (for example, `linux` or `windows`).
+    #[serde(rename = "OS")]
+    pub os: Option<String>,
+}
+
+/// Specifies how a service should be attached to a particular network.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+#[allow(missing_docs)]
+pub struct NetworkAttachmentConfig {
+    /// The target network for attachment. Must be a network name or ID.
+    pub target: Option<String>,
+    /// Discoverable alternate names for the service on this network.
+    pub aliases: Option<Vec<String>>,
+    /// Driver attachment options for the network target
+    pub driver_opts: Option<HashMap<String, String>>,
+}
+
+/// Specifies the log driver to use for tasks created from this spec. If not present, the default one for the swarm will be used, finally falling back to the engine default if not specified.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+#[allow(missing_docs)]
+pub struct TaskSpecLogDriver {
+    pub name: Option<String>,
+    pub options: Option<HashMap<String, String>>,
+}
+
+/// Scheduling mode for the service.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+#[allow(missing_docs)]
+pub struct ServiceSpecMode {
+    pub replicated: Option<ServiceSpecModeReplicated>,
+    pub global: Option<HashMap<(), ()>>,
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+#[allow(missing_docs)]
+pub struct ServiceSpecModeReplicated {
+    pub replicas: Option<i64>,
+}
+
+/// Specification for the update or rollback strategy of the service.
+#[derive(Debug, Copy, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+#[allow(missing_docs)]
+pub struct ServiceSpecUpdateConfig {
+    /// Maximum number of tasks to be updated in one iteration (0 means unlimited parallelism).
+    pub parallelism: Option<i64>,
+    /// Amount of time between updates, in nanoseconds.
+    pub delay: Option<i64>,
+    /// Action to take if an updated task fails to run, or stops running during the update.
+    pub failure_action: Option<ServiceSpecUpdateConfigFailureAction>,
+    /// Amount of time to monitor each updated task for failures, in nanoseconds.
+    pub monitor: Option<i64>,
+    /// The fraction of tasks that may fail during an update before the failure action is invoked, specified as a floating point number between 0 and 1.
+    pub max_failure_ratio: Option<f64>,
+    /// The order of operations when rolling out an updated task. Either the old task is shut down before the new task is started, or the new task is started before the old task is shut down.
+    pub order: Option<ServiceSpecUpdateConfigOrder>,
+}
+
+/// Action to take if an updated task fails to run, or stops running during the update.
+#[derive(Debug, Copy, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+#[allow(missing_docs)]
+pub enum ServiceSpecUpdateConfigFailureAction {
+    Continue,
+    Pause,
+    Rollback,
+}
+
+/// The order of operations when rolling out an updated task. Either the old task is shut down before the new task is started, or the new task is started before the old task is shut down.
+#[derive(Debug, Copy, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+#[allow(missing_docs)]
+pub enum ServiceSpecUpdateConfigOrder {
+    StopFirst,
+    StartFirst,
+}
+
+/// Properties that can be configured to access and load balance a service.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+#[allow(missing_docs)]
+pub struct EndpointSpec {
+    /// The mode of resolution to use for internal load balancing between tasks.
+    pub mode: Option<EndpointSpecMode>,
+    /// List of exposed ports that this service is accessible on from the outside. Ports can only be provided if `vip` resolution mode is used.
+    pub ports: Option<Vec<EndpointPortConfig>>,
+}
+
+/// The mode of resolution to use for internal load balancing between tasks.
+#[derive(Debug, Copy, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+#[allow(missing_docs)]
+pub enum EndpointSpecMode {
+    Vip,
+    Dnsrr,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+#[allow(missing_docs)]
+pub struct EndpointPortConfig {
+    pub name: Option<String>,
+    pub protocol: Option<EndpointPortConfigProtocol>,
+    /// The port inside the container.
+    pub target_port: Option<isize>,
+    /// The port on the swarm hosts.
+    pub published_port: Option<isize>,
+    /// The mode in which port is published.  <p><br /></p>  - \"ingress\" makes the target port accessible on every node,   regardless of whether there is a task for the service running on   that node or not. - \"host\" bypasses the routing mesh and publish the port directly on   the swarm node where that service is running.
+    pub publish_mode: Option<EndpointPortConfigPublishMode>,
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+#[allow(missing_docs)]
+pub enum EndpointPortConfigProtocol {
+    Tcp,
+    Udp,
+    Sctp,
+}
+
+/// The mode in which port is published.  <p><br /></p>  - \"ingress\" makes the target port accessible on every node,   regardless of whether there is a task for the service running on   that node or not. - \"host\" bypasses the routing mesh and publish the port directly on   the swarm node where that service is running.
+#[derive(Debug, Copy, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+#[allow(missing_docs)]
+pub enum EndpointPortConfigPublishMode {
+    Ingress,
+    Host,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+#[allow(missing_docs)]
+pub struct ServiceEndpoint {
+    pub spec: Option<EndpointSpec>,
+    pub ports: Option<Vec<EndpointPortConfig>>,
+    #[serde(rename = "VirtualIPs")]
+    pub virtual_ips: Option<Vec<ServiceEndpointVirtualIPs>>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+#[allow(missing_docs)]
+pub struct ServiceEndpointVirtualIPs {
+    #[serde(rename = "NetworkID")]
+    pub network_id: Option<String>,
+    pub addr: Option<String>,
+}
+
+/// The status of a service update.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+#[allow(missing_docs)]
+pub struct ServiceUpdateStatus {
+    pub state: ServiceUpdateStatusState,
+    #[serde(with = "ts_seconds")]
+    pub started_at: DateTime<Utc>,
+    #[serde(with = "ts_seconds")]
+    pub completed_at: DateTime<Utc>,
+    pub message: String,
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+#[allow(missing_docs)]
+pub enum ServiceUpdateStatusState {
+    Updating,
+    Paused,
+    Completed,
+}

--- a/src/service_models.rs
+++ b/src/service_models.rs
@@ -2,26 +2,27 @@
 
 use chrono::Utc;
 use chrono::{serde::ts_seconds, DateTime};
-use std::collections::HashMap;
+use std::{collections::HashMap, hash::Hash};
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "PascalCase")]
 #[allow(missing_docs)]
-pub struct Service {
+pub struct Service<T>
+where
+    T: AsRef<str> + Eq + Hash,
+{
     #[serde(rename = "ID")]
-    pub id: String,
+    pub id: T,
     pub version: ObjectVersion,
-    #[serde(with = "ts_seconds")]
     pub created_at: DateTime<Utc>,
-    #[serde(with = "ts_seconds")]
     pub updated_at: DateTime<Utc>,
-    pub spec: ServiceSpec,
-    pub endpoint: ServiceEndpoint,
-    pub update_status: ServiceUpdateStatus,
+    pub spec: ServiceSpec<T>,
+    pub endpoint: ServiceEndpoint<T>,
+    pub update_status: Option<ServiceUpdateStatus<T>>,
 }
 
 /// The version number of the object such as node, service, etc. This is needed to avoid conflicting writes. The client must send the version number along with the modified specification when updating these objects. This approach ensures safe concurrency and determinism in that the change on the object may not be applied if the version number has changed from the last read. In other words, if two update requests specify the same base version, only one of the requests can succeed. As a result, two separate update requests that happen at the same time will not unintentionally overwrite each other.
-#[derive(Debug, Copy, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Copy, Clone, Default, Serialize, Deserialize)]
 #[serde(rename_all = "PascalCase")]
 #[allow(missing_docs)]
 pub struct ObjectVersion {
@@ -29,91 +30,106 @@ pub struct ObjectVersion {
 }
 
 /// User modifiable configuration for a service.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(rename_all = "PascalCase")]
 #[allow(missing_docs)]
-pub struct ServiceSpec {
+pub struct ServiceSpec<T>
+where
+    T: AsRef<str> + Eq + Hash,
+{
     /// Name of the service.
-    pub name: Option<String>,
+    pub name: T,
     /// User-defined key/value metadata.
-    pub labels: Option<HashMap<String, String>>,
-    pub task_template: Option<TaskSpec>,
+    pub labels: HashMap<T, String>,
+    pub task_template: TaskSpec<T>,
     pub mode: Option<ServiceSpecMode>,
     pub update_config: Option<ServiceSpecUpdateConfig>,
     pub rollback_config: Option<ServiceSpecUpdateConfig>,
     /// Specifies which networks the service should attach to.
-    pub networks: Option<Vec<NetworkAttachmentConfig>>,
-    pub endpoint_spec: Option<EndpointSpec>,
+    pub networks: Option<Vec<NetworkAttachmentConfig<T>>>,
+    pub endpoint_spec: Option<EndpointSpec<T>>,
 }
 
 /// User modifiable task configuration.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(rename_all = "PascalCase")]
 #[allow(missing_docs)]
-pub struct TaskSpec {
-    pub plugin_spec: Option<TaskSpecPluginSpec>,
-    pub container_spec: Option<TaskSpecContainerSpec>,
-    pub network_attachment_spec: Option<TaskSpecNetworkAttachmentSpec>,
-    pub resources: Option<TaskSpecResources>,
+pub struct TaskSpec<T>
+where
+    T: AsRef<str> + Eq + Hash,
+{
+    pub plugin_spec: Option<TaskSpecPluginSpec<T>>,
+    pub container_spec: Option<TaskSpecContainerSpec<T>>,
+    pub network_attachment_spec: Option<TaskSpecNetworkAttachmentSpec<T>>,
+    pub resources: Option<TaskSpecResources<T>>,
     pub restart_policy: Option<TaskSpecRestartPolicy>,
-    pub placement: Option<TaskSpecPlacement>,
+    pub placement: Option<TaskSpecPlacement<T>>,
     /// A counter that triggers an update even if no relevant parameters have been changed.
     pub force_update: Option<isize>,
     /// Runtime is the type of runtime specified for the task executor.
-    pub runtime: Option<String>,
+    pub runtime: Option<T>,
     /// Specifies which networks the service should attach to.
-    pub networks: Option<Vec<NetworkAttachmentConfig>>,
-    pub log_driver: Option<TaskSpecLogDriver>,
+    pub networks: Option<Vec<NetworkAttachmentConfig<T>>>,
+    pub log_driver: Option<TaskSpecLogDriver<T>>,
 }
 
 /// Plugin spec for the service.  *(Experimental release only.)*  <p><br /></p>  > **Note**: ContainerSpec, NetworkAttachmentSpec, and PluginSpec are > mutually exclusive. PluginSpec is only used when the Runtime field > is set to `plugin`. NetworkAttachmentSpec is used when the Runtime > field is set to `attachment`.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(rename_all = "PascalCase")]
 #[allow(missing_docs)]
-pub struct TaskSpecPluginSpec {
+pub struct TaskSpecPluginSpec<T>
+where
+    T: AsRef<str> + Eq + Hash,
+{
     /// The name or 'alias' to use for the plugin.
-    pub name: Option<String>,
+    pub name: Option<T>,
     /// The plugin image reference to use.
-    pub remote: Option<String>,
+    pub remote: Option<T>,
     /// Disable the plugin once scheduled.
     pub disabled: Option<bool>,
-    pub plugin_privilege: Option<Vec<Body>>,
+    pub plugin_privilege: Option<Vec<Body<T>>>,
 }
 
 /// Describes a permission accepted by the user upon installing the plugin.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(rename_all = "PascalCase")]
 #[allow(missing_docs)]
-pub struct Body {
-    pub name: Option<String>,
-    pub description: Option<String>,
-    pub value: Option<Vec<String>>,
+pub struct Body<T>
+where
+    T: AsRef<str> + Eq + Hash,
+{
+    pub name: Option<T>,
+    pub description: Option<T>,
+    pub value: Option<Vec<T>>,
 }
 
 /// Container spec for the service.  <p><br /></p>  > **Note**: ContainerSpec, NetworkAttachmentSpec, and PluginSpec are > mutually exclusive. PluginSpec is only used when the Runtime field > is set to `plugin`. NetworkAttachmentSpec is used when the Runtime > field is set to `attachment`.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(rename_all = "PascalCase")]
 #[allow(missing_docs)]
-pub struct TaskSpecContainerSpec {
+pub struct TaskSpecContainerSpec<T>
+where
+    T: AsRef<str> + Eq + Hash,
+{
     /// The image name to use for the container
-    pub image: Option<String>,
+    pub image: Option<T>,
     /// User-defined key/value data.
-    pub labels: Option<HashMap<String, String>>,
+    pub labels: Option<HashMap<T, String>>,
     /// The command to be run in the image.
-    pub command: Option<Vec<String>>,
+    pub command: Option<Vec<T>>,
     /// Arguments to the command.
-    pub args: Option<Vec<String>>,
+    pub args: Option<Vec<T>>,
     /// The hostname to use for the container, as a valid RFC 1123 hostname.
-    pub hostname: Option<String>,
+    pub hostname: Option<T>,
     /// A list of environment variables in the form `VAR=value`.
-    pub env: Option<Vec<String>>,
+    pub env: Option<Vec<T>>,
     /// The working directory for commands to run in.
-    pub dir: Option<String>,
+    pub dir: Option<T>,
     /// The user inside the container.
-    pub user: Option<String>,
+    pub user: Option<T>,
     /// A list of additional groups that the container process will run as.
-    pub groups: Option<Vec<String>>,
-    pub privileges: Option<TaskSpecContainerSpecPrivileges>,
+    pub groups: Option<Vec<T>>,
+    pub privileges: Option<TaskSpecContainerSpecPrivileges<T>>,
     /// Whether a pseudo-TTY should be allocated.
     #[serde(rename = "TTY")]
     pub tty: Option<bool>,
@@ -122,30 +138,30 @@ pub struct TaskSpecContainerSpec {
     /// Mount the container's root filesystem as read only.
     pub read_only: Option<bool>,
     /// Specification for mounts to be added to containers created as part of the service.
-    pub mounts: Option<Vec<Mount>>,
+    pub mounts: Option<Vec<Mount<T>>>,
     /// Signal to stop the container.
-    pub stop_signal: Option<String>,
+    pub stop_signal: Option<T>,
     /// Amount of time to wait for the container to terminate before forcefully killing it.
     pub stop_grace_period: Option<i64>,
-    pub health_check: Option<HealthConfig>,
+    pub health_check: Option<HealthConfig<T>>,
     /// A list of hostname/IP mappings to add to the container's `hosts` file. The format of extra hosts is specified in the [hosts(5)](http://man7.org/linux/man-pages/man5/hosts.5.html) man page:      IP_address canonical_hostname [aliases...]
-    pub hosts: Option<Vec<String>>,
+    pub hosts: Option<Vec<T>>,
     #[serde(rename = "DNSConfig")]
-    pub dns_config: Option<TaskSpecContainerSpecDnsConfig>,
+    pub dns_config: Option<TaskSpecContainerSpecDnsConfig<T>>,
     /// Secrets contains references to zero or more secrets that will be exposed to the service.
-    pub secrets: Option<Vec<TaskSpecContainerSpecSecrets>>,
+    pub secrets: Option<Vec<TaskSpecContainerSpecSecrets<T>>>,
     /// Configs contains references to zero or more configs that will be exposed to the service.
-    pub configs: Option<Vec<TaskSpecContainerSpecConfigs>>,
+    pub configs: Option<Vec<TaskSpecContainerSpecConfigs<T>>>,
     /// Isolation technology of the containers running the service. (Windows only)
     pub isolation: Option<TaskSpecContainerSpecIsolation>,
     /// Run an init inside the container that forwards signals and reaps processes. This field is omitted if empty, and the default (as configured on the daemon) is used.
     pub init: Option<bool>,
     /// Set kernel namedspaced parameters (sysctls) in the container. The Sysctls option on services accepts the same sysctls as the are supported on containers. Note that while the same sysctls are supported, no guarantees or checks are made about their suitability for a clustered environment, and it's up to the user to determine whether a given sysctl will work properly in a Service.
-    pub sysctls: Option<HashMap<String, String>>,
+    pub sysctls: Option<HashMap<T, String>>,
 }
 
 /// Isolation technology of the containers running the service. (Windows only)
-#[derive(Debug, Copy, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Copy, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 #[allow(missing_docs)]
 pub enum TaskSpecContainerSpecIsolation {
@@ -155,68 +171,80 @@ pub enum TaskSpecContainerSpecIsolation {
 }
 
 /// Security options for the container
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(rename_all = "PascalCase")]
 #[allow(missing_docs)]
-pub struct TaskSpecContainerSpecPrivileges {
-    pub credential_spec: Option<TaskSpecContainerSpecPrivilegesCredentialSpec>,
+pub struct TaskSpecContainerSpecPrivileges<T>
+where
+    T: AsRef<str> + Eq + Hash,
+{
+    pub credential_spec: Option<TaskSpecContainerSpecPrivilegesCredentialSpec<T>>,
     #[serde(rename = "SELinuxContext")]
-    pub se_linux_context: Option<TaskSpecContainerSpecPrivilegesSeLinuxContext>,
+    pub se_linux_context: Option<TaskSpecContainerSpecPrivilegesSeLinuxContext<T>>,
 }
 
 /// CredentialSpec for managed service account (Windows only)
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(rename_all = "PascalCase")]
 #[allow(missing_docs)]
-pub struct TaskSpecContainerSpecPrivilegesCredentialSpec {
+pub struct TaskSpecContainerSpecPrivilegesCredentialSpec<T>
+where
+    T: AsRef<str> + Eq + Hash,
+{
     /// Load credential spec from a Swarm Config with the given ID. The specified config must also be present in the Configs field with the Runtime property set.  <p><br /></p>   > **Note**: `CredentialSpec.File`, `CredentialSpec.Registry`, and `CredentialSpec.Config` are mutually exclusive.
-    pub config: Option<String>,
+    pub config: Option<T>,
     /// Load credential spec from this file. The file is read by the daemon, and must be present in the `CredentialSpecs` subdirectory in the docker data directory, which defaults to `C:\\ProgramData\\Docker\\` on Windows.  For example, specifying `spec.json` loads `C:\\ProgramData\\Docker\\CredentialSpecs\\spec.json`.  <p><br /></p>  > **Note**: `CredentialSpec.File`, `CredentialSpec.Registry`, and `CredentialSpec.Config` are mutually exclusive.
-    pub file: Option<String>,
+    pub file: Option<T>,
     /// Load credential spec from this value in the Windows registry. The specified registry value must be located in:  `HKLM\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Virtualization\\Containers\\CredentialSpecs`  <p><br /></p>   > **Note**: `CredentialSpec.File`, `CredentialSpec.Registry`, and `CredentialSpec.Config` are mutually exclusive.
-    pub registry: Option<String>,
+    pub registry: Option<T>,
 }
 
 /// SELinux labels of the container
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(rename_all = "PascalCase")]
 #[allow(missing_docs)]
-pub struct TaskSpecContainerSpecPrivilegesSeLinuxContext {
+pub struct TaskSpecContainerSpecPrivilegesSeLinuxContext<T>
+where
+    T: AsRef<str> + Eq + Hash,
+{
     /// Disable SELinux
     pub disable: Option<bool>,
     /// SELinux user label
-    pub user: Option<String>,
+    pub user: Option<T>,
     /// SELinux role label
-    pub role: Option<String>,
+    pub role: Option<T>,
     /// SELinux type label
     #[serde(rename = "Type")]
-    pub _type: Option<String>,
+    pub _type: Option<T>,
     /// SELinux level label
-    pub level: Option<String>,
+    pub level: Option<T>,
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(rename_all = "PascalCase")]
 #[allow(missing_docs)]
-pub struct Mount {
+pub struct Mount<T>
+where
+    T: AsRef<str> + Eq + Hash,
+{
     /// Container path.
-    pub target: Option<String>,
+    pub target: Option<T>,
     /// Mount source (e.g. a volume name, a host path).
-    pub source: Option<String>,
+    pub source: Option<T>,
     /// The mount type. Available types:  - `bind` Mounts a file or directory from the host into the container. Must exist prior to creating the container. - `volume` Creates a volume with the given name and options (or uses a pre-existing volume with the same name and options). These are **not** removed when the container is removed. - `tmpfs` Create a tmpfs with the given options. The mount source cannot be specified for tmpfs. - `npipe` Mounts a named pipe from the host into the container. Must exist prior to creating the container.
     #[serde(rename = "Type")]
     pub _type: Option<MountType>,
     /// Whether the mount should be read-only.
     pub read_only: Option<bool>,
     /// The consistency requirement for the mount: `default`, `consistent`, `cached`, or `delegated`.
-    pub consistency: Option<String>,
+    pub consistency: Option<T>,
     pub bind_options: Option<MountBindOptions>,
-    pub volume_options: Option<MountVolumeOptions>,
+    pub volume_options: Option<MountVolumeOptions<T>>,
     pub tmpfs_options: Option<MountTmpfsOptions>,
 }
 
 /// The mount type. Available types:  - `bind` Mounts a file or directory from the host into the container. Must exist prior to creating the container. - `volume` Creates a volume with the given name and options (or uses a pre-existing volume with the same name and options). These are **not** removed when the container is removed. - `tmpfs` Create a tmpfs with the given options. The mount source cannot be specified for tmpfs. - `npipe` Mounts a named pipe from the host into the container. Must exist prior to creating the container.
-#[derive(Debug, Copy, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Copy, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 #[allow(missing_docs)]
 pub enum MountType {
@@ -227,7 +255,7 @@ pub enum MountType {
 }
 
 /// Optional configuration for the `bind` type.
-#[derive(Debug, Copy, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Copy, Clone, Default, Serialize, Deserialize)]
 #[serde(rename_all = "PascalCase")]
 #[allow(missing_docs)]
 pub struct MountBindOptions {
@@ -238,7 +266,7 @@ pub struct MountBindOptions {
 }
 
 /// A propagation mode with the value `[r]private`, `[r]shared`, or `[r]slave`.
-#[derive(Debug, Copy, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Copy, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 #[allow(missing_docs)]
 pub enum MountBindOptionsPropagation {
@@ -254,30 +282,36 @@ pub enum MountBindOptionsPropagation {
 }
 
 /// Optional configuration for the `volume` type.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(rename_all = "PascalCase")]
 #[allow(missing_docs)]
-pub struct MountVolumeOptions {
+pub struct MountVolumeOptions<T>
+where
+    T: AsRef<str> + Eq + Hash,
+{
     /// Populate volume with data from the target.
     pub no_copy: Option<bool>,
     /// User-defined key/value metadata.
-    pub labels: Option<HashMap<String, String>>,
-    pub driver_config: Option<MountVolumeOptionsDriverConfig>,
+    pub labels: Option<HashMap<T, T>>,
+    pub driver_config: Option<MountVolumeOptionsDriverConfig<T>>,
 }
 
 /// Map of driver specific options
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(rename_all = "PascalCase")]
 #[allow(missing_docs)]
-pub struct MountVolumeOptionsDriverConfig {
+pub struct MountVolumeOptionsDriverConfig<T>
+where
+    T: AsRef<str> + Eq + Hash,
+{
     /// Name of the driver to use to create the volume.
-    pub name: Option<String>,
+    pub name: Option<T>,
     /// key/value map of driver specific options.
-    pub options: Option<HashMap<String, String>>,
+    pub options: Option<HashMap<T, T>>,
 }
 
 /// Optional configuration for the `tmpfs` type.
-#[derive(Debug, Copy, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Copy, Clone, Default, Serialize, Deserialize)]
 #[serde(rename_all = "PascalCase")]
 #[allow(missing_docs)]
 pub struct MountTmpfsOptions {
@@ -288,12 +322,15 @@ pub struct MountTmpfsOptions {
 }
 
 /// A test to perform to check that the container is healthy.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(rename_all = "PascalCase")]
 #[allow(missing_docs)]
-pub struct HealthConfig {
+pub struct HealthConfig<T>
+where
+    T: AsRef<str> + Eq + Hash,
+{
     /// The test to perform. Possible values are:  - `[]` inherit healthcheck from image or parent image - `[\"NONE\"]` disable healthcheck - `[\"CMD\", args...]` exec arguments directly - `[\"CMD-SHELL\", command]` run command with system's default shell
-    pub test: Option<Vec<String>>,
+    pub test: Option<Vec<T>>,
     /// The time to wait between checks in nanoseconds. It should be 0 or at least 1000000 (1 ms). 0 means inherit.
     pub interval: Option<isize>,
     /// The time to wait before considering the check to have hung. It should be 0 or at least 1000000 (1 ms). 0 means inherit.
@@ -305,120 +342,150 @@ pub struct HealthConfig {
 }
 
 /// Specification for DNS related configurations in resolver configuration file (`resolv.conf`).
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(rename_all = "PascalCase")]
 #[allow(missing_docs)]
-pub struct TaskSpecContainerSpecDnsConfig {
+pub struct TaskSpecContainerSpecDnsConfig<T>
+where
+    T: AsRef<str> + Eq + Hash,
+{
     /// The IP addresses of the name servers.
-    pub nameservers: Option<Vec<String>>,
+    pub nameservers: Option<Vec<T>>,
     /// A search list for host-name lookup.
-    pub search: Option<Vec<String>>,
+    pub search: Option<Vec<T>>,
     /// A list of internal resolver variables to be modified (e.g., `debug`, `ndots:3`, etc.).
-    pub options: Option<Vec<String>>,
+    pub options: Option<Vec<T>>,
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(rename_all = "PascalCase")]
 #[allow(missing_docs)]
-pub struct TaskSpecContainerSpecSecrets {
-    pub file: Option<TaskSpecContainerSpecFile>,
+pub struct TaskSpecContainerSpecSecrets<T>
+where
+    T: AsRef<str> + Eq + Hash,
+{
+    pub file: Option<TaskSpecContainerSpecFile<T>>,
     /// SecretID represents the ID of the specific secret that we're referencing.
     #[serde(rename = "SecretID")]
-    pub secret_id: Option<String>,
+    pub secret_id: Option<T>,
     /// SecretName is the name of the secret that this references, but this is just provided for lookup/display purposes. The secret in the reference will be identified by its ID.
-    pub secret_name: Option<String>,
+    pub secret_name: Option<T>,
 }
 
 /// File represents a specific target that is backed by a file.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(rename_all = "PascalCase")]
 #[allow(missing_docs)]
-pub struct TaskSpecContainerSpecFile {
+pub struct TaskSpecContainerSpecFile<T>
+where
+    T: AsRef<str> + Eq + Hash,
+{
     /// Name represents the final filename in the filesystem.
-    pub name: Option<String>,
+    pub name: Option<T>,
     /// UID represents the file UID.
     #[serde(rename = "UID")]
-    pub uid: Option<String>,
+    pub uid: Option<T>,
     /// GID represents the file GID.
     #[serde(rename = "GID")]
-    pub gid: Option<String>,
+    pub gid: Option<T>,
     /// Mode represents the FileMode of the file.
     pub mode: Option<u32>,
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(rename_all = "PascalCase")]
 #[allow(missing_docs)]
-pub struct TaskSpecContainerSpecConfigs {
-    pub file: Option<TaskSpecContainerSpecFile>,
+pub struct TaskSpecContainerSpecConfigs<T>
+where
+    T: AsRef<str> + Eq + Hash,
+{
+    pub file: Option<TaskSpecContainerSpecFile<T>>,
     /// Runtime represents a target that is not mounted into the container but is used by the task  <p><br /><p>  > **Note**: `Configs.File` and `Configs.Runtime` are mutually exclusive
     pub runtime: Option<HashMap<(), ()>>,
     /// ConfigID represents the ID of the specific config that we're referencing.
     #[serde(rename = "ConfigID")]
-    pub config_id: Option<String>,
+    pub config_id: Option<T>,
     /// ConfigName is the name of the config that this references, but this is just provided for lookup/display purposes. The config in the reference will be identified by its ID.
-    pub config_name: Option<String>,
+    pub config_name: Option<T>,
 }
 
 /// Read-only spec type for non-swarm containers attached to swarm overlay networks.  <p><br /></p>  > **Note**: ContainerSpec, NetworkAttachmentSpec, and PluginSpec are > mutually exclusive. PluginSpec is only used when the Runtime field > is set to `plugin`. NetworkAttachmentSpec is used when the Runtime > field is set to `attachment`.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(rename_all = "PascalCase")]
 #[allow(missing_docs)]
-pub struct TaskSpecNetworkAttachmentSpec {
+pub struct TaskSpecNetworkAttachmentSpec<T>
+where
+    T: AsRef<str> + Eq + Hash,
+{
     /// ID of the container represented by this task
     #[serde(rename = "ContainerID")]
-    pub container_id: Option<String>,
+    pub container_id: Option<T>,
 }
 
 /// Resource requirements which apply to each individual container created as part of the service.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(rename_all = "PascalCase")]
 #[allow(missing_docs)]
-pub struct TaskSpecResources {
+pub struct TaskSpecResources<T>
+where
+    T: AsRef<str> + Eq + Hash,
+{
     /// Define resources limits.
-    pub limits: Option<ResourceObject>,
+    pub limits: Option<ResourceObject<T>>,
     /// Define resources reservation.
-    pub reservation: Option<ResourceObject>,
+    pub reservation: Option<ResourceObject<T>>,
 }
 
 /// An object describing the resources which can be advertised by a node and requested by a task
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(rename_all = "PascalCase")]
 #[allow(missing_docs)]
-pub struct ResourceObject {
+pub struct ResourceObject<T>
+where
+    T: AsRef<str> + Eq + Hash,
+{
     #[serde(rename = "NanoCPUs")]
     pub nano_cpus: Option<i64>,
     pub memory_bytes: Option<i64>,
-    pub generic_resources: Option<Vec<GenericResources>>,
+    pub generic_resources: Option<Vec<GenericResources<T>>>,
 }
 
-/// User-defined resources can be either Integer resources (e.g, `SSD=3`) or String resources (e.g, `GPU=UUID1`)
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+/// User-defined resources can be either Integer resources (e.g, `SSD=3`) or T resources (e.g, `GPU=UUID1`)
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(rename_all = "PascalCase")]
 #[allow(missing_docs)]
-pub struct GenericResources {
-    pub named_resource_spec: Option<GenericResourcesNamedResourceSpec>,
-    pub discrete_resource_spec: Option<GenericResourcesDiscreteResourceSpec>,
+pub struct GenericResources<T>
+where
+    T: AsRef<str> + Eq + Hash,
+{
+    pub named_resource_spec: Option<GenericResourcesNamedResourceSpec<T>>,
+    pub discrete_resource_spec: Option<GenericResourcesDiscreteResourceSpec<T>>,
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(rename_all = "PascalCase")]
 #[allow(missing_docs)]
-pub struct GenericResourcesNamedResourceSpec {
-    pub kind: Option<String>,
-    pub value: Option<String>,
+pub struct GenericResourcesNamedResourceSpec<T>
+where
+    T: AsRef<str> + Eq + Hash,
+{
+    pub kind: Option<T>,
+    pub value: Option<T>,
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(rename_all = "PascalCase")]
 #[allow(missing_docs)]
-pub struct GenericResourcesDiscreteResourceSpec {
-    pub kind: Option<String>,
+pub struct GenericResourcesDiscreteResourceSpec<T>
+where
+    T: AsRef<str> + Eq + Hash,
+{
+    pub kind: Option<T>,
     pub value: Option<i64>,
 }
 
 /// Specification for the restart policy which applies to containers created as part of this service.
-#[derive(Debug, Copy, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Copy, Clone, Default, Serialize, Deserialize)]
 #[serde(rename_all = "PascalCase")]
 #[allow(missing_docs)]
 pub struct TaskSpecRestartPolicy {
@@ -433,7 +500,7 @@ pub struct TaskSpecRestartPolicy {
 }
 
 /// Condition for restart.
-#[derive(Debug, Copy, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Copy, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 #[allow(missing_docs)]
 pub enum TaskSpecRestartPolicyCondition {
@@ -442,87 +509,100 @@ pub enum TaskSpecRestartPolicyCondition {
     Any,
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(rename_all = "PascalCase")]
 #[allow(missing_docs)]
-pub struct TaskSpecPlacement {
+pub struct TaskSpecPlacement<T>
+where
+    T: AsRef<str> + Eq + Hash,
+{
     /// An array of constraints.
-    pub constraints: Option<Vec<String>>,
+    pub constraints: Option<Vec<T>>,
     /// Preferences provide a way to make the scheduler aware of factors such as topology. They are provided in order from highest to lowest precedence.
-    pub preferences: Option<Vec<TaskSpecPlacementPreferences>>,
+    pub preferences: Option<Vec<TaskSpecPlacementPreferences<T>>>,
     /// Maximum number of replicas for per node (default value is 0, which is unlimited)
     pub max_replicas: Option<i64>,
     /// Platforms stores all the platforms that the service's image can run on. This field is used in the platform filter for scheduling. If empty, then the platform filter is off, meaning there are no scheduling restrictions.
-    pub platforms: Option<Vec<Platform>>,
+    pub platforms: Option<Vec<Platform<T>>>,
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(rename_all = "PascalCase")]
 #[allow(missing_docs)]
-pub struct TaskSpecPlacementPreferences {
-    pub spread: Option<TaskSpecPlacementSpread>,
+pub struct TaskSpecPlacementPreferences<T>
+where
+    T: AsRef<str> + Eq + Hash,
+{
+    pub spread: Option<TaskSpecPlacementSpread<T>>,
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(rename_all = "PascalCase")]
 #[allow(missing_docs)]
-pub struct TaskSpecPlacementSpread {
+pub struct TaskSpecPlacementSpread<T>
+where
+    T: AsRef<str> + Eq + Hash,
+{
     /// label descriptor, such as engine.labels.az
-    pub spread_descriptor: Option<String>,
+    pub spread_descriptor: Option<T>,
 }
 
 /// Platform represents the platform (Arch/OS).
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(rename_all = "PascalCase")]
 #[allow(missing_docs)]
-pub struct Platform {
+pub struct Platform<T>
+where
+    T: AsRef<str> + Eq + Hash,
+{
     /// Architecture represents the hardware architecture (for example, `x86_64`).
-    pub architecture: Option<String>,
+    pub architecture: Option<T>,
     /// OS represents the Operating System (for example, `linux` or `windows`).
     #[serde(rename = "OS")]
-    pub os: Option<String>,
+    pub os: Option<T>,
 }
 
 /// Specifies how a service should be attached to a particular network.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(rename_all = "PascalCase")]
 #[allow(missing_docs)]
-pub struct NetworkAttachmentConfig {
+pub struct NetworkAttachmentConfig<T>
+where
+    T: AsRef<str> + Eq + Hash,
+{
     /// The target network for attachment. Must be a network name or ID.
-    pub target: Option<String>,
+    pub target: Option<T>,
     /// Discoverable alternate names for the service on this network.
-    pub aliases: Option<Vec<String>>,
+    pub aliases: Option<Vec<T>>,
     /// Driver attachment options for the network target
-    pub driver_opts: Option<HashMap<String, String>>,
+    pub driver_opts: Option<HashMap<T, String>>,
 }
 
 /// Specifies the log driver to use for tasks created from this spec. If not present, the default one for the swarm will be used, finally falling back to the engine default if not specified.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(rename_all = "PascalCase")]
 #[allow(missing_docs)]
-pub struct TaskSpecLogDriver {
-    pub name: Option<String>,
-    pub options: Option<HashMap<String, String>>,
+pub struct TaskSpecLogDriver<T>
+where
+    T: AsRef<str> + Eq + Hash,
+{
+    pub name: Option<T>,
+    pub options: Option<HashMap<T, String>>,
 }
 
 /// Scheduling mode for the service.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-#[serde(rename_all = "PascalCase")]
+#[derive(Debug, Copy, Clone, Serialize, Deserialize)]
 #[allow(missing_docs)]
-pub struct ServiceSpecMode {
-    pub replicated: Option<ServiceSpecModeReplicated>,
-    pub global: Option<HashMap<(), ()>>,
-}
-
-#[derive(Debug, Copy, Clone, PartialEq, Serialize, Deserialize)]
-#[serde(rename_all = "PascalCase")]
-#[allow(missing_docs)]
-pub struct ServiceSpecModeReplicated {
-    pub replicas: Option<i64>,
+pub enum ServiceSpecMode {
+    Replicated {
+        #[serde(rename = "Replicas")]
+        replicas: i64,
+    },
+    Global,
 }
 
 /// Specification for the update or rollback strategy of the service.
-#[derive(Debug, Copy, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Copy, Clone, Default, Serialize, Deserialize)]
 #[serde(rename_all = "PascalCase")]
 #[allow(missing_docs)]
 pub struct ServiceSpecUpdateConfig {
@@ -541,7 +621,7 @@ pub struct ServiceSpecUpdateConfig {
 }
 
 /// Action to take if an updated task fails to run, or stops running during the update.
-#[derive(Debug, Copy, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Copy, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 #[allow(missing_docs)]
 pub enum ServiceSpecUpdateConfigFailureAction {
@@ -551,7 +631,7 @@ pub enum ServiceSpecUpdateConfigFailureAction {
 }
 
 /// The order of operations when rolling out an updated task. Either the old task is shut down before the new task is started, or the new task is started before the old task is shut down.
-#[derive(Debug, Copy, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Copy, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 #[allow(missing_docs)]
 pub enum ServiceSpecUpdateConfigOrder {
@@ -560,18 +640,21 @@ pub enum ServiceSpecUpdateConfigOrder {
 }
 
 /// Properties that can be configured to access and load balance a service.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(rename_all = "PascalCase")]
 #[allow(missing_docs)]
-pub struct EndpointSpec {
+pub struct EndpointSpec<T>
+where
+    T: AsRef<str> + Eq + Hash,
+{
     /// The mode of resolution to use for internal load balancing between tasks.
     pub mode: Option<EndpointSpecMode>,
     /// List of exposed ports that this service is accessible on from the outside. Ports can only be provided if `vip` resolution mode is used.
-    pub ports: Option<Vec<EndpointPortConfig>>,
+    pub ports: Option<Vec<EndpointPortConfig<T>>>,
 }
 
 /// The mode of resolution to use for internal load balancing between tasks.
-#[derive(Debug, Copy, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Copy, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 #[allow(missing_docs)]
 pub enum EndpointSpecMode {
@@ -579,11 +662,14 @@ pub enum EndpointSpecMode {
     Dnsrr,
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(rename_all = "PascalCase")]
 #[allow(missing_docs)]
-pub struct EndpointPortConfig {
-    pub name: Option<String>,
+pub struct EndpointPortConfig<T>
+where
+    T: AsRef<str> + Eq + Hash,
+{
+    pub name: Option<T>,
     pub protocol: Option<EndpointPortConfigProtocol>,
     /// The port inside the container.
     pub target_port: Option<isize>,
@@ -593,7 +679,7 @@ pub struct EndpointPortConfig {
     pub publish_mode: Option<EndpointPortConfigPublishMode>,
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Copy, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 #[allow(missing_docs)]
 pub enum EndpointPortConfigProtocol {
@@ -603,7 +689,7 @@ pub enum EndpointPortConfigProtocol {
 }
 
 /// The mode in which port is published.  <p><br /></p>  - \"ingress\" makes the target port accessible on every node,   regardless of whether there is a task for the service running on   that node or not. - \"host\" bypasses the routing mesh and publish the port directly on   the swarm node where that service is running.
-#[derive(Debug, Copy, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Copy, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 #[allow(missing_docs)]
 pub enum EndpointPortConfigPublishMode {
@@ -611,39 +697,48 @@ pub enum EndpointPortConfigPublishMode {
     Host,
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(rename_all = "PascalCase")]
 #[allow(missing_docs)]
-pub struct ServiceEndpoint {
-    pub spec: Option<EndpointSpec>,
-    pub ports: Option<Vec<EndpointPortConfig>>,
+pub struct ServiceEndpoint<T>
+where
+    T: AsRef<str> + Eq + Hash,
+{
+    pub spec: Option<EndpointSpec<T>>,
+    pub ports: Option<Vec<EndpointPortConfig<T>>>,
     #[serde(rename = "VirtualIPs")]
-    pub virtual_ips: Option<Vec<ServiceEndpointVirtualIPs>>,
+    pub virtual_ips: Option<Vec<ServiceEndpointVirtualIPs<T>>>,
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(rename_all = "PascalCase")]
 #[allow(missing_docs)]
-pub struct ServiceEndpointVirtualIPs {
+pub struct ServiceEndpointVirtualIPs<T>
+where
+    T: AsRef<str> + Eq + Hash,
+{
     #[serde(rename = "NetworkID")]
-    pub network_id: Option<String>,
-    pub addr: Option<String>,
+    pub network_id: Option<T>,
+    pub addr: Option<T>,
 }
 
 /// The status of a service update.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "PascalCase")]
 #[allow(missing_docs)]
-pub struct ServiceUpdateStatus {
+pub struct ServiceUpdateStatus<T>
+where
+    T: AsRef<str> + Eq + Hash,
+{
     pub state: ServiceUpdateStatusState,
     #[serde(with = "ts_seconds")]
     pub started_at: DateTime<Utc>,
     #[serde(with = "ts_seconds")]
     pub completed_at: DateTime<Utc>,
-    pub message: String,
+    pub message: T,
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Copy, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 #[allow(missing_docs)]
 pub enum ServiceUpdateStatusState {
@@ -652,14 +747,3 @@ pub enum ServiceUpdateStatusState {
     Completed,
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-#[serde(rename_all = "PascalCase")]
-#[allow(missing_docs)]
-pub struct ServiceCreateResponse {
-    /// The ID of the created service.
-    #[serde(rename = "ID")]
-    pub id: Option<String>,
-
-    /// Optional warning message
-    pub warning: Option<String>,
-}

--- a/tests/service_test.rs
+++ b/tests/service_test.rs
@@ -1,0 +1,42 @@
+use bollard::errors::Error;
+use bollard::{service::*, Docker};
+
+use tokio::runtime::Runtime;
+
+#[macro_use]
+mod common;
+use crate::common::*;
+
+async fn service_create_test(docker: Docker) -> Result<(), Error> {
+    let image = if cfg!(windows) {
+        format!("{}nanoserver/iis", registry_http_addr())
+    } else {
+        format!("{}fussybeaver/uhttpd", registry_http_addr())
+    };
+    let spec = ServiceSpec {
+        name: "integration_test_create_service",
+        task_template: TaskSpec {
+            container_spec: Some(TaskSpecContainerSpec {
+                image: Some(&image),
+                ..Default::default()
+            }),
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+
+    let respone = docker.create_service(spec, None).await?;
+
+    assert_ne!(respone.id.len(), 0);
+
+    docker
+        .delete_service("integration_test_create_service")
+        .await?;
+
+    Ok(())
+}
+
+#[test]
+fn integration_test_create_service() {
+    connect_to_docker_and_run!(service_create_test);
+}


### PR DESCRIPTION
This implements the docker engine Service APIs.
I've split the module into implementation and models, as the service models are quite large.
The `service_models` module is primarily generated from the OpenAPI spec and then manually cleaned up a bit. So there could still be a few places that would be better represented by an enum or some other type.
In order to not confuse the users the `service_models` module is not public but instead fully reexported from `service`.

This is only marked work-in-progress, because integration tests are still missing.

Fixes https://github.com/fussybeaver/bollard/issues/50