### PR TITLE
Fix readme example formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ async move {
     let version = docker.version().await.unwrap();
     println!("{:?}", version);
 };
-```rust
+```
 
 ### Listing images
 


### PR DESCRIPTION
Closing a fenced code block with the language causes the Markdown parser to not parse the source correctly. It previously thought the "```rust" line was part of the code block and merged the formatting of the Version and "Listing images" examples.