### PR TITLE
Convert to intra-doc links

### DIFF
--- a/src/auth.rs
+++ b/src/auth.rs
@@ -3,7 +3,7 @@
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[allow(missing_docs)]
 /// DockerCredentials credentials and server URI to push images using the [Push Image
-/// API](../struct.Docker.html#method.push_image) or the [Build Image
+/// API](crate::Docker::push_image()) or the [Build Image
 /// API](../struct.Docker.html#method.build_image).
 pub struct DockerCredentials {
     pub username: Option<String>,

--- a/src/container.rs
+++ b/src/container.rs
@@ -17,7 +17,7 @@ use crate::errors::Error;
 
 use crate::models::*;
 
-/// Parameters used in the [List Container API](../struct.Docker.html#method.list_containers)
+/// Parameters used in the [List Container API](Docker::list_containers())
 ///
 /// ## Examples
 ///
@@ -75,7 +75,7 @@ where
     pub filters: HashMap<T, Vec<T>>,
 }
 
-/// Parameters used in the [Create Container API](../struct.Docker.html#method.create_container)
+/// Parameters used in the [Create Container API](Docker::create_container())
 ///
 /// ## Examples
 ///
@@ -280,7 +280,7 @@ impl From<ContainerConfig> for Config<String> {
     }
 }
 
-/// Parameters used in the [Stop Container API](../struct.Docker.html#method.stop_container)
+/// Parameters used in the [Stop Container API](Docker::stop_container())
 ///
 /// ## Examples
 ///
@@ -295,7 +295,7 @@ pub struct StopContainerOptions {
     pub t: i64,
 }
 
-/// Parameters used in the [Start Container API](../struct.Docker.html#method.start_container)
+/// Parameters used in the [Start Container API](Docker::start_container())
 ///
 /// ## Examples
 ///
@@ -317,7 +317,7 @@ where
     pub detach_keys: T,
 }
 
-/// Parameters used in the [Remove Container API](../struct.Docker.html#method.remove_container)
+/// Parameters used in the [Remove Container API](Docker::remove_container())
 ///
 /// ## Examples
 ///
@@ -341,7 +341,7 @@ pub struct RemoveContainerOptions {
     pub link: bool,
 }
 
-/// Parameters used in the [Wait Container API](../struct.Docker.html#method.wait_container)
+/// Parameters used in the [Wait Container API](Docker::wait_container())
 ///
 /// ## Examples
 ///
@@ -362,7 +362,7 @@ where
     pub condition: T,
 }
 
-/// Parameters used in the [Restart Container API](../struct.Docker.html#method.restart_container)
+/// Parameters used in the [Restart Container API](Docker::restart_container())
 ///
 /// ## Example
 ///
@@ -379,7 +379,7 @@ pub struct RestartContainerOptions {
     pub t: isize,
 }
 
-/// Parameters used in the [Inspect Container API](../struct.Docker.html#method.inspect_container)
+/// Parameters used in the [Inspect Container API](Docker::inspect_container())
 ///
 /// ## Examples
 ///
@@ -396,7 +396,7 @@ pub struct InspectContainerOptions {
     pub size: bool,
 }
 
-/// Parameters used in the [Top Processes API](../struct.Docker.html#method.top_processes)
+/// Parameters used in the [Top Processes API](Docker::top_processes())
 ///
 /// ## Examples
 ///
@@ -417,7 +417,7 @@ where
     pub ps_args: T,
 }
 
-/// Parameters used in the [Logs API](../struct.Docker.html#method.logs)
+/// Parameters used in the [Logs API](Docker::logs())
 ///
 /// ## Examples
 ///
@@ -453,7 +453,7 @@ where
     pub tail: T,
 }
 
-/// Result type for the [Logs API](../struct.Docker.html#method.logs)
+/// Result type for the [Logs API](Docker::logs())
 #[derive(Debug, Clone)]
 #[allow(missing_docs)]
 pub enum LogOutput {
@@ -475,7 +475,7 @@ impl fmt::Display for LogOutput {
     }
 }
 
-/// Parameters used in the [Stats API](../struct.Docker.html#method.stats)
+/// Parameters used in the [Stats API](super::Docker::stats())
 ///
 /// ## Examples
 ///
@@ -649,7 +649,7 @@ pub struct BlkioStatsEntry {
     pub value: u64,
 }
 
-/// Parameters used in the [Kill Container API](../struct.Docker.html#method.kill_container)
+/// Parameters used in the [Kill Container API](Docker::kill_container())
 ///
 /// ## Examples
 ///
@@ -669,7 +669,7 @@ where
     pub signal: T,
 }
 
-/// Configuration for the [Update Container API](../struct.Docker.html#method.update_container)
+/// Configuration for the [Update Container API](Docker::update_container())
 ///
 /// ## Examples
 ///
@@ -856,7 +856,7 @@ where
     pub restart_policy: Option<RestartPolicy>,
 }
 
-/// Parameters used in the [Rename Container API](../struct.Docker.html#method.rename_container)
+/// Parameters used in the [Rename Container API](Docker::rename_container())
 ///
 /// ## Examples
 ///
@@ -876,7 +876,7 @@ where
     pub name: T,
 }
 
-/// Parameters used in the [Prune Containers API](../struct.Docker.html#method.prune_containers)
+/// Parameters used in the [Prune Containers API](Docker::prune_containers())
 ///
 /// ## Examples
 ///
@@ -907,7 +907,7 @@ where
 }
 
 /// Parameters used in the [Upload To Container
-/// API](../struct.Docker.html#method.upload_to_container)
+/// API](Docker::upload_to_container)
 ///
 /// ## Examples
 ///
