### PR TITLE
Only enable the `tokio` features used by this crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"
 serde_urlencoded = "0.7"
-tokio = { version = "1.7", features = ["time", "fs", "net", "rt", "rt-multi-thread", "io-util"] }
+tokio = { version = "1.7", features = ["time", "net", "io-util"] }
 thiserror = "1.0"
 tokio-util = { version = "0.6", features = ["codec"] }
 url = "2.2"
@@ -55,7 +55,7 @@ webpki = { version = "0.22", optional = true }
 env_logger = "0.9"
 flate2 = "1.0"
 tar = "0.4"
-tokio = { version = "1.7", features = ["time", "fs", "net", "rt", "rt-multi-thread", "macros", "io-std"] }
+tokio = { version = "1.7", features = ["fs", "rt-multi-thread", "macros"] }
 
 [target.'cfg(unix)'.dependencies]
 hyperlocal =  { version = "0.8.0" }


### PR DESCRIPTION
Tokio offers the following features:
https://docs.rs/tokio/latest/tokio/#feature-flags

This removes the following unused Tokio features from `dependencies`:
- `fs`: Since it's only used by examples/tests/doctests (so doesn't need to be in `dependencies`):
   https://github.com/fussybeaver/bollard/search?q=%22tokio%3A%3Afs%22
- `rt` / `rt-multi-thread`: Since it's not used by bollard itself, and should be specified by end-users in their application (see [authoring libraries](https://docs.rs/tokio/latest/tokio/#authoring-libraries)). By activating `rt-multi-thread` by default, it means anyone not using the multi-thread runtime has to pay the dependency/compile time price for it regardless.

And removes the following from `dev-dependencies`:
- `time` / `net`: Since they are already specified in `dependencies`, and it's not necessary to duplicate them in `dev-dependencies` as Cargo will perform feature unification.
- `rt`: Since `rt-multi-thread` includes `rt` already.
- `io-std`: Since it's not used by any examples/tests and isn't even one of the official top-level features anyway:
   https://docs.rs/tokio/latest/tokio/#feature-flags

Note: The full dependency tree/compile time reduction benefits of this change won't be realised until this `hyperlocal` change is picked up in the next `hyperlocal` release (which stops `hyperlocal` from pulling in too many `tokio` features):
https://github.com/softprops/hyperlocal/pull/54