### PR TITLE
Add support for serializing/deserializing more types

### DIFF
--- a/src/auth.rs
+++ b/src/auth.rs
@@ -1,6 +1,6 @@
 //! Credentials management, for access to the Docker Hub or a custom Registry.
 
-#[derive(Debug, Clone, Default, Serialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[allow(missing_docs)]
 /// DockerCredentials credentials and server URI to push images using the [Push Image
 /// API](../struct.Docker.html#method.push_image) or the [Build Image

--- a/src/container.rs
+++ b/src/container.rs
@@ -517,7 +517,7 @@ pub struct ContainerNetwork {
 }
 
 /// Network Settings for a container.
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "PascalCase")]
 #[allow(missing_docs)]
 pub struct NetworkSettings {
@@ -611,7 +611,7 @@ pub struct State {
 }
 
 /// Maps internal container port to external host port.
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "PascalCase")]
 #[allow(missing_docs)]
 pub struct APIPort {
@@ -624,7 +624,7 @@ pub struct APIPort {
 }
 
 /// A mapping of network name to endpoint configuration for that network.
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "PascalCase")]
 #[allow(missing_docs)]
 pub struct NetworkList {
@@ -632,7 +632,7 @@ pub struct NetworkList {
 }
 
 /// Result type for the [List Containers API](../struct.Docker.html#method.list_containers)
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "PascalCase")]
 #[allow(missing_docs)]
 pub struct APIContainers {
@@ -656,7 +656,7 @@ pub struct APIContainers {
 }
 
 /// Result type for the [Inspect Container API](../struct.Docker.html#method.inspect_container)
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "PascalCase")]
 #[allow(missing_docs)]
 pub struct Container {
@@ -778,7 +778,7 @@ where
 }
 
 /// Result type for the [Create Container API](../struct.Docker.html#method.create_container)
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "PascalCase")]
 #[allow(missing_docs)]
 pub struct CreateContainerResults {
@@ -935,7 +935,7 @@ impl<'a, T: AsRef<str>> WaitContainerQueryParams<&'a str, T> for WaitContainerOp
 }
 
 /// Error messages returned in the [Wait Container API](../struct.Docker.html#method.wait_container)
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "PascalCase")]
 #[allow(missing_docs)]
 pub struct WaitContainerResultsError {
@@ -943,7 +943,7 @@ pub struct WaitContainerResultsError {
 }
 
 /// Result type for the [Wait Container API](../struct.Docker.html#method.wait_container)
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "PascalCase")]
 #[allow(missing_docs)]
 pub struct WaitContainerResults {
@@ -1058,7 +1058,7 @@ impl<'a, T: AsRef<str>> TopQueryParams<&'a str, T> for TopOptions<T> {
 }
 
 /// Result type for the [Top Processes API](../struct.Docker.html#method.top_processes)
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "PascalCase")]
 #[allow(missing_docs)]
 pub struct TopResult {
@@ -1144,7 +1144,7 @@ impl fmt::Display for LogOutput {
 }
 
 /// Result type for the [Container Changes API](../struct.Docker.html#method.container_changes)
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "PascalCase")]
 #[allow(missing_docs)]
 pub struct Change {
@@ -1200,7 +1200,7 @@ impl<'a> StatsQueryParams<&'a str, &'a str> for StatsOptions {
 }
 
 /// Granular memory statistics for the container.
