### PR TITLE
Make push_image return a stream instead of a future

### DIFF
--- a/tests/container_test.rs
+++ b/tests/container_test.rs
@@ -93,6 +93,7 @@ async fn image_push_test(docker: Docker) -> Result<(), Error> {
                 Some(integration_test_registry_credentials())
             },
         )
+        .try_collect::<Vec<_>>()
         .await?;
 
     Ok(())


### PR DESCRIPTION
I encountered a problem using the images/push API with bollard, in which the function `push_image` wouldn't complete the request. When investigating, I noticed that the function returns a `impl Future<..>`, which was returned by the `Docker::process_into_unit`-method. Printing out what the response ultimately boiled down to, I found this struct:

```rust
Response {
    status: 200,
    version: HTTP/1.1,
    headers: {
        "api-version": "1.40",
        "content-type": "application/json",
        "date": "Tue, 06 Oct 2020 17:19:40 GMT",
        "docker-experimental": "true",
        "ostype": "linux",
        "server": "Docker/19.03.12 (linux)",
        "transfer-encoding": "chunked",
    },
    body: Body(
        Streaming,
    ),
}
```

which indicates that more data is expected, and a `impl Stream<..>` is to be used instead. So this PR fixes that.