### PR TITLE
Take all bytes from src to avoid processing again

### DIFF
--- a/src/read.rs
+++ b/src/read.rs
@@ -141,7 +141,8 @@ where
             } else {
                 // OSX will not send a newline for some API endpoints (`/events`),
                 if src[src.len() - 1] == b'}' {
-                    decode_json_from_slice(&src)
+                    let slice = src.split_to(src.len());
+                    decode_json_from_slice(&slice)
                 } else {
                     Ok(None)
                 }


### PR DESCRIPTION
This is necessary because the src is mutable and is a container that
gets new data appended later, if we don't update the "read" pointer of
the BytesMut we end up processing the same JSON "slice" over and over,
and the event stream never seems to progress.

This only happens on macOS where apparently the /events endpoint does
not get newline delineated.

This bug was found when testing vector for log processing, see https://github.com/timberio/vector/issues/5937

Related issues: 
https://github.com/fussybeaver/bollard/issues/113
https://github.com/fussybeaver/bollard/pull/114