### PR TITLE
Allow passing input to docker exec processes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"
 serde_urlencoded = "0.7"
-tokio = { version = "1.2", features = ["time", "fs", "net", "rt", "rt-multi-thread"] }
+tokio = { version = "1.2", features = ["time", "fs", "net", "rt", "rt-multi-thread", "io-util"] }
 thiserror = "1.0"
 tokio-util = { version = "0.6", features = ["codec"] }
 url = "2.2"
@@ -52,7 +52,8 @@ webpki-roots = { version = "0.21", optional = true }
 env_logger = "0.8"
 flate2 = "1.0"
 tar = "0.4"
-tokio = { version = "1.2", features = ["time", "fs", "net", "rt", "rt-multi-thread", "macros"] }
+tokio = { version = "1.2", features = ["time", "fs", "net", "rt", "rt-multi-thread", "macros", "io-std"] }
+termion = "1.5"
 
 [target.'cfg(unix)'.dependencies]
 hyperlocal =  { version = "0.2.2", package = "hyper-unix-connector" }

--- a/examples/exec.rs
+++ b/examples/exec.rs
@@ -4,13 +4,27 @@ use bollard::container::{Config, RemoveContainerOptions};
 use bollard::Docker;
 
 use bollard::exec::{CreateExecOptions, StartExecResults};
+use bollard::image::CreateImageOptions;
 use futures_util::stream::StreamExt;
+use futures_util::TryStreamExt;
 
 const IMAGE: &'static str = "alpine:3";
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error + 'static>> {
     let docker = Docker::connect_with_unix_defaults().unwrap();
+
+    docker
+        .create_image(
+            Some(CreateImageOptions {
+                from_image: IMAGE,
+                ..Default::default()
+            }),
+            None,
+            None,
+        )
+        .try_collect::<Vec<_>>()
+        .await?;
 
     let alpine_config = Config {
         image: Some(IMAGE),

--- a/examples/exec.rs
+++ b/examples/exec.rs
@@ -1,0 +1,61 @@
+//! This example will run a non-interactive command inside the container using `docker exec`
+
+use bollard::container::{Config, RemoveContainerOptions};
+use bollard::Docker;
+
+use bollard::exec::{CreateExecOptions, StartExecResults};
+use futures_util::stream::StreamExt;
+
+const IMAGE: &'static str = "alpine:3";
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error + 'static>> {
+    let docker = Docker::connect_with_unix_defaults().unwrap();
+
+    let alpine_config = Config {
+        image: Some(IMAGE),
+        tty: Some(true),
+        ..Default::default()
+    };
+
+    let id = docker
+        .create_container::<&str, &str>(None, alpine_config)
+        .await?
+        .id;
+    docker.start_container::<String>(&id, None).await?;
+
+    // non interactive
+    let exec = docker
+        .create_exec(
+            &id,
+            CreateExecOptions {
+                attach_stdout: Some(true),
+                attach_stderr: Some(true),
+                cmd: Some(vec!["ls", "-l", "/"]),
+                ..Default::default()
+            },
+        )
+        .await?
+        .id;
+    if let StartExecResults::Attached { mut output, .. } =
+        docker.start_exec(&exec, None, false).await?
+    {
+        while let Some(Ok(msg)) = output.next().await {
+            print!("{}", msg);
+        }
+    } else {
+        unreachable!();
+    }
+
+    docker
+        .remove_container(
+            &id,
+            Some(RemoveContainerOptions {
+                force: true,
+                ..Default::default()
+            }),
+        )
+        .await?;
+
+    Ok(())
+}

