### PR TITLE
add missing service update-status state

### DIFF
--- a/src/service_models.rs
+++ b/src/service_models.rs
@@ -737,10 +737,11 @@ where
 }
 
 #[derive(Debug, Copy, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "kebab-case")]
+#[serde(rename_all = "snake_case")]
 #[allow(missing_docs)]
 pub enum ServiceUpdateStatusState {
     Updating,
     Paused,
     Completed,
+    RollbackCompleted,
 }

--- a/src/service_models.rs
+++ b/src/service_models.rs
@@ -743,5 +743,7 @@ pub enum ServiceUpdateStatusState {
     Updating,
     Paused,
     Completed,
+    RollbackStarted,
+    RollbackPaused,
     RollbackCompleted,
 }


### PR DESCRIPTION
The `ServiceUpdateStatusState` can take the fourth, undocumented value `rollback_completed` which is set after successfully performing a rollback.