### PR TITLE
Fix NewlineLogOutputDecoder

### DIFF
--- a/src/container.rs
+++ b/src/container.rs
@@ -683,20 +683,21 @@ impl<'a> LogsQueryParams<&'a str> for LogsOptions {
 #[derive(Debug, Clone)]
 #[allow(missing_docs)]
 pub enum LogOutput {
-    StdErr { message: String },
-    StdOut { message: String },
-    StdIn { message: String },
-    Console { message: String },
+    StdErr { message: Bytes },
+    StdOut { message: Bytes },
+    StdIn { message: Bytes },
+    Console { message: Bytes },
 }
 
 impl fmt::Display for LogOutput {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match &self {
-            LogOutput::StdErr { message } => write!(f, "{}", message),
-            LogOutput::StdOut { message } => write!(f, "{}", message),
-            LogOutput::StdIn { message } => write!(f, "{}", message),
-            LogOutput::Console { message } => write!(f, "{}", message),
-        }
+        let message = match &self {
+            LogOutput::StdErr { message } => message,
+            LogOutput::StdOut { message } => message,
+            LogOutput::StdIn { message } => message,
+            LogOutput::Console { message } => message,
+        };
+        write!(f, "{}", String::from_utf8_lossy(&message))
     }
 }
 

--- a/src/read.rs
+++ b/src/read.rs
@@ -18,72 +18,73 @@ use tokio_util::codec::Decoder;
 use crate::container::LogOutput;
 
 use crate::errors::Error;
-use crate::errors::ErrorKind::{JsonDataError, JsonDeserializeError, StrParseError};
+use crate::errors::ErrorKind::{JsonDataError, JsonDeserializeError};
 
 #[derive(Debug, Copy, Clone)]
-pub(crate) struct NewlineLogOutputDecoder {}
+enum NewlineLogOutputDecoderState {
+    WaitingHeader,
+    WaitingPayload(u8, usize), // StreamType, Length
+}
+
+#[derive(Debug, Copy, Clone)]
+pub(crate) struct NewlineLogOutputDecoder {
+    state: NewlineLogOutputDecoderState,
+}
 
 impl NewlineLogOutputDecoder {
     pub(crate) fn new() -> NewlineLogOutputDecoder {
-        NewlineLogOutputDecoder {}
+        NewlineLogOutputDecoder {
+            state: NewlineLogOutputDecoderState::WaitingHeader,
+        }
     }
 }
 
 impl Decoder for NewlineLogOutputDecoder {
     type Item = LogOutput;
     type Error = Error;
+
     fn decode(&mut self, src: &mut BytesMut) -> Result<Option<Self::Item>, Self::Error> {
-        let nl_index = src.iter().position(|b| *b == b'\n');
-
-        if src.len() > 0 {
-            let pos = nl_index.unwrap_or(src.len() - 1);
-
-            let slice = src.split_to(pos + 1);
-            let slice = &slice[..slice.len() - 1];
-
-            if slice.len() == 0 {
-                Ok(Some(LogOutput::Console {
-                    message: String::new(),
-                }))
-            } else {
-                match &slice[0] {
-                    0 if slice.len() <= 8 => Ok(Some(LogOutput::StdIn {
-                        message: String::new(),
-                    })),
-                    0 => Ok(Some(LogOutput::StdIn {
-                        message: String::from_utf8_lossy(&slice[8..]).to_string(),
-                    })),
-                    1 if slice.len() <= 8 => Ok(Some(LogOutput::StdOut {
-                        message: String::new(),
-                    })),
-                    1 => Ok(Some(LogOutput::StdOut {
-                        message: String::from_utf8_lossy(&slice[8..]).to_string(),
-                    })),
-                    2 if slice.len() <= 8 => Ok(Some(LogOutput::StdErr {
-                        message: String::new(),
-                    })),
-                    2 => Ok(Some(LogOutput::StdErr {
-                        message: String::from_utf8_lossy(&slice[8..]).to_string(),
-                    })),
-                    _ =>
+        loop {
+            match self.state {
+                NewlineLogOutputDecoderState::WaitingHeader => {
                     // `start_exec` API on unix socket will emit values without a header
-                    {
-                        Ok(Some(LogOutput::Console {
-                            message: String::from_utf8_lossy(&slice).to_string(),
-                        }))
+                    if src.len() >= 1 && src[0] > 2 {
+                        debug!("NewlineLogOutputDecoder: no header found, return LogOutput::Console");
+                        return Ok(Some(LogOutput::Console {
+                            message: String::from_utf8_lossy(&src.split()).to_string(),
+                        }));
+                    }
+
+                    if src.len() < 8 {
+                        debug!("NewlineLogOutputDecoder: not enough data for read header");
+                        return Ok(None);
+                    }
+
+                    let header = src.split_to(8);
+                    let length = u32::from_be_bytes([header[4], header[5], header[6], header[7]]) as usize;
+                    debug!("NewlineLogOutputDecoder: read header, type = {}, length = {}", header[0], length);
+                    self.state = NewlineLogOutputDecoderState::WaitingPayload(header[0], length);
+                }
+                NewlineLogOutputDecoderState::WaitingPayload(typ, length) => {
+                    if src.len() < length {
+                        debug!("NewlineLogOutputDecoder: not enough data to read");
+                        return Ok(None);
+                    } else {
+                        debug!("NewlineLogOutputDecoder: Reading payload");
+                        let message = String::from_utf8_lossy(&src.split_to(length)).to_string();
+                        let item = match typ {
+                            0 => LogOutput::StdIn { message },
+                            1 => LogOutput::StdOut { message },
+                            2 => LogOutput::StdErr { message },
+                            _ => unreachable!(),
+                        };
+
+
+                        self.state = NewlineLogOutputDecoderState::WaitingHeader;
+                        return Ok(Some(item));
                     }
                 }
-                .map_err(|e| {
-                    StrParseError {
-                        content: hex::encode(slice.to_owned()),
-                        err: e,
-                    }
-                    .into()
-                })
             }
-        } else {
-            debug!("NewlineLogOutputDecoder returning due to an empty line");
-            Ok(None)
         }
     }
 }

--- a/tests/container_test.rs
+++ b/tests/container_test.rs
@@ -200,7 +200,7 @@ async fn logs_test(docker: Docker) -> Result<(), Error> {
 
     let value = vec.get(1).unwrap();
 
-    assert_eq!(format!("{}", value), "Hello from Docker!".to_string());
+    assert_eq!(format!("{}", value), "Hello from Docker!\n".to_string());
 
     &docker
         .remove_container("integration_test_logs", None::<RemoveContainerOptions>)


### PR DESCRIPTION
Currently [NewlineLogOutputDecoder](https://github.com/fussybeaver/bollard/blob/af9d7d808813f15fdb0be629efabba48bfe824d0/src/read.rs#L32-L89) works incorrect, `decode` always produce message even if no `\n` at end of line. `decode` also remove newline, so it's not possible distinguish is it was part of message of full message. `shiplift` implements this correctly, see https://github.com/softprops/shiplift/blob/a4cd2185976ad56b880d5a10374c4dee6d116e6a/src/tty.rs#L79-L147

- What should be fixed for this change in crate?
- Since this breaking change, `0.7.0` will be required, is this ok for you?
- What about return `Bytes` instead `String`?