### PR TITLE
fix parsing responses without an IPv6Address

### DIFF
--- a/src/network.rs
+++ b/src/network.rs
@@ -277,7 +277,7 @@ impl<'a> ListNetworksQueryParams<&'a str, String> for ListNetworksOptions<&'a st
 #[serde(rename_all = "PascalCase")]
 pub struct ConnectNetworkOptions<T>
 where
-    T: AsRef<str> + Eq + Hash,
+    T: AsRef<str> + Eq + Hash + Default,
 {
     /// The ID or name of the container to connect to the network.
     pub container: T,
@@ -290,7 +290,7 @@ where
 #[serde(rename_all = "PascalCase")]
 pub struct EndpointSettings<T>
 where
-    T: AsRef<str> + Eq + Hash,
+    T: AsRef<str> + Eq + Hash + Default,
 {
     /// EndpointIPAMConfig represents an endpoint's IPAM configuration.
     #[serde(rename = "IPAMConfig")]
@@ -333,7 +333,7 @@ where
 #[allow(missing_docs)]
 pub struct EndpointIPAMConfig<T>
 where
-    T: AsRef<str>,
+    T: AsRef<str> + Default,
 {
     #[serde(rename = "IPv4Address")]
     pub ipv4_address: Option<T>,
@@ -655,7 +655,7 @@ impl Docker {
         config: ConnectNetworkOptions<T>,
     ) -> Result<(), Error>
     where
-        T: AsRef<str> + Eq + Hash + Serialize,
+        T: AsRef<str> + Eq + Hash + Serialize + Default,
     {
         let url = format!("/networks/{}/connect", network_name);
 


### PR DESCRIPTION
I'm not really sure why/if this change is necessary.
It seems to me as if serde does not handle a missing json key for an `Option<T>` field where `T` is not `Default` even though `None` would be the obvious value.
Another working fix for this is to mark the field with `#[serde(default = "crate::network::none")]` and create the function
`fn none<T>() -> Option<T> { None }`.
I suspect a similar issue could come up with other optional `AsRef<str>`s.

This is also relevant for calling the inspect container api, since `EndpointIPAMConfig` is a part of its response.