### PR TITLE
Fix Clippy failures on master with Rust 1.59

### DIFF
--- a/src/docker.rs
+++ b/src/docker.rs
@@ -924,7 +924,7 @@ impl Docker {
             None => Ok(None),
         }
         .map(|payload| {
-            debug!("{}", payload.clone().unwrap_or_else(String::new));
+            debug!("{}", payload.clone().unwrap_or_default());
             payload
                 .map(|content| content.into())
                 .unwrap_or_else(Body::empty)

--- a/src/image.rs
+++ b/src/image.rs
@@ -1026,7 +1026,7 @@ impl Docker {
     {
         let url = "/build";
 
-        match serde_json::to_string(&credentials.unwrap_or_else(HashMap::new)) {
+        match serde_json::to_string(&credentials.unwrap_or_default()) {
             Ok(ser_cred) => {
                 let req = self.build_request(
                     url,
@@ -1142,7 +1142,7 @@ impl Docker {
         root_fs: Body,
         credentials: Option<HashMap<String, DockerCredentials>>,
     ) -> impl Stream<Item = Result<BuildInfo, Error>> {
-        match serde_json::to_string(&credentials.unwrap_or_else(HashMap::new)) {
+        match serde_json::to_string(&credentials.unwrap_or_default()) {
             Ok(ser_cred) => {
                 let req = self.build_request(
                     "/images/load",


### PR DESCRIPTION
Now that Rust 1.59 has been released, CI is failing on `master` with:

```
error: use of `.unwrap_or_else(..)` to construct default value
   --> src/docker.rs:927:26
    |
927 |             debug!("{}", payload.clone().unwrap_or_else(String::new));
    |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `payload.clone().unwrap_or_default()`
    |
    = note: `-D clippy::unwrap-or-else-default` implied by `-D warnings`
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unwrap_or_else_default

error: use of `.unwrap_or_else(..)` to construct default value
    --> src/image.rs:1029:38
     |
1029 |         match serde_json::to_string(&credentials.unwrap_or_else(HashMap::new)) {
     |                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `credentials.unwrap_or_default()`
     |
     = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unwrap_or_else_default

error: use of `.unwrap_or_else(..)` to construct default value
    --> src/image.rs:1145:38
     |
1145 |         match serde_json::to_string(&credentials.unwrap_or_else(HashMap::new)) {
     |                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `credentials.unwrap_or_default()`
     |
     = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unwrap_or_else_default
```

This appears to be due to:

> * [`unwrap_or_else_default`]: Now also lints on `std` constructors like
  `Vec::new`, `HashSet::new`, and `HashMap::new`

See:
https://github.com/rust-lang/rust-clippy/blame/d1ca1c1d0c3f8ee20d58f2fc57c9f0e93da37d21/CHANGELOG.md#L67-L68