### PR TITLE
Remove stray `dbg!()` in image.rs

### DIFF
--- a/src/image.rs
+++ b/src/image.rs
@@ -1595,7 +1595,6 @@ impl Docker {
             image_name: &str,
         ) ->  impl Stream<Item = Result<Bytes, Error>> {
             let url = format!("/images/{}/get", image_name);
-            dbg!(&url);
             let req = self.build_request::<_, String, String>(
                 &url,
                 Builder::new()


### PR DESCRIPTION
This was probably left in by accident, and is mildly annoying.