### PR TITLE
Ensure the X-Registry-Auth header is base64 url-safe encoded

### DIFF
--- a/src/auth.rs
+++ b/src/auth.rs
@@ -14,3 +14,7 @@ pub struct DockerCredentials {
     pub identitytoken: Option<String>,
     pub registrytoken: Option<String>,
 }
+
+pub(crate) fn base64_url_encode(payload: &str) -> String {
+    base64::encode_config(payload, base64::URL_SAFE)
+}

--- a/src/image.rs
+++ b/src/image.rs
@@ -7,7 +7,7 @@ use hyper::{body::Bytes, Body, Method};
 use serde::Serialize;
 
 use super::Docker;
-use crate::auth::DockerCredentials;
+use crate::auth::{base64_url_encode, DockerCredentials};
 use crate::container::Config;
 use crate::errors::Error;
 use crate::models::*;
@@ -539,7 +539,7 @@ impl Docker {
                     url,
                     Builder::new()
                         .method(Method::POST)
-                        .header("X-Registry-Auth", base64::encode(&ser_cred)),
+                        .header("X-Registry-Auth", base64_url_encode(&ser_cred)),
                     options,
                     match root_fs {
                         Some(body) => Ok(body),
@@ -779,7 +779,7 @@ impl Docker {
                     &url,
                     Builder::new()
                         .method(Method::DELETE)
-                        .header("X-Registry-Auth", base64::encode(&ser_cred)),
+                        .header("X-Registry-Auth", base64_url_encode(&ser_cred)),
                     options,
                     Ok(Body::empty()),
                 );
@@ -899,7 +899,7 @@ impl Docker {
                     Builder::new()
                         .method(Method::POST)
                         .header(CONTENT_TYPE, "application/json")
-                        .header("X-Registry-Auth", base64::encode(&ser_cred)),
+                        .header("X-Registry-Auth", base64_url_encode(&ser_cred)),
                     options,
                     Ok(Body::empty()),
                 );
@@ -1033,7 +1033,7 @@ impl Docker {
                     Builder::new()
                         .method(Method::POST)
                         .header(CONTENT_TYPE, "application/x-tar")
-                        .header("X-Registry-Config", base64::encode(&ser_cred)),
+                        .header("X-Registry-Config", base64_url_encode(&ser_cred)),
                     Some(options),
                     Ok(tar.unwrap_or_else(Body::empty)),
                 );
@@ -1149,7 +1149,7 @@ impl Docker {
                     Builder::new()
                         .method(Method::POST)
                         .header(CONTENT_TYPE, "application/json")
-                        .header("X-Registry-Config", base64::encode(&ser_cred)),
+                        .header("X-Registry-Config", base64_url_encode(&ser_cred)),
                     Some(options),
                     Ok(root_fs),
                 );

--- a/src/service.rs
+++ b/src/service.rs
@@ -3,7 +3,7 @@
 pub use crate::models::*;
 
 use super::Docker;
-use crate::auth::DockerCredentials;
+use crate::auth::{base64_url_encode, DockerCredentials};
 use crate::errors::Error;
 use http::header::CONTENT_TYPE;
 use http::request::Builder;
@@ -237,7 +237,7 @@ impl Docker {
                     Builder::new()
                         .method(Method::POST)
                         .header(CONTENT_TYPE, "application/json")
-                        .header("X-Registry-Auth", base64::encode(&ser_cred)),
+                        .header("X-Registry-Auth", base64_url_encode(&ser_cred)),
                     None::<String>,
                     Docker::serialize_payload(Some(service_spec)),
                 );
@@ -406,7 +406,7 @@ impl Docker {
                     Builder::new()
                         .method(Method::POST)
                         .header(CONTENT_TYPE, "application/json")
-                        .header("X-Registry-Auth", base64::encode(&ser_cred)),
+                        .header("X-Registry-Auth", base64_url_encode(&ser_cred)),
                     Some(options),
                     Docker::serialize_payload(Some(service_spec)),
                 );


### PR DESCRIPTION
According to Docker Engine API docs, the `X-Registry-Auth` header needs to be base64 url-safe encoded but it's currently not.

Appreciate moby/moby#41570 for the pointers on helping us find this issue.