### PR TITLE
Changed LogStateHealth exit_code to i16 type

### DIFF
--- a/src/container.rs
+++ b/src/container.rs
@@ -586,7 +586,7 @@ pub struct Mount {
 pub struct LogStateHealth {
     pub start: DateTime<Utc>,
     pub end: DateTime<Utc>,
-    pub exit_code: u16,
+    pub exit_code: i16,
     pub output: String,
 }
 


### PR DESCRIPTION
Small change of type from `u16` to `i16` for the LogStateHealth exit_code field for issue #68. 