### PR TITLE
Bump version to 0.6.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "bollard"
 description = "An asynchronous Docker daemon API"
-version = "0.6.0"
+version = "0.6.1"
 authors = [ "Bollard contributors" ]
 license = "Apache-2.0"
 homepage = "https://github.com/fussybeaver/bollard"

--- a/src/container.rs
+++ b/src/container.rs
@@ -300,6 +300,40 @@ where
     pub networking_config: Option<NetworkingConfig<T>>,
 }
 
+impl From<ContainerConfig> for Config<String> {
+    fn from(container: ContainerConfig) -> Self {
+        Config {
+            hostname: container.hostname,
+            domainname: container.domainname,
+            user: container.user,
+            attach_stdin: container.attach_stdin,
+            attach_stdout: container.attach_stdout,
+            attach_stderr: container.attach_stderr,
+            exposed_ports: container.exposed_ports,
+            tty: container.tty,
+            open_stdin: container.open_stdin,
+            stdin_once: container.stdin_once,
+            env: container.env,
+            cmd: container.cmd,
+            healthcheck: container.healthcheck,
+            args_escaped: container.args_escaped,
+            image: container.image,
+            volumes: container.volumes,
+            working_dir: container.working_dir,
+            entrypoint: container.entrypoint,
+            network_disabled: container.network_disabled,
+            mac_address: container.mac_address,
+            on_build: container.on_build,
+            labels: container.labels,
+            stop_signal: container.stop_signal,
+            stop_timeout: container.stop_timeout,
+            shell: container.shell,
+            host_config: None,
+            networking_config: None,
+        }
+    }
+}
+
 /// Result type for the [Create Container API](../struct.Docker.html#method.create_container)
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "PascalCase")]

--- a/tests/container_test.rs
+++ b/tests/container_test.rs
@@ -551,6 +551,13 @@ async fn inspect_container_test(docker: Docker) -> Result<(), Error> {
 
     assert_eq!(None, result.host_config.as_ref().unwrap().capabilities);
 
+    let config: Config<String> = result.config.as_ref().unwrap().to_owned().into();
+
+    assert_eq!(
+        config.image.as_ref().unwrap(),
+        result.config.as_ref().unwrap().image.as_ref().unwrap()
+    );
+
     kill_container(&docker, "integration_test_inspect_container").await?;
 
     Ok(())


### PR DESCRIPTION
Also add `From` implementation to go from a serialized `ContainerConfig` to a `Config`, if you need to use the output of an inspect container as the input to creating a container.

Closes #75 