### PR TITLE
Switch from pin-project to pin-project-lite

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ http = "0.2"
 hyper = { version = "0.14", features = ["client", "tcp", "http1", "http2", "stream"] }
 hyper-rustls = { version = "0.23", optional = true }
 log = "0.4"
-pin-project = "1.0.2"
+pin-project-lite = "0.2.8"
 rustls = { version = "0.20", optional = true }
 rustls-native-certs = { version = "0.6.0", optional = true }
 rustls-pemfile = { version = "0.2", optional = true }

--- a/src/named_pipe.rs
+++ b/src/named_pipe.rs
@@ -1,7 +1,7 @@
 #![cfg(windows)]
 
 use hyper::client::connect::Connected;
-use pin_project::pin_project;
+use pin_project_lite::pin_project;
 use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
 use tokio::net::windows::named_pipe::{ClientOptions, NamedPipeClient};
 use tokio::time;
@@ -19,10 +19,11 @@ use winapi::shared::winerror;
 use crate::docker::ClientType;
 use crate::uri::Uri;
 
-#[pin_project]
-pub struct NamedPipeStream {
-    #[pin]
-    io: NamedPipeClient,
+pin_project! {
+    pub struct NamedPipeStream {
+        #[pin]
+        io: NamedPipeClient,
+    }
 }
 
 impl NamedPipeStream {

--- a/src/read.rs
+++ b/src/read.rs
@@ -2,7 +2,7 @@ use bytes::Buf;
 use bytes::BytesMut;
 use futures_core::Stream;
 use hyper::body::Bytes;
-use pin_project::pin_project;
+use pin_project_lite::pin_project;
 use serde::de::DeserializeOwned;
 use std::pin::Pin;
 use std::string::String;
@@ -90,10 +90,11 @@ impl Decoder for NewlineLogOutputDecoder {
     }
 }
 
-#[pin_project]
-#[derive(Debug)]
-pub(crate) struct JsonLineDecoder<T> {
-    ty: PhantomData<T>,
+pin_project! {
+    #[derive(Debug)]
+    pub(crate) struct JsonLineDecoder<T> {
+        ty: PhantomData<T>,
+    }
 }
 
 impl<T> JsonLineDecoder<T> {
@@ -174,12 +175,13 @@ enum ReadState {
     NotReady,
 }
 
-#[pin_project]
-#[derive(Debug)]
-pub(crate) struct StreamReader<S> {
-    #[pin]
-    stream: S,
-    state: ReadState,
+pin_project! {
+    #[derive(Debug)]
+    pub(crate) struct StreamReader<S> {
+        #[pin]
+        stream: S,
+        state: ReadState,
+    }
 }
 
 impl<S> StreamReader<S>


### PR DESCRIPTION
This is another small step towards reducing the size of bollard's dependency tree :-)

`tokio` and `hyper` have both switched from `pin-project` crate to the lighter-weight `pin-project-lite`:
https://github.com/tokio-rs/tokio/pull/1778
https://github.com/hyperium/hyper/pull/2566

This does the same for bollard. For the differences between the two crates, see:
https://docs.rs/pin-project-lite/0.2.8/pin_project_lite/#pin-project-vs-pin-project-lite

Note: The full advantage of this won't be seen until a new `hyperlocal` release exists that contains:
https://github.com/softprops/hyperlocal/pull/54

...and bollard updates to that release, so that `pin-project` can be fully dropped from the dependency tree. However this doesn't make things any worse in the meantime, since `pin-project-lite` is already in bollard's dependency tree via both `hyper` and `tokio`.