@@ -935,7 +935,7 @@ where
 }
 
 /// Parameters used in the [Download From Container
-/// API](../struct.Docker.html#method.download_from_container)
+/// API](Docker::download_from_container())
 ///
 /// ## Examples
 ///
@@ -964,11 +964,11 @@ impl Docker {
     ///
     /// # Arguments
     ///
-    ///  - Optional [ListContainersOptions](container/struct.ListContainersOptions.html) struct.
+    ///  - Optional [ListContainersOptions](ListContainersOptions) struct.
     ///
     /// # Returns
     ///
-    ///  - Vector of [ContainerSummaryInner](models/struct.ContainerSummaryInner.html), wrapped in a Future.
+    ///  - Vector of [ContainerSummaryInner](ContainerSummaryInner), wrapped in a Future.
     ///
     /// # Examples
     ///
@@ -1018,12 +1018,12 @@ impl Docker {
     ///
     /// # Arguments
     ///
-    ///  - Optional [Create Container Options](container/struct.CreateContainerOptions.html) struct.
-    ///  - Container [Config](container/struct.Config.html) struct.
+    ///  - Optional [Create Container Options](CreateContainerOptions) struct.
+    ///  - Container [Config](Config) struct.
     ///
     /// # Returns
     ///
-    ///  - [ContainerCreateResponse](models/struct.ContainerCreateResponse.html), wrapped in a Future.
+    ///  - [ContainerCreateResponse](ContainerCreateResponse), wrapped in a Future.
     ///
     /// # Examples
     ///
@@ -1076,7 +1076,7 @@ impl Docker {
     /// # Arguments
     ///
     ///  - Container name as a string slice.
-    ///  - Optional [Start Container Options](container/struct.StartContainerOptions.html) struct.
+    ///  - Optional [Start Container Options](StartContainerOptions) struct.
     ///
     /// # Returns
     ///
@@ -1120,7 +1120,7 @@ impl Docker {
     /// # Arguments
     ///
     /// - Container name as string slice.
-    /// - Optional [Stop Container Options](container/struct.StopContainerOptions.html) struct.
+    /// - Optional [Stop Container Options](StopContainerOptions) struct.
     ///
     /// # Returns
     ///
@@ -1165,7 +1165,7 @@ impl Docker {
     /// # Arguments
     ///
     /// - Container name as a string slice.
-    /// - Optional [Remove Container Options](container/struct.RemoveContainerOptions.html) struct.
+    /// - Optional [Remove Container Options](RemoveContainerOptions) struct.
     ///
     /// # Returns
     ///
@@ -1215,11 +1215,11 @@ impl Docker {
     /// # Arguments
     ///
     /// - Container name as string slice.
-    /// - Optional [Wait Container Options](container/struct.WaitContainerOptions.html) struct.
+    /// - Optional [Wait Container Options](WaitContainerOptions) struct.
     ///
     /// # Returns
     ///
-    ///  - [ContainerWaitResponse](models/struct.ContainerWaitResponse.html), wrapped in a
+    ///  - [ContainerWaitResponse](ContainerWaitResponse), wrapped in a
     ///  Stream.
     ///
     /// # Examples
@@ -1265,7 +1265,7 @@ impl Docker {
     /// # Arguments
     ///
     ///  - Container name as string slice.
-    ///  - Optional [Restart Container Options](container/struct.RestartContainerOptions.html) struct.
+    ///  - Optional [Restart Container Options](RestartContainerOptions) struct.
     ///
     /// # Returns
     ///
@@ -1311,11 +1311,11 @@ impl Docker {
     /// # Arguments
     ///
     ///  - Container name as a string slice.
-    ///  - Optional [Inspect Container Options](container/struct.InspectContainerOptions.html) struct.
+    ///  - Optional [Inspect Container Options](InspectContainerOptions) struct.
     ///
     /// # Returns
     ///
-    ///  - [ContainerInspectResponse](models/struct.ContainerInspectResponse.html), wrapped in a Future.
+    ///  - [ContainerInspectResponse](ContainerInspectResponse), wrapped in a Future.
     ///
     /// # Examples
     ///
@@ -1356,11 +1356,11 @@ impl Docker {
     /// # Arguments
     ///
     ///  - Container name as string slice.
-    ///  - Optional [Top Options](container/struct.TopOptions.html) struct.
+    ///  - Optional [Top Options](TopOptions) struct.
     ///
     /// # Returns
     ///
-    ///  - [ContainerTopResponse](models/struct.ContainerTopResponse.html), wrapped in a Future.
+    ///  - [ContainerTopResponse](ContainerTopResponse), wrapped in a Future.
     ///
     /// # Examples
     ///
@@ -1404,11 +1404,11 @@ impl Docker {
     /// # Arguments
     ///
     ///  - Container name as string slice.
-    ///  - Optional [Logs Options](container/struct.LogsOptions.html) struct.
+    ///  - Optional [Logs Options](LogsOptions) struct.
     ///
     /// # Returns
     ///
-    ///  - [Log Output](container/enum.LogOutput.html) enum, wrapped in a
+    ///  - [Log Output](LogOutput) enum, wrapped in a
     ///  Stream.
     ///
     /// # Examples
@@ -1460,7 +1460,7 @@ impl Docker {
     ///
     /// # Returns
     ///
-    ///  - An Option of Vector of [Container Change Response Item](models/struct.ContainerChangeResponseItem.html) structs, wrapped in a
+    ///  - An Option of Vector of [Container Change Response Item](ContainerChangeResponseItem) structs, wrapped in a
     ///  Future.
     ///
     /// # Examples
@@ -1496,11 +1496,11 @@ impl Docker {
     /// # Arguments
     ///
     /// - Container name as string slice.
-    /// - Optional [Stats Options](container/struct.StatsOptions.html) struct.
+    /// - Optional [Stats Options](StatsOptions) struct.
     ///
     /// # Returns
     ///
-    ///  - [Stats](container/struct.Stats.html) struct, wrapped in a
+    ///  - [Stats](Stats) struct, wrapped in a
     ///  Stream.
     ///
     /// # Examples
@@ -1543,7 +1543,7 @@ impl Docker {
     /// # Arguments
     ///
     /// - Container name as string slice.
-    /// - Optional [Kill Container Options](container/struct.KillContainerOptions.html) struct.
+    /// - Optional [Kill Container Options](KillContainerOptions) struct.
     ///
     /// # Returns
     ///
@@ -1592,7 +1592,7 @@ impl Docker {
     /// # Arguments
     ///
     ///  - Container name as string slice.
-    ///  - [Update Container Options](container/struct.UpdateContainerOptions.html) struct.
+    ///  - [Update Container Options](UpdateContainerOptions) struct.
     ///
     /// # Returns
     ///
@@ -1644,7 +1644,7 @@ impl Docker {
     /// # Arguments
     ///
     ///  - Container name as string slice.
-    ///  - [Rename Container Options](container/struct.RenameContainerOptions.html) struct
+    ///  - [Rename Container Options](RenameContainerOptions) struct
     ///
     /// # Returns
     ///
@@ -1762,11 +1762,11 @@ impl Docker {
     ///
     /// # Arguments
     ///
-    ///  - Optional [Prune Containers Options](container/struct.PruneContainersOptions.html) struct.
+    ///  - Optional [Prune Containers Options](PruneContainersOptions) struct.
     ///
     /// # Returns
     ///
-    ///  - [Container Prune Response](models/struct.ContainerPruneResponse.html) struct, wrapped in a Future.
+    ///  - [Container Prune Response](ContainerPruneResponse) struct, wrapped in a Future.
     ///
     /// # Examples
     ///
@@ -1813,7 +1813,7 @@ impl Docker {
     ///
     /// # Arguments
     ///
-    ///  - Optional [Upload To Container Options](container/struct.UploadToContainerOptions.html) struct.
+    ///  - Optional [Upload To Container Options](UploadToContainerOptions) struct.
     ///
     /// # Returns
     ///
@@ -1872,12 +1872,12 @@ impl Docker {
     ///
     /// # Arguments
     ///
-    ///  - [Download From Container Options](container/struct.DownloadFromContainerOptions.html) struct.
+    ///  - [Download From Container Options](DownloadFromContainerOptions) struct.
     ///
     /// # Returns
     ///
     ///  - Tar archive compressed with one of the following algorithms: identity (no compression),
-    ///    gzip, bzip2, xz. [Hyper Body](https://hyper.rs/hyper/master/hyper/struct.Body.html).
+    ///    gzip, bzip2, xz. [Hyper Body](hyper::body::Body).
     ///
     /// # Examples
     ///

--- a/src/docker.rs
+++ b/src/docker.rs
@@ -117,8 +117,8 @@ impl fmt::Debug for Transport {
 /// a higher client version is used than is compatible with the server. Beware also, that the
 /// docker server will return stubs for a higher version than the version set when communicating.
 ///
-/// See also [negotiate_version](struct.Docker.html#method.negotiate_version), and the `client_version` argument when instantiating the
-/// [Docker](struct.Docker.html) client instance.
+/// See also [negotiate_version](Docker::negotiate_version()), and the `client_version` argument when instantiating the
+/// [Docker] client instance.
 pub struct ClientVersion {
     /// The major version number.
     pub major_version: usize,
@@ -203,11 +203,11 @@ where
 ///
 /// The main interface for calling the Docker API. Construct a new Docker instance using one of the
 /// connect methods:
-///  - [`Docker::connect_with_http_defaults`](struct.Docker.html#method.connect_with_http_defaults)
-///  - [`Docker::connect_with_named_pipe_defaults`](struct.Docker.html#method.connect_with_pipe_defaults)
-///  - [`Docker::connect_with_ssl_defaults`](struct.Docker.html#method.connect_with_ssl_defaults)
-///  - [`Docker::connect_with_unix_defaults`](struct.Docker.html#method.connect_with_unix_defaults)
-///  - [`Docker::connect_with_local_defaults`](struct.Docker.html#method.connect_with_local_defaults)
+///  - [`Docker::connect_with_http_defaults`](Docker::connect_with_http_defaults())
+///  - [`Docker::connect_with_named_pipe_defaults`](Docker::connect_with_named_pipe_defaults())
+///  - [`Docker::connect_with_ssl_defaults`](Docker::connect_with_ssl_defaults())
+///  - [`Docker::connect_with_unix_defaults`](Docker::connect_with_unix_defaults())
+///  - [`Docker::connect_with_local_defaults`](Docker::connect_with_local_defaults())
 pub struct Docker {
     pub(crate) transport: Arc<Transport>,
     pub(crate) client_type: ClientType,
@@ -683,8 +683,8 @@ impl Docker {
     ///  * Unix: [`Docker::connect_with_unix_defaults`]
     ///  * Windows: [`Docker::connect_with_named_pipe_defaults`]
     ///
-    /// [`Docker::connect_with_unix_defaults`]: struct.Docker.html#method.connect_with_unix_defaults
-    /// [`Docker::connect_with_named_pipe_defaults`]: struct.Docker.html#method.connect_with_named_pipe_defaults
+    /// [`Docker::connect_with_unix_defaults`]: Docker::connect_with_unix_defaults()
+    /// [`Docker::connect_with_named_pipe_defaults`]: Docker::connect_with_named_pipe_defaults()
     pub fn connect_with_local_defaults() -> Result<Docker, Error> {
         #[cfg(unix)]
         return Docker::connect_with_unix_defaults();
@@ -698,8 +698,8 @@ impl Docker {
     ///  * Unix: [`Docker::connect_with_unix`]
     ///  * Windows: [`Docker::connect_with_named_pipe`]
     ///
-    /// [`Docker::connect_with_unix`]: struct.Docker.html#method.connect_with_unix
-    /// [`Docker::connect_with_named_pipe`]: struct.Docker.html#method.connect_with_named_pipe
+    /// [`Docker::connect_with_unix`]: Docker::connect_with_unix()
+    /// [`Docker::connect_with_named_pipe`]: Docker::connect_with_named_pipe()
     pub fn connect_with_local(
         addr: &str,
         timeout: u64,

--- a/src/exec.rs
+++ b/src/exec.rs
@@ -17,7 +17,7 @@ use crate::container::LogOutput;
 use crate::errors::Error;
 use crate::models::ExecInspectResponse;
 
-/// Exec configuration used in the [Create Exec API](../struct.Docker.html#method.create_exec)
+/// Exec configuration used in the [Create Exec API](Docker::create_exec())
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(rename_all = "PascalCase")]
 pub struct CreateExecOptions<T>
@@ -48,7 +48,7 @@ where
     pub working_dir: Option<T>,
 }
 
-/// Result type for the [Create Exec API](../struct.Docker.html#method.create_exec)
+/// Result type for the [Create Exec API](Docker::create_exec())
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "PascalCase")]
 #[allow(missing_docs)]
@@ -56,7 +56,7 @@ pub struct CreateExecResults {
     pub id: String,
 }
 
-/// Exec configuration used in the [Create Exec API](../struct.Docker.html#method.create_exec)
+/// Exec configuration used in the [Create Exec API](Docker::create_exec())
 #[derive(Debug, Clone, Copy, Default, Serialize, Deserialize)]
 #[serde(rename_all = "PascalCase")]
 pub struct StartExecOptions {
@@ -64,7 +64,7 @@ pub struct StartExecOptions {
     pub detach: bool,
 }
 
-/// Result type for the [Start Exec API](../struct.Docker.html#method.start_exec)
+/// Result type for the [Start Exec API](Docker::start_exec())
 #[derive(Debug, Clone)]
 #[allow(missing_docs)]
 pub enum StartExecResults {
@@ -82,11 +82,11 @@ impl Docker {
     /// # Arguments
     ///
     ///  - Container name as string slice.
-    ///  - [Create Exec Options](exec/struct.CreateExecOptions.html) struct.
+    ///  - [Create Exec Options](CreateExecOptions) struct.
     ///
     /// # Returns
     ///
-    ///  - A [Create Exec Results](exec/struct.CreateExecResults.html) struct, wrapped in a
+    ///  - A [Create Exec Results](CreateExecResults) struct, wrapped in a
     ///  Future.
     ///
     /// # Examples
@@ -140,7 +140,7 @@ impl Docker {
     ///
     /// # Returns
     ///
-    ///  - [Log Output](container/enum.LogOutput.html) enum, wrapped in a Stream.
+    ///  - [Log Output](LogOutput) enum, wrapped in a Stream.
     ///
     /// # Examples
     ///
@@ -220,7 +220,7 @@ impl Docker {
     ///
     /// # Returns
     ///
-    ///  - An [Exec Inspect Response](models/struct.ExecInspectResponse.html) struct, wrapped in a Future.
+    ///  - An [Exec Inspect Response](ExecInspectResponse) struct, wrapped in a Future.
     ///
     /// # Examples
     ///

--- a/src/image.rs
+++ b/src/image.rs
@@ -17,7 +17,7 @@ use std::collections::HashMap;
 use std::hash::Hash;
 
 /// Parameters available for pulling an image, used in the [Create Image
-/// API](../struct.Docker.html#method.create_image)
+/// API](Docker::create_image)
 ///
 /// ## Examples
 ///
@@ -63,7 +63,7 @@ where
 }
 
 /// Parameters to the [List Images
-/// API](../struct.Docker.html#method.list_images)
+/// API](Docker::list_images())
 ///
 /// ## Examples
 ///
@@ -110,7 +110,7 @@ where
     pub digests: bool,
 }
 
-/// Parameters to the [Prune Images API](../struct.Docker.html#method.prune_images)
+/// Parameters to the [Prune Images API](Docker::prune_images())
 ///
 /// ## Examples
 ///
@@ -153,7 +153,7 @@ where
     pub filters: HashMap<T, Vec<T>>,
 }
 
-/// Parameters to the [Search Images API](../struct.Docker.html#method.search_images)
+/// Parameters to the [Search Images API](Docker::search_images())
 ///
 /// ## Example
 ///
@@ -196,7 +196,7 @@ where
     pub filters: HashMap<T, T>,
 }
 
-/// Parameters to the [Remove Image API](../struct.Docker.html#method.remove_image)
+/// Parameters to the [Remove Image API](Docker::remove_image())
 ///
 /// ## Examples
 ///
@@ -217,7 +217,7 @@ pub struct RemoveImageOptions {
     pub noprune: bool,
 }
 
-/// Parameters to the [Tag Image API](../struct.Docker.html#method.tag_image)
+/// Parameters to the [Tag Image API](Docker::tag_image())
 ///
 /// ## Examples
 ///
@@ -249,7 +249,7 @@ where
     pub tag: T,
 }
 
-/// Parameters to the [Push Image API](../struct.Docker.html#method.push_image)
+/// Parameters to the [Push Image API](Docker::push_image())
 ///
 /// ## Examples
 ///
@@ -277,7 +277,7 @@ where
     pub tag: T,
 }
 
-/// Parameters to the [Commit Container API](../struct.Docker.html#method.commit_container)
+/// Parameters to the [Commit Container API](Docker::commit_container())
 ///
 /// ## Examples
 ///
@@ -319,7 +319,7 @@ where
     pub changes: Option<T>,
 }
 
-/// Parameters to the [Build Image API](../struct.Docker.html#method.build_image)
+/// Parameters to the [Build Image API](Docker::build_image())
 ///
 /// ## Examples
 ///
@@ -405,7 +405,7 @@ where
     pub platform: T,
 }
 
-/// Parameters to the [Import Image API](../struct.Docker.html#method.import_image)
+/// Parameters to the [Import Image API](Docker::import_image())
 ///
 /// ## Examples
 ///
@@ -434,11 +434,11 @@ impl Docker {
     ///
     /// # Arguments
     ///
-    ///  - An optional [List Images Options](image/struct.ListImagesOptions.html) struct.
+    ///  - An optional [List Images Options](ListImagesOptions) struct.
     ///
     /// # Returns
     ///
-    ///  - Vector of [API Images](models/struct.ImageSummary.html), wrapped in a Future.
+    ///  - Vector of [API Images](ImageSummary), wrapped in a Future.
     ///
     /// # Examples
     ///
@@ -488,13 +488,13 @@ impl Docker {
     ///
     /// # Arguments
     ///
-    ///  - An optional [Create Image Options](image/struct.CreateImageOptions.html) struct.
+    ///  - An optional [Create Image Options](CreateImageOptions) struct.
     ///  - An optional request body consisting of a tar or tar.gz archive with the root file system
     ///    for the image. If this argument is used, the value of the `from_src` option must be "-".
     ///
     /// # Returns
     ///
-    ///  - [Build Info](models/struct.BuildInfo.html), wrapped in an asynchronous
+    ///  - [Build Info](BuildInfo), wrapped in an asynchronous
     ///  Stream.
     ///
     /// # Examples
@@ -564,7 +564,7 @@ impl Docker {
     ///
     /// # Returns
     ///
-    ///  - [Image](models/struct.Image.html), wrapped in a Future.
+    ///  - [Image](Image), wrapped in a Future.
     ///
     /// # Examples
     ///
@@ -597,11 +597,11 @@ impl Docker {
     ///
     /// # Arguments
     ///
-    /// - An optional [Prune Images Options](image/struct.PruneImagesOptions.html) struct.
+    /// - An optional [Prune Images Options](PruneImagesOptions) struct.
     ///
     /// # Returns
     ///
-    ///  - a [Prune Image Response](models/struct.ImagePruneResponse.html), wrapped in a Future.
+    ///  - a [Prune Image Response](ImagePruneResponse), wrapped in a Future.
     ///
     /// # Examples
     ///
@@ -652,7 +652,7 @@ impl Docker {
     ///
     /// # Returns
     ///
-    ///  - Vector of [History Response Item](models/struct.HistoryResponseItem.html), wrapped in a
+    ///  - Vector of [History Response Item](HistoryResponseItem), wrapped in a
     ///  Future.
     ///
     /// # Examples
@@ -684,11 +684,11 @@ impl Docker {
     ///
     /// # Arguments
     ///
-    ///  - [Search Image Options](image/struct.SearchImagesOptions.html) struct.
+    ///  - [Search Image Options](SearchImagesOptions) struct.
     ///
     /// # Returns
     ///
-    ///  - Vector of [Image Search Response Item](models/struct.ImageSearchResponseItem.html) results, wrapped in a
+    ///  - Vector of [Image Search Response Item](ImageSearchResponseItem) results, wrapped in a
     ///  Future.
     ///
     /// # Examples
@@ -740,11 +740,11 @@ impl Docker {
     /// # Arguments
     ///
     ///  - Image name as a string slice.
-    ///  - An optional [Remove Image Options](image/struct.RemoveImageOptions.html) struct.
+    ///  - An optional [Remove Image Options](RemoveImageOptions) struct.
     ///
     /// # Returns
     ///
-    ///  - Vector of [Image Delete Response Item](models/struct.ImageDeleteResponseItem.html), wrapped in a
+    ///  - Vector of [Image Delete Response Item](ImageDeleteResponseItem), wrapped in a
     ///  Future.
     ///
     /// # Examples
@@ -798,7 +798,7 @@ impl Docker {
     /// # Arguments
     ///
     ///  - Image name as a string slice.
-    ///  - Optional [Tag Image Options](image/struct.TagImageOptions.html) struct.
+    ///  - Optional [Tag Image Options](TagImageOptions) struct.
     ///
     /// # Returns
     ///
@@ -849,8 +849,8 @@ impl Docker {
     /// # Arguments
     ///
     ///  - Image name as a string slice.
-    ///  - Optional [Push Image Options](image/struct.PushImageOptions.html) struct.
-    ///  - Optional [Docker Credentials](auth/struct.DockerCredentials.html) struct.
+    ///  - Optional [Push Image Options](PushImageOptions) struct.
+    ///  - Optional [Docker Credentials](DockerCredentials) struct.
     ///
     /// # Returns
     ///
@@ -918,12 +918,12 @@ impl Docker {
     ///
     /// # Arguments
     ///
-    ///  - [Commit Container Options](image/struct.CommitContainerOptions.html) struct.
-    ///  - Container [Config](container/struct.Config.html) struct.
+    ///  - [Commit Container Options](CommitContainerOptions) struct.
+    ///  - Container [Config](Config) struct.
     ///
     /// # Returns
     ///
-    ///  - [Commit](models/struct.Commit.html), wrapped in a Future.
+    ///  - [Commit](Commit), wrapped in a Future.
     ///
     /// # Examples
     ///
@@ -980,14 +980,14 @@ impl Docker {
     ///
     /// # Arguments
     ///
-    ///  - [Build Image Options](image/struct.BuildImageOptions.html) struct.
-    ///  - Optional [Docker Credentials](auth/struct.DockerCredentials.html) struct.
+    ///  - [Build Image Options](BuildImageOptions) struct.
+    ///  - Optional [Docker Credentials](DockerCredentials) struct.
     ///  - Tar archive compressed with one of the following algorithms: identity (no compression),
-    ///    gzip, bzip2, xz. Optional [Hyper Body](https://hyper.rs/hyper/master/hyper/struct.Body.html).
+    ///    gzip, bzip2, xz. Optional [Hyper Body](hyper::body::Body).
     ///
     /// # Returns
     ///
-    ///  - [Create Image Info](models/struct.CreateImageInfo.html), wrapped in an asynchronous
+    ///  - [Create Image Info](CreateImageInfo), wrapped in an asynchronous
     ///  Stream.
     ///
     /// # Examples
@@ -1087,11 +1087,11 @@ impl Docker {
     /// endpoint](struct.Docker.html#method.export_image).
     ///
     /// # Arguments
-    ///  - [Image Import Options](./image/struct.ImportImageOptions.html) struct.
+    ///  - [Image Import Options](ImportImageOptions) struct.
     ///
     /// # Returns
     ///
-    ///  - [Build Info](models/struct.BuildInfo.html), wrapped in an asynchronous
+    ///  - [Build Info](BuildInfo), wrapped in an asynchronous
     ///  Stream.
     ///
     /// # Examples

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,7 +25,7 @@
 //! # API
 //! ## Documentation
 //!
-//! [API docs](https://docs.rs/bollard/).
+//! [API docs](crate).
 //!
 //! As of version 0.6, this project now generates API stubs from the upstream Docker-maintained
 //! [Swagger OpenAPI specification](https://docs.docker.com/engine/api/v1.40.yaml). The generated

--- a/src/network.rs
+++ b/src/network.rs
@@ -13,7 +13,7 @@ use crate::errors::Error;
 
 use crate::models::*;
 
-/// Network configuration used in the [Create Network API](../struct.Docker.html#method.create_network)
+/// Network configuration used in the [Create Network API](Docker::create_network())
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(rename_all = "PascalCase")]
 pub struct CreateNetworkOptions<T>
@@ -48,7 +48,7 @@ where
     pub labels: HashMap<T, T>,
 }
 
-/// Parameters used in the [Inspect Network API](../struct.Docker.html#method.inspect_network)
+/// Parameters used in the [Inspect Network API](super::Docker::inspect_network())
 ///
 /// ## Examples
 ///
@@ -79,7 +79,7 @@ where
     pub scope: T,
 }
 
-/// Parameters used in the [List Networks API](../struct.Docker.html#method.list_networks)
+/// Parameters used in the [List Networks API](super::Docker::list_networks())
 ///
 /// ## Examples
 ///
@@ -120,7 +120,7 @@ where
     pub filters: HashMap<T, Vec<T>>,
 }
 
-/// Network configuration used in the [Connect Network API](../struct.Docker.html#method.connect_network)
+/// Network configuration used in the [Connect Network API](Docker::connect_network())
 #[derive(Debug, Clone, Default, Serialize)]
 #[serde(rename_all = "PascalCase")]
 pub struct ConnectNetworkOptions<T>
@@ -133,7 +133,7 @@ where
     pub endpoint_config: EndpointSettings,
 }
 
-/// Network configuration used in the [Disconnect Network API](../struct.Docker.html#method.disconnect_network)
+/// Network configuration used in the [Disconnect Network API](Docker::disconnect_network())
 #[derive(Debug, Clone, Default, Serialize)]
 #[serde(rename_all = "PascalCase")]
 pub struct DisconnectNetworkOptions<T>
@@ -146,7 +146,7 @@ where
     pub force: bool,
 }
 
-/// Parameters used in the [Prune Networks API](../struct.Docker.html#method.prune_networks)
+/// Parameters used in the [Prune Networks API](Docker::prune_networks())
 ///
 /// ## Examples
 ///
@@ -195,11 +195,11 @@ impl Docker {
     ///
     /// # Arguments
     ///
-    ///  - [Create Network Options](network/struct.CreateNetworkOptions.html) struct.
+    ///  - [Create Network Options](CreateNetworkOptions) struct.
     ///
     /// # Returns
     ///
-    ///  - A [Network Create Response](models/struct.NetworkCreateResponse.html) struct, wrapped in a
+    ///  - A [Network Create Response](NetworkCreateResponse) struct, wrapped in a
     ///  Future.
     ///
     /// # Examples
@@ -281,7 +281,7 @@ impl Docker {
     ///
     /// # Returns
     ///
-    ///  - A [Models](models/struct.Network.html) struct, wrapped in a
+    ///  - A [Models](Network) struct, wrapped in a
     ///  Future.
     ///
     /// # Examples
@@ -327,11 +327,11 @@ impl Docker {
     ///
     /// # Arguments
     ///
-    ///  - Optional [List Network Options](network/struct.ListNetworksOptions.html) struct.
+    ///  - Optional [List Network Options](ListNetworksOptions) struct.
     ///
     /// # Returns
     ///
-    ///  - A vector of [Network](models/struct.Network.html) struct, wrapped in a
+    ///  - A vector of [Network](Network) struct, wrapped in a
     ///  Future.
     ///
     /// # Examples
@@ -378,7 +378,7 @@ impl Docker {
     ///
     /// # Arguments
     ///
-    ///  - A [Connect Network Options](network/struct.ConnectNetworkOptions.html) struct.
+    ///  - A [Connect Network Options](ConnectNetworkOptions) struct.
     ///
     /// # Returns
     ///
@@ -435,7 +435,7 @@ impl Docker {
     ///
     /// # Arguments
     ///
-    ///  - A [Disconnect Network Options](network/struct.DisconnectNetworkOptions.html) struct.
+    ///  - A [Disconnect Network Options](DisconnectNetworkOptions) struct.
     ///
     /// # Returns
     ///
@@ -486,11 +486,11 @@ impl Docker {
     ///
     /// # Arguments
     ///
-    ///  - A [Prune Networks Options](network/struct.PruneNetworksOptions.html) struct.
+    ///  - A [Prune Networks Options](PruneNetworksOptions) struct.
     ///
     /// # Returns
     ///
-    ///  - A [Network Prune Response](models/struct.NetworkPruneResponse.html) struct.
+    ///  - A [Network Prune Response](NetworkPruneResponse) struct.
     ///
     /// # Examples
     ///

--- a/src/service.rs
+++ b/src/service.rs
@@ -12,7 +12,7 @@ use serde::ser::Serialize;
 
 use std::{collections::HashMap, hash::Hash};
 
-/// Parameters used in the [List Service API](../struct.Docker.html#method.list_services)
+/// Parameters used in the [List Service API](super::Docker::list_services())
 ///
 /// ## Examples
 ///
@@ -49,7 +49,7 @@ where
     pub filters: HashMap<T, Vec<T>>,
 }
 
-/// Parameters used in the [Inspect Service API](../struct.Docker.html#method.inspect_service)
+/// Parameters used in the [Inspect Service API](Docker::inspect_service())
 ///
 /// ## Examples
 ///
@@ -67,7 +67,7 @@ pub struct InspectServiceOptions {
     pub insert_defaults: bool,
 }
 
-/// Parameters used in the [Update Service API](../struct.Docker.html#method.update_service)
+/// Parameters used in the [Update Service API](Docker::update_service())
 ///
 /// ## Examples
 ///
@@ -124,11 +124,11 @@ impl Docker {
     ///
     /// # Arguments
     ///
-    ///  - Optional [ListServicesOptions](service/struct.ListServicesOptions.html) struct.
+    ///  - Optional [ListServicesOptions](ListServicesOptions) struct.
     ///
     /// # Returns
     ///
-    ///  - Vector of [Services](models/struct.Service.html), wrapped in a Future.
+    ///  - Vector of [Services](Service), wrapped in a Future.
     ///
     /// # Examples
     ///
@@ -177,12 +177,12 @@ impl Docker {
     ///
     /// # Arguments
     ///
-    ///  - [ServiceSpec](models/struct.ServiceSpec.html) struct.
-    ///  - Optional [Docker Credentials](auth/struct.DockerCredentials.html) struct.
+    ///  - [ServiceSpec](ServiceSpec) struct.
+    ///  - Optional [Docker Credentials](DockerCredentials) struct.
     ///
     /// # Returns
     ///
-    ///  - A [Service Create Response](models/struct.ServiceCreateResponse.html) struct,
+    ///  - A [Service Create Response](ServiceCreateResponse) struct,
     ///  wrapped in a Future.
     ///
     /// # Examples
@@ -257,11 +257,11 @@ impl Docker {
     /// # Arguments
     ///
     ///  - Service name or id as a string slice.
-    ///  - Optional [Inspect Service Options](service/struct.InspectServiceOptions.html) struct.
+    ///  - Optional [Inspect Service Options](InspectServiceOptions) struct.
     ///
     /// # Returns
     ///
-    ///  - [Service](models/struct.Service.html), wrapped in a Future.
+    ///  - [Service](Service), wrapped in a Future.
     ///
     /// # Examples
     ///
@@ -337,13 +337,13 @@ impl Docker {
     /// # Arguments
     ///
     ///  - Service name or id as a string slice.
-    ///  - [ServiceSpec](models/struct.ServiceSpec.html) struct.
-    ///  - [UpdateServiceOptions](service/struct.UpdateServiceOptions.html) struct.
-    ///  - Optional [Docker Credentials](auth/struct.DockerCredentials.html) struct.
+    ///  - [ServiceSpec](ServiceSpec) struct.
+    ///  - [UpdateServiceOptions](UpdateServiceOptions) struct.
+    ///  - Optional [Docker Credentials](DockerCredentials) struct.
     ///
     /// # Returns
     ///
-    ///  - A [Service Update Response](models/struct.ServiceUpdateResponse.html) struct,
+    ///  - A [Service Update Response](ServiceUpdateResponse) struct,
     ///  wrapped in a Future.
     ///
     /// # Examples

--- a/src/system.rs
+++ b/src/system.rs
@@ -98,7 +98,7 @@ pub struct VersionComponents {
     pub details: Option<HashMap<String, Value>>,
 }
 
-/// Parameters used in the [Events API](../struct.Docker.html#method.events)
+/// Parameters used in the [Events API](Docker::events())
 ///
 /// ## Examples
 ///
@@ -156,7 +156,7 @@ impl Docker {
     ///
     /// # Returns
     ///
-    ///  - [Version](system/struct.Version.html), wrapped in a Future.
+    ///  - [Version](Version), wrapped in a Future.
     ///
     /// # Examples
     ///
@@ -184,7 +184,7 @@ impl Docker {
     ///
     /// # Returns
     ///
-    ///  - [Info](system/struct.Info.html), wrapped in a Future.
+    ///  - [Info](SystemInfo), wrapped in a Future.
     ///
     /// # Examples
     ///
@@ -212,7 +212,7 @@ impl Docker {
     ///
     /// # Returns
     ///
-    ///  - A String, wrapped in a Future.
+    ///  - A [String](std::string::String), wrapped in a Future.
     ///
     /// # Examples
     ///
@@ -243,7 +243,7 @@ impl Docker {
     ///
     /// # Returns
     ///
-    ///  - [System Events Response](models/struct.SystemEventsResponse.html),
+    ///  - [System Events Response](SystemEventsResponse),
     ///  wrapped in a Stream.
     ///
     /// # Examples
@@ -290,7 +290,7 @@ impl Docker {
     /// # Returns
     ///
     ///  - [System Data Usage
-    ///  Response](models/struct.SystemDataUsageResponse.html), wrapped in a
+    ///  Response](SystemDataUsageResponse), wrapped in a
     ///  Future.
     ///
     /// # Examples

--- a/src/volume.rs
+++ b/src/volume.rs
@@ -12,7 +12,7 @@ use super::Docker;
 use crate::errors::Error;
 use crate::models::*;
 
-/// Parameters used in the [List Volume API](../struct.Docker.html#method.list_volumes)
+/// Parameters used in the [List Volume API](Docker::list_volumes())
 #[derive(Debug, Clone, Default, Serialize)]
 pub struct ListVolumesOptions<T>
 where
@@ -28,7 +28,7 @@ where
 }
 
 /// Volume configuration used in the [Create Volume
-/// API](../struct.Docker.html#method.create_volume)
+/// API](Docker::create_volume())
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(rename_all = "PascalCase")]
 pub struct CreateVolumeOptions<T>
@@ -46,7 +46,7 @@ where
     pub labels: HashMap<T, T>,
 }
 
-/// Parameters used in the [Remove Volume API](../struct.Docker.html#method.remove_volume)
+/// Parameters used in the [Remove Volume API](super::Docker::remove_volume())
 #[derive(Debug, Clone, Copy, Default, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RemoveVolumeOptions {
@@ -54,7 +54,7 @@ pub struct RemoveVolumeOptions {
     pub force: bool,
 }
 
-/// Parameters used in the [Prune Volumes API](../struct.Docker.html#method.prune_volumes)
+/// Parameters used in the [Prune Volumes API](Docker::prune_volumes())
 ///
 /// ## Examples
 ///
@@ -99,11 +99,11 @@ impl Docker {
     ///
     /// # Arguments
     ///
-    ///  - [List Volumes Options](volume/struct.ListVolumesOptions.html) struct.
+    ///  - [List Volumes Options](ListVolumesOptions) struct.
     ///
     /// # Returns
     ///
-    ///  - A [Volume List Response](models/struct.VolumeListResponse.html) struct, wrapped in a
+    ///  - A [Volume List Response]VolumeListResponse) struct, wrapped in a
     ///  Future.
     ///
     /// # Examples
@@ -152,11 +152,11 @@ impl Docker {
     ///
     /// # Arguments
     ///
-    ///  - [Create Volume Options](volume/struct.CreateVolumeOptions.html) struct.
+    ///  - [Create Volume Options](CreateVolumeOptions) struct.
     ///
     /// # Returns
     ///
-    ///  - A [Volume](models/struct.Volume.html) struct, wrapped in a
+    ///  - A [Volume](Volume) struct, wrapped in a
     ///  Future.
     ///
     /// # Examples
@@ -202,7 +202,7 @@ impl Docker {
     ///
     /// # Returns
     ///
-    ///  - A [Volume](models/struct.Volume.html) struct, wrapped in a
+    ///  - A [Volume](Volume) struct, wrapped in a
     ///  Future.
     ///
     /// # Examples
@@ -236,7 +236,7 @@ impl Docker {
     ///
     /// # Arguments
     ///
-    ///  - [Remove Volume Options](volume/struct.RemoveVolumeOptions.html) struct.
+    ///  - [Remove Volume Options](RemoveVolumeOptions) struct.
     ///
     /// # Returns
     ///
@@ -281,11 +281,11 @@ impl Docker {
     ///
     /// # Arguments
     ///
-    ///  - A [Prune Volumes Options](volume/struct.PruneVolumesOptions.html) struct.
+    ///  - A [Prune Volumes Options](PruneVolumesOptions) struct.
     ///
     /// # Returns
     ///
-    ///  - A [Volume Prune Response](models/struct.VolumePruneResponse.html) struct.
+    ///  - A [Volume Prune Response](VolumePruneResponse) struct.
     ///
     /// # Examples
     ///


### PR DESCRIPTION
resolves #136 

The documentation needs to be generated with `--all-features` flag in order to properly resolve links. (For _ssl_ feature)
```shell
cargo doc --all-features
```