-#[derive(Debug, Copy, Clone, Deserialize)]
+#[derive(Debug, Copy, Clone, Serialize, Deserialize)]
 #[allow(missing_docs)]
 pub struct MemoryStatsStats {
     pub cache: u64,
@@ -1238,7 +1238,7 @@ pub struct MemoryStatsStats {
 }
 
 /// General memory statistics for the container.
-#[derive(Debug, Copy, Clone, Deserialize)]
+#[derive(Debug, Copy, Clone, Serialize, Deserialize)]
 #[allow(missing_docs)]
 pub struct MemoryStats {
     pub stats: Option<MemoryStatsStats>,
@@ -1254,7 +1254,7 @@ pub struct MemoryStats {
 }
 
 /// Process ID statistics for the container.
-#[derive(Debug, Copy, Clone, Deserialize)]
+#[derive(Debug, Copy, Clone, Serialize, Deserialize)]
 #[allow(missing_docs)]
 pub struct PidsStats {
     pub current: Option<u64>,
@@ -1262,7 +1262,7 @@ pub struct PidsStats {
 }
 
 /// I/O statistics for the container.
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[allow(missing_docs)]
 pub struct BlkioStats {
     pub io_service_bytes_recursive: Option<Vec<BlkioStatsEntry>>,
@@ -1276,7 +1276,7 @@ pub struct BlkioStats {
 }
 
 /// File I/O statistics for the container.
-#[derive(Debug, Copy, Clone, Deserialize)]
+#[derive(Debug, Copy, Clone, Serialize, Deserialize)]
 #[allow(missing_docs)]
 pub struct StorageStats {
     pub read_count_normalized: Option<u64>,
@@ -1286,7 +1286,7 @@ pub struct StorageStats {
 }
 
 /// Statistics for the container.
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[allow(missing_docs)]
 pub struct Stats {
     pub read: DateTime<Utc>,
@@ -1305,7 +1305,7 @@ pub struct Stats {
 }
 
 /// Network statistics for the container.
-#[derive(Debug, Copy, Clone, Deserialize)]
+#[derive(Debug, Copy, Clone, Serialize, Deserialize)]
 #[allow(missing_docs)]
 pub struct NetworkStats {
     pub rx_dropped: u64,
@@ -1319,7 +1319,7 @@ pub struct NetworkStats {
 }
 
 /// CPU usage statistics for the container.
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[allow(missing_docs)]
 pub struct CPUUsage {
     pub percpu_usage: Option<Vec<u64>>,
@@ -1329,7 +1329,7 @@ pub struct CPUUsage {
 }
 
 /// CPU throttling statistics.
-#[derive(Debug, Copy, Clone, Deserialize)]
+#[derive(Debug, Copy, Clone, Serialize, Deserialize)]
 #[allow(missing_docs)]
 pub struct ThrottlingData {
     pub periods: u64,
@@ -1338,7 +1338,7 @@ pub struct ThrottlingData {
 }
 
 /// General CPU statistics for the container.
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[allow(missing_docs)]
 pub struct CPUStats {
     pub cpu_usage: CPUUsage,
@@ -1347,7 +1347,7 @@ pub struct CPUStats {
     pub throttling_data: ThrottlingData,
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[allow(missing_docs)]
 pub struct BlkioStatsEntry {
     pub major: u64,
@@ -1393,7 +1393,7 @@ impl<'a, T: AsRef<str>> KillContainerQueryParams<&'a str, T> for KillContainerOp
 }
 
 /// Block IO weight (relative device weight).
-#[derive(Debug, Clone, Default, Serialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(rename_all = "PascalCase")]
 #[allow(missing_docs)]
 pub struct UpdateContainerOptionsBlkioWeight {
@@ -1402,7 +1402,7 @@ pub struct UpdateContainerOptionsBlkioWeight {
 }
 
 /// Limit read/write rate (IO/bytes per second) from/to a device.
-#[derive(Debug, Clone, Default, Serialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(rename_all = "PascalCase")]
 #[allow(missing_docs)]
 pub struct UpdateContainerOptionsBlkioDeviceRate {
@@ -1411,7 +1411,7 @@ pub struct UpdateContainerOptionsBlkioDeviceRate {
 }
 
 /// A list of devices to add to the container.
-#[derive(Debug, Clone, Default, Serialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(rename_all = "PascalCase")]
 #[allow(missing_docs)]
 pub struct UpdateContainerOptionsDevices {
@@ -1421,7 +1421,7 @@ pub struct UpdateContainerOptionsDevices {
 }
 
 /// A list of resource limits to set in the container.
-#[derive(Debug, Clone, Default, Serialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(rename_all = "PascalCase")]
 #[allow(missing_docs)]
 pub struct UpdateContainerOptionsUlimits {
@@ -1434,7 +1434,7 @@ pub struct UpdateContainerOptionsUlimits {
 ///
 /// An ever increasing delay (double the previous delay, starting at 100ms) is added before each
 /// restart to prevent flooding the server.
-#[derive(Debug, Clone, Default, Serialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(rename_all = "PascalCase")]
 #[allow(missing_docs)]
 pub struct UpdateContainerOptionsRestartPolicy {
@@ -1456,7 +1456,7 @@ pub struct UpdateContainerOptionsRestartPolicy {
 ///     ..Default::default()
 /// };
 /// ```
-#[derive(Debug, Clone, Default, Serialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(rename_all = "PascalCase")]
 pub struct UpdateContainerOptions {
     /// An integer value representing this container's relative CPU weight versus other containers.
@@ -1631,7 +1631,7 @@ impl<'a, T: AsRef<str> + Eq + Hash + Serialize> PruneContainersQueryParams<&'a s
 }
 
 /// Result type for the [Prune Containers API](../struct.Docker.html#method.prune_containers)
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "PascalCase")]
 #[allow(missing_docs)]
 pub struct PruneContainersResults {

--- a/src/exec.rs
+++ b/src/exec.rs
@@ -44,7 +44,7 @@ where
 }
 
 /// Result type for the [Create Exec API](../struct.Docker.html#method.create_exec)
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "PascalCase")]
 #[allow(missing_docs)]
 pub struct CreateExecResults {
@@ -67,7 +67,7 @@ pub enum StartExecResults {
     Detached,
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[allow(missing_docs)]
 pub struct ExecProcessConfig {
     pub user: Option<String>,
@@ -78,7 +78,7 @@ pub struct ExecProcessConfig {
 }
 
 /// Result type for the [Inspect Exec API](../struct.Docker.html#method.inspect_exec)
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "PascalCase")]
 #[allow(missing_docs)]
 pub struct ExecInspect {

--- a/src/image.rs
+++ b/src/image.rs
@@ -7,7 +7,7 @@ use futures_core::Stream;
 use futures_util::{stream, stream::StreamExt};
 use http::header::CONTENT_TYPE;
 use http::request::Builder;
-use hyper::{Body, body::Bytes, Method};
+use hyper::{body::Bytes, Body, Method};
 use serde::Serialize;
 use serde_json;
 
@@ -23,7 +23,7 @@ use std::collections::HashMap;
 use std::hash::Hash;
 
 /// Image type returned by the [Inspect Image API](../struct.Docker.html#method.inspect_image)
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "PascalCase")]
 #[allow(missing_docs)]
 pub struct Image {
@@ -51,7 +51,7 @@ pub struct Image {
 }
 
 /// Metadata returned by the [Inspect Image API](../struct.Docker.html#method.inspect_image)
-#[derive(Debug, Copy, Clone, Deserialize)]
+#[derive(Debug, Copy, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "PascalCase")]
 #[allow(missing_docs)]
 pub struct Metadata {
@@ -59,7 +59,7 @@ pub struct Metadata {
 }
 
 /// Root FS returned by the [Inspect Image API](../struct.Docker.html#method.inspect_image)
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "PascalCase")]
 #[allow(missing_docs)]
 pub struct RootFS {
@@ -69,7 +69,7 @@ pub struct RootFS {
 }
 
 /// APIImages type returned by the [List Images API](../struct.Docker.html#method.list_images)
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "PascalCase")]
 #[allow(missing_docs)]
 pub struct APIImages {
@@ -166,7 +166,7 @@ impl<'a> CreateImageQueryParams<&'a str, String> for CreateImageOptions<String> 
 }
 
 /// Subtype for the [Create Image Results](struct.CreateImagesResults.html) type.
-#[derive(Debug, Copy, Clone, Deserialize)]
+#[derive(Debug, Copy, Clone, Serialize, Deserialize)]
 #[allow(missing_docs)]
 pub struct CreateImageProgressDetail {
     pub current: Option<u64>,
@@ -174,13 +174,13 @@ pub struct CreateImageProgressDetail {
 }
 
 /// Subtype for the [Create Image Results](struct.CreateImagesResults.html) type.
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CreateImageErrorDetail {
     message: String,
 }
 
 /// Result type for the [Create Image API](../struct.Docker.html#method.create_image)
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(untagged)]
 #[allow(missing_docs)]
 pub enum CreateImageResults {
@@ -334,7 +334,7 @@ impl<'a, T: AsRef<str> + Eq + Hash + Serialize> PruneImagesQueryParams<&'a str>
 }
 
 /// Subtype for the [Prune Image Results](struct.PruneImagesResults.html) type.
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "PascalCase")]
 #[allow(missing_docs)]
 pub struct PruneImagesImagesDeleted {
@@ -343,7 +343,7 @@ pub struct PruneImagesImagesDeleted {
 }
 
 /// Result type for the [Prune Images API](../struct.Docker.html#method.prune_images)
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "PascalCase")]
 #[allow(missing_docs)]
 pub struct PruneImagesResults {
@@ -352,7 +352,7 @@ pub struct PruneImagesResults {
 }
 
 /// Result type for the [Image History API](../struct.Docker.html#method.image_history)
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "PascalCase")]
 #[allow(missing_docs)]
 pub struct ImageHistory {
@@ -455,7 +455,7 @@ impl<'a> SearchImagesQueryParams<&'a str> for SearchImagesOptions<String> {
 }
 
 /// Result type for the [Image Search API](../struct.Docker.html#method.image_search)
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[allow(missing_docs)]
 pub struct APIImageSearch {
     pub description: String,
@@ -507,7 +507,7 @@ impl<'a> RemoveImageQueryParams<&'a str, &'a str> for RemoveImageOptions {
 }
 
 /// Result type for the [Remove Image API](../struct.Docker.html#method.remove_image)
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(untagged)]
 #[allow(missing_docs)]
 pub enum RemoveImageResults {
@@ -690,7 +690,7 @@ impl<'a> CommitContainerQueryParams<&'a str, String> for CommitContainerOptions<
 }
 
 /// Result type for the [Commit Container API](../struct.Docker.html#method.commit_container)
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "PascalCase")]
 #[allow(missing_docs)]
 pub struct CommitContainerResults {
@@ -889,7 +889,7 @@ impl<'a> BuildImageQueryParams<&'a str> for BuildImageOptions<String> {
 }
 
 /// Subtype for the [Build Image Results](struct.BuildImageResults.html) type.
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[allow(missing_docs)]
 pub struct BuildImageAuxDetail {
     #[serde(rename = "ID")]
@@ -897,7 +897,7 @@ pub struct BuildImageAuxDetail {
 }
 
 /// Subtype for the [Build Image Results](struct.BuildImageResults.html) type.
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[allow(missing_docs)]
 pub struct BuildImageErrorDetail {
     pub code: Option<u64>,
@@ -905,7 +905,7 @@ pub struct BuildImageErrorDetail {
 }
 
 /// Subtype for the [Build Image Results](struct.BuildImageResults.html) type.
-#[derive(Debug, Clone, Copy, Deserialize)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
 #[allow(missing_docs)]
 pub struct BuildImageProgressDetail {
     pub current: Option<u64>,
@@ -913,7 +913,7 @@ pub struct BuildImageProgressDetail {
 }
 
 /// Result type for the [Build Image API](../struct.Docker.html#method.build_image)
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(untagged)]
 #[allow(missing_docs)]
 pub enum BuildImageResults {
@@ -1057,8 +1057,8 @@ impl Docker {
                     Docker::transpose_option(options.map(|o| o.into_array())),
                     match root_fs {
                         Some(body) => Ok(body),
-                        None => Ok(Body::empty())
-                    }
+                        None => Ok(Body::empty()),
+                    },
                 );
                 self.process_into_stream(req).boxed()
             }
@@ -1590,19 +1590,16 @@ impl Docker {
     ///
     /// # Returns
     ///  - An uncompressed TAR archive
-    pub fn export_image(
-            &self,
-            image_name: &str,
-        ) ->  impl Stream<Item = Result<Bytes, Error>> {
-            let url = format!("/images/{}/get", image_name);
-            let req = self.build_request::<_, String, String>(
-                &url,
-                Builder::new()
-                    .method(Method::GET)
-                    .header(CONTENT_TYPE, "application/json"),
-                Ok(None::<ArrayVec<[(_, _); 0]>>),
-                Ok(Body::empty()),
-            );
-            self.process_into_body(req)
-        }
+    pub fn export_image(&self, image_name: &str) -> impl Stream<Item = Result<Bytes, Error>> {
+        let url = format!("/images/{}/get", image_name);
+        let req = self.build_request::<_, String, String>(
+            &url,
+            Builder::new()
+                .method(Method::GET)
+                .header(CONTENT_TYPE, "application/json"),
+            Ok(None::<ArrayVec<[(_, _); 0]>>),
+            Ok(Body::empty()),
+        );
+        self.process_into_body(req)
+    }
 }

--- a/src/network.rs
+++ b/src/network.rs
@@ -82,7 +82,7 @@ where
 }
 
 /// Result type for the [Create Network API](../struct.Docker.html#method.create_network)
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "PascalCase")]
 #[allow(missing_docs)]
 pub struct CreateNetworkResults {
@@ -148,7 +148,7 @@ impl<'a> InspectNetworkQueryParams<'a, String> for InspectNetworkOptions<String>
 }
 
 /// Result type for the [Inspect Network API](../struct.Docker.html#method.inspect_network)
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "PascalCase")]
 #[allow(missing_docs)]
 pub struct InspectNetworkResults {
@@ -172,7 +172,7 @@ pub struct InspectNetworkResults {
 }
 
 /// Result type for the [Inspect Network API](../struct.Docker.html#method.inspect_network)
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "PascalCase")]
 #[allow(missing_docs)]
 pub struct InspectNetworkResultsContainers {
@@ -187,7 +187,7 @@ pub struct InspectNetworkResultsContainers {
 }
 
 /// Result type for the [List Networks API](../struct.Docker.html#method.list_networks)
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "PascalCase")]
 #[allow(missing_docs)]
 pub struct ListNetworksResults {
@@ -417,7 +417,7 @@ impl<'a> PruneNetworksQueryParams<&'a str, String> for PruneNetworksOptions<&'a 
 }
 
 /// Result type for the [Prune Networks API](../struct.Docker.html#method.prune_networks)
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "PascalCase")]
 #[allow(missing_docs)]
 pub struct PruneNetworksResults {

--- a/src/system.rs
+++ b/src/system.rs
@@ -104,7 +104,7 @@ where
 }
 
 /// Actor returned in the [Events API](../struct.Docker.html#method.events)
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "PascalCase")]
 #[allow(missing_docs)]
 pub struct EventsActorResults {
@@ -114,7 +114,7 @@ pub struct EventsActorResults {
 }
 
 /// Result type for the [Events API](../struct.Docker.html#method.events)
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "PascalCase")]
 #[allow(missing_docs)]
 pub struct EventsResults {
@@ -131,7 +131,7 @@ pub struct EventsResults {
 }
 
 /// Volumes returned in the [Df API](../struct.Docker.html#method.df)
-#[derive(Debug, Clone, Copy, Deserialize)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
 #[serde(rename_all = "PascalCase")]
 #[allow(missing_docs)]
 pub struct DfVolumesUsageDataResults {
@@ -140,7 +140,7 @@ pub struct DfVolumesUsageDataResults {
 }
 
 /// Volumes returned in the [Df API](../struct.Docker.html#method.df)
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "PascalCase")]
 #[allow(missing_docs)]
 pub struct DfVolumesResults {
@@ -154,7 +154,7 @@ pub struct DfVolumesResults {
 }
 
 /// Result type for the [Df API](../struct.Docker.html#method.df)
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "PascalCase")]
 #[allow(missing_docs)]
 pub struct DfResults {

--- a/src/volume.rs
+++ b/src/volume.rs
@@ -17,7 +17,7 @@ use crate::errors::Error;
 use crate::errors::ErrorKind::JsonSerializeError;
 
 /// Subresult type for the [List Volumes API](../struct.Docker.html#method.list_volumes)
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "PascalCase")]
 #[allow(missing_docs)]
 pub struct VolumesListVolumesResults {
@@ -31,7 +31,7 @@ pub struct VolumesListVolumesResults {
 }
 
 /// Result type for the [List Volumes API](../struct.Docker.html#method.list_volumes)
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "PascalCase")]
 #[allow(missing_docs)]
 pub struct ListVolumesResults {
@@ -79,7 +79,7 @@ impl<'a, T: AsRef<str> + Eq + Hash + Serialize> ListVolumesQueryParams<&'a str, 
 
 /// Result type for the [Inspect Volume API](../struct.Docker.html#method.inspect_volume) and the
 /// [Create Volume API](../struct.Docker.html#method.create_volume)
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "PascalCase")]
 #[allow(missing_docs)]
 pub struct VolumeAPI {
@@ -197,7 +197,7 @@ impl<'a> PruneVolumesQueryParams<&'a str, String> for PruneVolumesOptions<&'a st
 }
 
 /// Result type for the [Prune Volumes API](../struct.Docker.html#method.prune_volumes)
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "PascalCase")]
 #[allow(missing_docs)]
 pub struct PruneVolumesResults {


### PR DESCRIPTION
Not sure if it was an oversight or done on purpose, but I noticed that some types were deriving `Deserialize` but not `Serialize`. Added the missing derives and hope I didn't miss any.
Just in case this was on purpose, I'm specifically looking into serializing [`Image`](https://docs.rs/bollard/0.5.0/bollard/image/struct.Image.html), so maybe I could get that in at least. 😉 