### PR TITLE
Fix errors under features

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ jobs:
       - run: docker run -h test.example.com --volumes-from certs -d --privileged --name test-docker-daemon docker:stable-dind --storage-driver=overlay --tlsverify --tlscacert=/certs/ca.pem --tlscert=/certs/cert.pem --tlskey=/certs/key.pem
       - run: docker run --rm --volumes-from certs --privileged --rm --entrypoint=chmod docker:stable-dind 644 /certs/key.pem /certs/ca-key.pem
       - run: docker build -t bollard .
-      - run: docker run -ti -e DOCKER_CERT_PATH=/certs -e DOCKER_HOST='tcp://test.example.com:2376' --volumes-from certs --rm --link test-docker-daemon:docker bollard cargo test -- --test test_version_tls
+      - run: docker run -ti -e DOCKER_CERT_PATH=/certs -e DOCKER_HOST='tcp://test.example.com:2376' --volumes-from certs --rm --link test-docker-daemon:docker bollard cargo test --features tls -- --test test_version_tls
   test_http:
     docker:
       - image: docker:19.03.8

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,9 +13,9 @@ edition = "2018"
 
 [features]
 # Enable OpenSSL both directly and for Hyper
-ssl = ["openssl", "hyper-openssl"]
+ssl = ["dirs", "openssl", "hyper-openssl"]
 # Enable native-tls both directly for Hyper
-tls = ["native-tls", "hyper-tls"]
+tls = ["dirs", "native-tls", "hyper-tls"]
 # Enable tests specifically for the http connector
 test_http = []
 # Enable tests specifically for the tls connector
@@ -26,7 +26,7 @@ arrayvec = "0.5.1"
 base64 = "0.12.0"
 bytes = "0.5.4"
 chrono = { version = "0.4.11", features = ["serde"] }
-dirs = "2.0.2"
+dirs = { version = "2.0.2", optional = true }
 env_logger = "0.7.1"
 failure = "0.1.7"
 hex = "0.4.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,6 @@ hyper = "0.13.6"
 hyper-openssl = { version = "0.8.0", optional = true }
 hyper-tls = { version = "0.4.1", optional = true }
 log = "0.4.8"
-mio = "0.7.0"
 native-tls = { version = "0.2.4", optional = true }
 openssl = { version = "0.10.29", optional = true }
 pin-project = "0.4.20"

--- a/src/docker.rs
+++ b/src/docker.rs
@@ -22,7 +22,7 @@ use http::header::CONTENT_TYPE;
 use http::request::Builder;
 use hyper::client::HttpConnector;
 use hyper::{self, body::Bytes, Body, Client, Method, Request, Response, StatusCode};
-#[cfg(feature = "openssl")]
+#[cfg(feature = "ssl")]
 use hyper_openssl::HttpsConnector;
 #[cfg(feature = "tls")]
 use hyper_tls;
@@ -30,10 +30,8 @@ use hyper_tls;
 use hyperlocal::UnixClient as UnixConnector;
 #[cfg(feature = "tls")]
 use native_tls::{Certificate, Identity, TlsConnector};
-#[cfg(feature = "openssl")]
-use openssl::ssl::SslConnector;
-#[cfg(feature = "openssl")]
-use openssl::ssl::{SslFiletype, SslMethod};
+#[cfg(feature = "ssl")]
+use openssl::ssl::{SslConnector, SslFiletype, SslMethod};
 use tokio_util::codec::FramedRead;
 
 use crate::container::LogOutput;
@@ -114,7 +112,7 @@ pub(crate) enum Transport {
     Http {
         client: Client<HttpConnector>,
     },
-    #[cfg(feature = "openssl")]
+    #[cfg(feature = "ssl")]
     Https {
         client: Client<HttpsConnector<HttpConnector>>,
     },
@@ -136,7 +134,7 @@ impl fmt::Debug for Transport {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Transport::Http { .. } => write!(f, "HTTP"),
-            #[cfg(feature = "openssl")]
+            #[cfg(feature = "ssl")]
             Transport::Https { .. } => write!(f, "HTTPS(openssl)"),
             #[cfg(feature = "tls")]
             Transport::Tls { .. } => write!(f, "HTTPS(native)"),
@@ -241,7 +239,7 @@ impl Clone for Docker {
     }
 }
 
-#[cfg(feature = "openssl")]
+#[cfg(feature = "ssl")]
 /// A Docker implementation typed to connect to a secure HTTPS connection using the `openssl`
 /// library.
 impl Docker {
@@ -1038,7 +1036,7 @@ impl Docker {
         // This is where we determine to which transport we issue the request.
         let request = match *transport {
             Transport::Http { ref client } => client.request(req),
-            #[cfg(feature = "openssl")]
+            #[cfg(feature = "ssl")]
             Transport::Https { ref client } => client.request(req),
             #[cfg(feature = "tls")]
             Transport::Tls { ref client } => client.request(req),

--- a/src/docker.rs
+++ b/src/docker.rs
@@ -11,8 +11,6 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use arrayvec::ArrayVec;
-#[cfg(any(feature = "ssl", feature = "tls"))]
-use dirs;
 use futures_core::Stream;
 use futures_util::future::FutureExt;
 use futures_util::future::TryFutureExt;

--- a/src/docker.rs
+++ b/src/docker.rs
@@ -44,8 +44,10 @@ use crate::errors::ErrorKind::{
     HttpClientError, HyperResponseError, JsonDataError, JsonDeserializeError, JsonSerializeError,
     RequestTimeoutError, StrParseError,
 };
-#[cfg(feature = "openssl")]
-use crate::errors::ErrorKind::{NoCertPathError, SSLError};
+#[cfg(any(feature = "ssl", feature = "tls"))]
+use crate::errors::ErrorKind::NoCertPathError;
+#[cfg(feature = "ssl")]
+use crate::errors::ErrorKind::SSLError;
 #[cfg(windows)]
 use crate::named_pipe::NamedPipeConnector;
 use crate::read::{JsonLineDecoder, NewlineLogOutputDecoder, StreamReader};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -104,7 +104,7 @@
 //!
 //! ```rust
 //! use bollard::Docker;
-//! #[cfg(feature = "openssl")]
+//! #[cfg(feature = "ssl")]
 //! Docker::connect_with_ssl_defaults();
 //! ```
 //!

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -55,11 +55,11 @@ macro_rules! rt_exec_ignore_error {
 macro_rules! connect_to_docker_and_run {
     ($exec:expr) => {{
         let rt = Runtime::new().unwrap();
-        #[cfg(all(unix, not(feature = "test_http"), not(feature = "openssl")))]
+        #[cfg(all(unix, not(feature = "test_http"), not(feature = "ssl")))]
         let fut = $exec(Docker::connect_with_unix_defaults().unwrap());
         #[cfg(feature = "test_http")]
         let fut = $exec(Docker::connect_with_http_defaults().unwrap());
-        #[cfg(feature = "openssl")]
+        #[cfg(feature = "ssl")]
         let fut = $exec(Docker::connect_with_ssl_defaults().unwrap());
         #[cfg(windows)]
         let fut = $exec(Docker::connect_with_named_pipe_defaults().unwrap());


### PR DESCRIPTION
Currently `NoCertPathError` will be imported only if `ssl` feature activated, if activate only `tls` it will not be possible compile project with this crate.