--- a/examples/exec_term.rs
+++ b/examples/exec_term.rs
@@ -1,0 +1,91 @@
+//! This example will run a interactive command inside the container using `docker exec`,
+//! passing trough input and output into the tty running inside the container
+
+use bollard::container::{Config, RemoveContainerOptions};
+use bollard::Docker;
+
+use bollard::exec::{CreateExecOptions, StartExecResults};
+use std::io::{stdout, Read, Write};
+use std::time::Duration;
+use termion::async_stdin;
+use termion::raw::IntoRawMode;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::task::spawn;
+use tokio::time::sleep;
+
+const IMAGE: &'static str = "alpine:3";
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error + 'static>> {
+    let docker = Docker::connect_with_unix_defaults().unwrap();
+
+    let alpine_config = Config {
+        image: Some(IMAGE),
+        tty: Some(true),
+        ..Default::default()
+    };
+
+    let id = docker
+        .create_container::<&str, &str>(None, alpine_config)
+        .await?
+        .id;
+    docker.start_container::<String>(&id, None).await?;
+
+    let exec = docker
+        .create_exec(
+            &id,
+            CreateExecOptions {
+                attach_stdout: Some(true),
+                attach_stderr: Some(true),
+                attach_stdin: Some(true),
+                tty: Some(true),
+                cmd: Some(vec!["sh"]),
+                ..Default::default()
+            },
+        )
+        .await?
+        .id;
+    if let StartExecResults::AttachedTTY {
+        mut output,
+        mut input,
+    } = docker.start_exec(&exec, None, true).await?
+    {
+        // pipe stdin into the docker exec stream input
+        spawn(async move {
+            let mut stdin = async_stdin().bytes();
+            loop {
+                if let Some(Ok(byte)) = stdin.next() {
+                    input.write(&[byte]).await.ok();
+                } else {
+                    sleep(Duration::from_nanos(10)).await;
+                }
+            }
+        });
+
+        // set stdout in raw mode so we can do tty stuff
+        let stdout = stdout();
+        let mut stdout = stdout.lock().into_raw_mode()?;
+
+        // pipe docker exec output into stdout
+        let mut buff = [0; 128];
+        while let Ok(read) = output.read(&mut buff).await {
+            if read == 0 {
+                break;
+            }
+            stdout.write(&buff[0..read])?;
+            stdout.flush()?;
+        }
+    }
+
+    docker
+        .remove_container(
+            &id,
+            Some(RemoveContainerOptions {
+                force: true,
+                ..Default::default()
+            }),
+        )
+        .await?;
+
+    Ok(())
+}

--- a/examples/exec_term.rs
+++ b/examples/exec_term.rs
@@ -5,6 +5,8 @@ use bollard::container::{Config, RemoveContainerOptions};
 use bollard::Docker;
 
 use bollard::exec::{CreateExecOptions, StartExecResults};
+use bollard::image::CreateImageOptions;
+use futures_util::TryStreamExt;
 use std::io::{stdout, Read, Write};
 use std::time::Duration;
 use termion::async_stdin;
@@ -18,6 +20,18 @@ const IMAGE: &'static str = "alpine:3";
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error + 'static>> {
     let docker = Docker::connect_with_unix_defaults().unwrap();
+
+    docker
+        .create_image(
+            Some(CreateImageOptions {
+                from_image: IMAGE,
+                ..Default::default()
+            }),
+            None,
+            None,
+        )
+        .try_collect::<Vec<_>>()
+        .await?;
 
     let alpine_config = Config {
         image: Some(IMAGE),

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -130,5 +130,5 @@ pub enum Error {
     },
     /// Disable NamedPipe support until tokio#3511 is resolved
     #[error("Named Pipe support is disabled until tokio#3511 is resolved")]
-    NamedPipeDisabled { }
+    NamedPipeDisabled {},
 }


### PR DESCRIPTION
This changes the `start_exec` output from a `Stream<Item=Result<LogOutput>>` into on of

 - `(Stream<Item=Result<LogOutput>>, impl AsyncWrite)`
 - `(impl AsyncRead, impl AsyncWrite)`

depending on if tty mode is enabled.

I'm not to pleased with having the `start_exec` return different a variant depending on the parameters which the caller than has to match. But I couldn't figure out a clean way to encode it into the type system without a larger overhaul.

Fixes #147