### PR TITLE
Depend on a version of hyper-unix-connector without deprecated dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ flate2 = "1.0.14"
 tar = "0.4.29"
 
 [target.'cfg(unix)'.dependencies]
-hyperlocal =  { version = "0.1.4", package = "hyper-unix-connector" }
+hyperlocal =  { version = "0.1.5", package = "hyper-unix-connector" }
 
 [target.'cfg(windows)'.dependencies]
 mio-named-pipes = "0.1.6"


### PR DESCRIPTION
See: https://github.com/fussybeaver/bollard/issues/101 