### PR TITLE
make container mount consistency optional

### DIFF
--- a/src/container.rs
+++ b/src/container.rs
@@ -240,7 +240,7 @@ where
     /// Whether the mount should be read-only.
     pub read_only: Option<bool>,
     /// The consistency requirement for the mount: `default`, `consistent`, `cached`, or `delegated`.
-    pub consistency: T,
+    pub consistency: Option<T>,
     /// Optional configuration for the `bind` type.
     pub bind_options: Option<MountPointBindOptions<T>>,
     /// Optional configuration for the `volume` type.

--- a/tests/container_test.rs
+++ b/tests/container_test.rs
@@ -554,7 +554,7 @@ async fn mount_volume_container_test(docker: Docker) -> Result<(), Error> {
                 "/tmp"
             },
             type_: "bind",
-            consistency: "default",
+            consistency: Some("default"),
             ..Default::default()
         }]),
         ..Default::default()


### PR DESCRIPTION
The path `container.config.host_config.mounts[].consistency` of `crate::container::Container` is not always present, resulting in a json parse failure when inspecting such a container.