### PR TITLE
Add missing TTY option for create exec

### DIFF
--- a/src/exec.rs
+++ b/src/exec.rs
@@ -30,6 +30,8 @@ where
     pub attach_stdout: Option<bool>,
     /// Attach to stderr of the exec command.
     pub attach_stderr: Option<bool>,
+    /// Allocate a pseudo-TTY.
+    pub tty: Option<bool>,
     /// Override the key sequence for detaching a container. Format is a single character `[a-Z]`
     /// or `ctrl-<value>` where `<value>` is one of: `a-z`, `@`, `^`, `[`, `,` or `_`.
     pub detach_keys: Option<T>,


### PR DESCRIPTION
The TTY option is missing from the bollard library but available at 1.39 in the Docker API https://docs.docker.com/engine/api/v1.39/#operation/ContainerExec.

I've tested this in the project I'm consuming bollard from and it works the way I wanted.