### PR TITLE
Add audit to circle CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,7 +46,14 @@ jobs:
       - setup_remote_docker
       - run: docker build -t bollard .
       - run: docker run -ti --rm bollard bash -c "rustup component add clippy && cargo clippy"
-
+  test_audit:
+    docker:
+      - image: docker:19.03.12
+    steps:
+      - checkout
+      - setup_remote_docker
+      - run: docker build -t bollard .
+      - run: docker run -ti --rm bollard bash -c "cargo install cargo-audit && cargo audit"
 workflows:
   version: 2
   test-image:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,3 +63,4 @@ workflows:
       - test_unix
       - test_doc
       - test_clippy
+      - test_audit

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ flate2 = "1.0.14"
 tar = "0.4.29"
 
 [target.'cfg(unix)'.dependencies]
-hyperlocal =  { version = "0.1.4", package = "hyper-unix-connector" }
+hyperlocal =  { version = "0.1.5", package = "hyper-unix-connector" }
 
 [target.'cfg(windows)'.dependencies]
 mio-named-pipes = "0.1.6"


### PR DESCRIPTION
This is a follow-up to https://github.com/fussybeaver/bollard/pull/102, and an attempt to provide auditing of crates within CI.

Ideally, this will provide a quick way to identify security vulnerabilities automatically, and flag new dependencies if they bring along any known security issues.