### PR TITLE
Add info API route

### DIFF
--- a/src/system.rs
+++ b/src/system.rs
@@ -98,6 +98,403 @@ pub struct VersionComponents {
     pub details: Option<HashMap<String, Value>>,
 }
 
+/// Response of Engine API: GET \"/info\"
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[allow(missing_docs)]
+pub struct Info {
+    #[serde(rename = "ID")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id: Option<String>,
+
+    #[serde(rename = "Containers")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub containers: Option<usize>,
+
+    #[serde(rename = "ContainersRunning")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub containers_running: Option<usize>,
+
+    #[serde(rename = "ContainersPaused")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub containers_paused: Option<usize>,
+
+    #[serde(rename = "ContainersStopped")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub containers_stopped: Option<usize>,
+
+    #[serde(rename = "Images")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub images: Option<usize>,
+
+    #[serde(rename = "Driver")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub driver: Option<String>,
+
+    #[serde(rename = "DriverStatus")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub driver_status: Option<Vec<Vec<String>>>,
+
+    #[serde(rename = "SystemStatus")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub system_status: Option<String>,
+
+    #[serde(rename = "Plugins")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub plugins: Option<InfoPlugins>,
+
+    #[serde(rename = "MemoryLimit")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub memory_limit: Option<bool>,
+
+    #[serde(rename = "SwapLimit")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub swap_limit: Option<bool>,
+
+    #[serde(rename = "KernelMemoryTCP")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub kernel_memory: Option<bool>,
+
+    #[serde(rename = "CpuCfsPeriod")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cpu_cfs_period: Option<bool>,
+
+    #[serde(rename = "MemoryLimit")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cpu_cfs_quota: Option<bool>,
+
+    #[serde(rename = "CPUShares")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cpushares: Option<bool>,
+
+    #[serde(rename = "CPUSet")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cpuset: Option<bool>,
+
+    #[serde(rename = "PidsLimit")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pids_limit: Option<bool>,
+
+    #[serde(rename = "IPv4Forwarding")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ipv4_forwarding: Option<bool>,
+
+    #[serde(rename = "BridgeNfIptables")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub bridge_nf_iptables: Option<bool>,
+
+    #[serde(rename = "BridgeNfIp6tables")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub bridge_nf_ip6_tables: Option<bool>,
+
+    #[serde(rename = "Debug")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub debug: Option<bool>,
+
+    #[serde(rename = "NFd")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub nfd: Option<usize>,
+
+    #[serde(rename = "OomKillDisable")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub oom_kill_disable: Option<bool>,
+
+    #[serde(rename = "NGoroutines")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ngoroutines: Option<usize>,
+
+    #[serde(rename = "SystemTime")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub system_time: Option<String>,
+
+    #[serde(rename = "LoggingDriver")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub logging_driver: Option<String>,
+
+    #[serde(rename = "CgroupDriver")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cgroup_driver: Option<String>,
+
+    #[serde(rename = "NEventsListener")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub nevents_listener: Option<usize>,
+
+    #[serde(rename = "KernelVersion")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub kernel_version: Option<String>,
+
+    #[serde(rename = "OperatingSystem")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub operating_system: Option<String>,
+
+    #[serde(rename = "Ostype")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ostype: Option<String>,
+
+    #[serde(rename = "Architecture")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub architecture: Option<String>,
+
+    #[serde(rename = "CgroupDriver")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub index_server_address: Option<String>,
+
+    #[serde(rename = "RegistryConfig")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub registry_config: Option<InfoRegistryConfig>,
+
+    #[serde(rename = "NCPU")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ncpu: Option<usize>,
+
+    #[serde(rename = "MemTotal")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mem_total: Option<usize>,
+
+    #[serde(rename = "GenericResources")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub generic_resources: Option<String>,
+
+    #[serde(rename = "DockerRootDir")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub docker_root_dir: Option<String>,
+
+    #[serde(rename = "HttpProxy")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub http_proxy: Option<String>,
+
+    #[serde(rename = "HttpsProxy")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub https_proxy: Option<String>,
+
+    #[serde(rename = "NoProxy")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub no_proxy: Option<String>,
+
+    #[serde(rename = "Name")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+
+    #[serde(rename = "Labels")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub labels: Option<Vec<String>>,
+
+    #[serde(rename = "ExperimentalBuild")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub experimental_build: Option<bool>,
+
+    #[serde(rename = "ServerVersion")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub server_version: Option<String>,
+
+    #[serde(rename = "ClusterStore")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cluster_store: Option<String>,
+
+    #[serde(rename = "ClusterAdvertise")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cluster_advertise: Option<String>,
+
+    #[serde(rename = "Runtimes")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub runtimes: Option<InfoRuntimes>,
+
+    #[serde(rename = "DefaultRuntime")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub default_runtime: Option<String>,
+
+    #[serde(rename = "Swarm")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub swarm: Option<InfoSwarm>,
+
+    #[serde(rename = "LiveRestoreEnabled")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub live_restore_enabled: Option<bool>,
+
+    #[serde(rename = "Isolation")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub isolation: Option<String>,
+
+    #[serde(rename = "InitBinary")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub init_binary: Option<String>,
+
+    #[serde(rename = "ContainerdCommit")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub containerd_commit: Option<InfoContainerdCommit>,
+
+    #[serde(rename = "RuncCommit")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub runc_commit: Option<InfoRuncCommit>,
+
+    #[serde(rename = "InitCommit")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub init_commit: Option<InfoInitCommit>,
+
+    #[serde(rename = "SecurityOptions")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub security_options: Option<Vec<String>>,
+
+    #[serde(rename = "ProductLicense")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub product_license: Option<String>,
+
+    #[serde(rename = "Warnings")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub warnings: Option<String>,
+}
+
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[allow(missing_docs)]
+pub struct InfoPlugins {
+    #[serde(rename = "Volume")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub volume: Option<Vec<String>>,
+
+    #[serde(rename = "Network")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub network: Option<Vec<String>>,
+
+    #[serde(rename = "Authorization")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub authorization: Option<String>,
+
+    #[serde(rename = "Log")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub log: Option<Vec<String>>,
+}
+
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[allow(missing_docs)]
+pub struct InfoRegistryConfig {
+    #[serde(rename = "AllowNondistributableArtifactsCidrs")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub allow_nondistributable_artifacts_cidrs: Option<Vec<String>>,
+
+    #[serde(rename = "AllowNondistributableArtifactsHostnames")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub allow_nondistributable_artifacts_hostnames: Option<Vec<String>>,
+
+    #[serde(rename = "InsecureRegistryCidrs")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub insecure_registry_cidrs: Option<Vec<String>>,
+
+    #[serde(rename = "IndexConfigs")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub index_configs: Option<InfoIndexConfigs>,
+
+    #[serde(rename = "Mirrors")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mirrors: Option<Vec<String>>,
+}
+
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[allow(missing_docs)]
+pub struct InfoIndexConfigs {
+    #[serde(rename = "DockerIo")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub docker_io: Option<InfoDockerIo>,
+}
+
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[allow(missing_docs)]
+pub struct InfoDockerIo {
+    #[serde(rename = "Name")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+
+    #[serde(rename = "Mirrors")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mirros: Option<Vec<String>>,
+
+    #[serde(rename = "Secure")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub secure: Option<bool>,
+
+    #[serde(rename = "Official")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub official: Option<bool>,
+}
+
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[allow(missing_docs)]
+pub struct InfoRuntimes {
+    #[serde(rename = "Run")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub run: Option<InfoRunc>,
+}
+
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[allow(missing_docs)]
+pub struct InfoRunc {
+    #[serde(rename = "Path")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub run: Option<String>,
+}
+
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[allow(missing_docs)]
+pub struct InfoSwarm {
+    #[serde(rename = "NodeID")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub node_id: Option<String>,
+
+    #[serde(rename = "NodeAddr")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub node_addr: Option<String>,
+
+    #[serde(rename = "LocalNodeState")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub local_node_state: Option<String>,
+
+    #[serde(rename = "ControlAvailable")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub control_available: Option<bool>,
+
+    #[serde(rename = "Error")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+
+    #[serde(rename = "RemoteManagers")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub remote_managers: Option<String>,
+}
+
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[allow(missing_docs)]
+pub struct InfoContainerdCommit {
+    #[serde(rename = "ID")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id: Option<String>,
+
+    #[serde(rename = "Expected")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub expected: Option<String>,
+}
+
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[allow(missing_docs)]
+pub struct InfoRuncCommit {
+    #[serde(rename = "ID")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id: Option<String>,
+
+    #[serde(rename = "Expected")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub expected: Option<String>,
+}
+
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[allow(missing_docs)]
+pub struct InfoInitCommit {
+    #[serde(rename = "ID")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id: Option<String>,
+
+    #[serde(rename = "Expected")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub expected: Option<String>,
+}
+
 /// Parameters used in the [Events API](../struct.Docker.html#method.events)
 ///
 /// ## Examples
