### PR TITLE
fix tty output

### DIFF
--- a/examples/exec.rs
+++ b/examples/exec.rs
@@ -51,9 +51,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + 'static>> {
         )
         .await?
         .id;
-    if let StartExecResults::Attached { mut output, .. } =
-        docker.start_exec(&exec, None, false).await?
-    {
+    if let StartExecResults::Attached { mut output, .. } = docker.start_exec(&exec, None).await? {
         while let Some(Ok(msg)) = output.next().await {
             print!("{}", msg);
         }

--- a/src/container.rs
+++ b/src/container.rs
@@ -475,6 +475,18 @@ impl fmt::Display for LogOutput {
     }
 }
 
+impl LogOutput {
+    /// Get the raw bytes of the output
+    pub fn into_bytes(self) -> Bytes {
+        match self {
+            LogOutput::StdErr { message } => message,
+            LogOutput::StdOut { message } => message,
+            LogOutput::StdIn { message } => message,
+            LogOutput::Console { message } => message,
+        }
+    }
+}
+
 /// Parameters used in the [Stats API](super::Docker::stats())
 ///
 /// ## Examples

--- a/src/exec.rs
+++ b/src/exec.rs
@@ -15,7 +15,7 @@ use crate::read::NewlineLogOutputDecoder;
 use futures_core::Stream;
 use std::fmt::{Debug, Formatter};
 use std::pin::Pin;
-use tokio::io::{AsyncRead, AsyncWrite};
+use tokio::io::AsyncWrite;
 use tokio_util::codec::FramedRead;
 
 /// Exec configuration used in the [Create Exec API](Docker::create_exec())
@@ -72,10 +72,6 @@ pub enum StartExecResults {
         output: Pin<Box<dyn Stream<Item = Result<LogOutput, Error>> + Send>>,
         input: Pin<Box<dyn AsyncWrite + Send>>,
     },
-    AttachedTTY {
-        output: Pin<Box<dyn AsyncRead + Send>>,
-        input: Pin<Box<dyn AsyncWrite + Send>>,
-    },
     Detached,
 }
 
@@ -83,7 +79,6 @@ impl Debug for StartExecResults {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
             StartExecResults::Attached { .. } => write!(f, "StartExecResults::Attached"),
-            StartExecResults::AttachedTTY { .. } => write!(f, "StartExecResults::AttachedTTY"),
             StartExecResults::Detached => write!(f, "StartExecResults::Detached"),
         }
     }
@@ -189,14 +184,13 @@ impl Docker {
     /// async {
     ///     let message = docker.create_exec("hello-world", config).await.unwrap();
     ///     use bollard::exec::StartExecOptions;
-    ///     docker.start_exec(&message.id, None::<StartExecOptions>, false);
+    ///     docker.start_exec(&message.id, None::<StartExecOptions>);
     /// };
     /// ```
     pub async fn start_exec(
         &self,
         exec_id: &str,
         config: Option<StartExecOptions>,
-        tty: bool,
     ) -> Result<StartExecResults, Error> {
         let url = format!("/exec/{}/start", exec_id);
 
@@ -229,18 +223,11 @@ impl Docker {
 
                 let (read, write) = self.process_upgraded(req).await?;
 
-                if tty {
-                    Ok(StartExecResults::AttachedTTY {
-                        output: Box::pin(read),
-                        input: Box::pin(write),
-                    })
-                } else {
-                    let log = FramedRead::new(read, NewlineLogOutputDecoder::new());
-                    Ok(StartExecResults::Attached {
-                        output: Box::pin(log),
-                        input: Box::pin(write),
-                    })
-                }
+                let log = FramedRead::new(read, NewlineLogOutputDecoder::new());
+                Ok(StartExecResults::Attached {
+                    output: Box::pin(log),
+                    input: Box::pin(write),
+                })
             }
         }
     }

--- a/tests/exec_test.rs
+++ b/tests/exec_test.rs
@@ -36,7 +36,7 @@ async fn start_exec_test(docker: Docker) -> Result<(), Error> {
         .await?;
 
     let results = docker
-        .start_exec(&message.id, None::<StartExecOptions>, false)
+        .start_exec(&message.id, None::<StartExecOptions>)
         .await?;
 
     assert!(match results {
@@ -109,7 +109,7 @@ async fn inspect_exec_test(docker: Docker) -> Result<(), Error> {
         .await?;
 
     docker
-        .start_exec(&message.id, Some(StartExecOptions { detach: true }), false)
+        .start_exec(&message.id, Some(StartExecOptions { detach: true }))
         .await?;
 
     let exec_process = &docker.inspect_exec(&message.id).await?;


### PR DESCRIPTION
Turns out the tty output *is* encoded the same as the log output, the [lack of documentation](https://docs.docker.com/engine/api/v1.41/#operation/ContainerExec) of how exec output streaming is supposed to work made me guess the wrong thing from other documentation bits.

This wasn't obvious while testing because as long as the message length is small enough the extra bytes being written to stdout doesn't have any visual impact.