### PR TITLE
Make remaining ssl-only dependencies optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ test_ssl = ["ssl"]
 # Enable tests specifically for macos
 test_macos = []
 # Enable rustls / ssl
-ssl = ["hyper-rustls", "rustls", "rustls-native-certs", "webpki-roots"]
+ssl = ["dirs-next", "hyper-rustls", "rustls", "rustls-native-certs", "rustls-pemfile", "webpki", "webpki-roots"]
 ct_logs = ["ssl", "ct-logs"]
 
 [dependencies]
@@ -28,7 +28,7 @@ bollard-stubs = { version = "1.41.0" }
 bytes = "1"
 chrono = { version = "0.4", features = ["serde"] }
 ct-logs = { version = "0.9.0", optional = true }
-dirs-next = "2.0"
+dirs-next = { version = "2.0", optional = true }
 futures-core = "0.3"
 futures-util = "0.3"
 hex = "0.4.2"
@@ -39,7 +39,7 @@ log = "0.4"
 pin-project = "1.0.2"
 rustls = { version = "0.20", optional = true }
 rustls-native-certs = { version = "0.6.0", optional = true }
-rustls-pemfile = "0.2"
+rustls-pemfile = { version = "0.2", optional = true }
 serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"
@@ -49,7 +49,7 @@ thiserror = "1.0"
 tokio-util = { version = "0.6", features = ["codec"] }
 url = "2.2"
 webpki-roots = { version = "0.22", optional = true }
-webpki = "0.22"
+webpki = { version = "0.22", optional = true }
 
 [dev-dependencies]
 env_logger = "0.9"

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,4 +1,6 @@
 //! Errors for this module.
+
+#[cfg(feature = "ssl")]
 use std::path::PathBuf;
 
 /// The type of error embedded in an Error.
@@ -6,15 +8,18 @@ use std::path::PathBuf;
 pub enum Error {
     /// Error emitted during client instantiation when the `DOCKER_CERT_PATH` environment variable
     /// is invalid.
+    #[cfg(feature = "ssl")]
     #[error("Could not find home directory")]
     NoHomePathError,
     /// Generic error when reading a certificate from the filesystem
+    #[cfg(feature = "ssl")]
     #[error("Cannot open/read certificate with path: {path}")]
     CertPathError {
         /// Path for the failing certificate file
         path: PathBuf,
     },
     /// Error emitted when multiple keys are found in a certificate file
+    #[cfg(feature = "ssl")]
     #[error("Found multiple keys ({count}), expected one: {path}")]
     CertMultipleKeys {
         /// Number of keys found in the certificate file
@@ -23,12 +28,14 @@ pub enum Error {
         path: PathBuf,
     },
     /// Parse error for RSA encrypted keys
+    #[cfg(feature = "ssl")]
     #[error("Could not parse key: {path}")]
     CertParseError {
         /// Path for the failing certificate file
         path: PathBuf,
     },
     /// Error emitted when the client is unable to load native certs for SSL
+    #[cfg(feature = "ssl")]
     #[error("Could not load native certs")]
     NoNativeCertsError {
         /// The original error emitted.


### PR DESCRIPTION
The `dirs-next`, `rustls-pemfile` and `webpki` dependencies are all only used by `connect_with_ssl_defaults()` and `connect_with_ssl()`, which are behind the `ssl` feature flag.

This makes those dependencies optional, for faster compile times for consumers of `bollard` who aren't using the `ssl` feature.

The `dirs-next` and `rustls-pemfile` dependencies were completely unused when not using `ssl`, and showed up as warnings with the `unused_crate_dependencies` lint enabled, when using `cargo check` (with the `ssl` feature not enabled).
(I've not enabled that lint now, since it doesn't interact well with integration tests.)

The `webpki` dependency was being used on one of the `Error` variants, however that's now been moved behind the `ssl` feature flag too. For consistency, all SSL related `Error` variants have been moved behind the flag, even those that didn't require additional dependencies.

Before:

```
$ cargo tree -e no-dev --prefix none --no-dedupe | sort -u | wc -l
84

$ rm -rf target/ && time cargo build
...
    Finished dev [unoptimized + debuginfo] target(s) in 46.65s
```

After:

```
$ cargo tree -e no-dev --prefix none --no-dedupe | sort -u | wc -l
76

$ rm -rf target/ && time cargo build
...
    Finished dev [unoptimized + debuginfo] target(s) in 43.61s
```