### PR TITLE
Fix `Docker::ping`, using the response string directly

### DIFF
--- a/src/docker.rs
+++ b/src/docker.rs
@@ -777,6 +777,17 @@ impl Docker {
         )
     }
 
+    pub(crate) fn process_into_string(
+        &self,
+        req: Result<Request<Body>, Error>,
+    ) -> impl Future<Output = Result<String, Error>> {
+        let fut = self.process_request(req);
+        async move {
+            let response = fut.await?;
+            Docker::decode_into_string(response).await
+        }
+    }
+
     pub(crate) async fn process_upgraded(
         &self,
         req: Result<Request<Body>, Error>,

--- a/src/system.rs
+++ b/src/system.rs
@@ -232,7 +232,7 @@ impl Docker {
             Ok(Body::empty()),
         );
 
-        self.process_into_value(req).await
+        self.process_into_string(req).await
     }
 
     /// ---

--- a/tests/system_test.rs
+++ b/tests/system_test.rs
@@ -153,6 +153,13 @@ async fn info_test(docker: Docker) -> Result<(), Error> {
     Ok(())
 }
 
+async fn ping_test(docker: Docker) -> Result<(), Error> {
+    let res = &docker.ping().await?;
+    assert_eq!("OK", res);
+
+    Ok(())
+}
+
 #[test]
 fn integration_test_events() {
     connect_to_docker_and_run!(events_test);
@@ -173,4 +180,9 @@ fn integration_test_df() {
 #[test]
 fn integration_test_info() {
     connect_to_docker_and_run!(info_test);
+}
+
+#[test]
+fn integration_test_ping() {
+    connect_to_docker_and_run!(ping_test);
 }


### PR DESCRIPTION
While `serde_json::from_str` can parse a string into a `String`, it expects the incoming string to be a valid JSON string value, i.e. the string has to include quotes. The Docker `/_ping` endpoint returns just the string `OK` without any quotes, which means we cannot use `serde_json` for parsing, but instead should just take the string as-is.

To give more detail: without this change, `docker.ping().await` returns the following error:

```
Err(
    JsonSerdeError {
        err: Error("expected value", line: 1, column: 1),
     }
)
```

With this change it now correctly returns:

```
Ok(
    "OK"
)
```