@@ -168,6 +565,34 @@ impl Docker {
     pub async fn version(&self) -> Result<Version, Error> {
         let req = self.build_request(
             "/version",
+            Builder::new().method(Method::GET),
+            None::<String>,
+            Ok(Body::empty()),
+        );
+
+        self.process_into_value(req).await
+    }
+
+    /// ---
+    ///
+    /// # Info
+    ///
+    /// Returns Docker client and server information that is running.
+    ///
+    /// # Returns
+    ///
+    ///  - [Info](system/struct.Info.html), wrapped in a Future.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use bollard::Docker;
+    /// # let docker = Docker::connect_with_http_defaults().unwrap();
+    /// docker.info();
+    /// ```
+    pub async fn info(&self) -> Result<Info, Error> {
+        let req = self.build_request(
+            "/info",
             Builder::new().method(Method::GET),
             None::<String>,
             Ok(Body::empty()),


### PR DESCRIPTION
**Closes:** #125 

**Testing Done:**

Added these lines to the `info.rs` example...

```rust
async fn run() -> Result<(), Box<dyn std::error::Error>> {    
    #[cfg(unix)]    
    let docker = Docker::connect_with_unix_defaults().unwrap();    
    #[cfg(windows)]    
    let docker = Docker::connect_with_named_pipe_defaults().unwrap();    
    
    // FIXME: for testing...    
    let info = docker.info().await.unwrap();    
    println!("{:#?}", info); 
```

Then, I ran the example locally.

```bash
cargo run --example info
```
**Additional Notes:**

This PR is probably not correct since this code was not autogenerated. It was manually parsed from a `curl` command. However, I think the base idea still comes across.

@fussybeaver Thanks for this awesome project! Please let me know if you need changes for this to be merged. If my PR is way off, I'd be fine closing it.