### PR TITLE
Fix Clippy warnings in examples and tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,7 +45,7 @@ jobs:
       - checkout
       - setup_remote_docker
       - run: docker build -t bollard .
-      - run: docker run -ti --rm bollard bash -c "rustup component add clippy && cargo clippy -- -Dwarnings -Aclippy::upper_case_acronyms"
+      - run: docker run -ti --rm bollard bash -c "rustup component add clippy && cargo clippy --all-targets -- -Dwarnings -Aclippy::upper_case_acronyms"
   test_audit:
     docker:
       - image: docker:20.10.11

--- a/examples/attach_container.rs
+++ b/examples/attach_container.rs
@@ -18,7 +18,7 @@ use tokio::io::AsyncWriteExt;
 use tokio::task::spawn;
 use tokio::time::sleep;
 
-const IMAGE: &'static str = "alpine:3";
+const IMAGE: &str = "alpine:3";
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error + 'static>> {
@@ -88,7 +88,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + 'static>> {
 
         // pipe docker attach output into stdout
         while let Some(Ok(output)) = output.next().await {
-            stdout.write(output.into_bytes().as_ref())?;
+            stdout.write_all(output.into_bytes().as_ref())?;
             stdout.flush()?;
         }
     }

--- a/examples/error.rs
+++ b/examples/error.rs
@@ -13,6 +13,4 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
 
 fn main() {
     run().unwrap();
-
-    ()
 }

--- a/examples/exec.rs
+++ b/examples/exec.rs
@@ -8,7 +8,7 @@ use bollard::image::CreateImageOptions;
 use futures_util::stream::StreamExt;
 use futures_util::TryStreamExt;
 
-const IMAGE: &'static str = "alpine:3";
+const IMAGE: &str = "alpine:3";
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error + 'static>> {

--- a/examples/exec_term.rs
+++ b/examples/exec_term.rs
@@ -17,7 +17,7 @@ use tokio::io::AsyncWriteExt;
 use tokio::task::spawn;
 use tokio::time::sleep;
 
-const IMAGE: &'static str = "alpine:3";
+const IMAGE: &str = "alpine:3";
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error + 'static>> {
@@ -98,7 +98,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + 'static>> {
 
         // pipe docker exec output into stdout
         while let Some(Ok(output)) = output.next().await {
-            stdout.write(output.into_bytes().as_ref())?;
+            stdout.write_all(output.into_bytes().as_ref())?;
             stdout.flush()?;
         }
     }

--- a/examples/info.rs
+++ b/examples/info.rs
@@ -10,7 +10,7 @@ use std::default::Default;
 use futures_util::stream;
 use futures_util::stream::StreamExt;
 
-async fn conc(arg: (Docker, &ContainerSummary)) -> () {
+async fn conc(arg: (Docker, &ContainerSummary)) {
     let (docker, container) = arg;
     println!(
         "{:?}",

--- a/examples/kafka.rs
+++ b/examples/kafka.rs
@@ -9,8 +9,8 @@ use futures_util::stream::select;
 use futures_util::stream::StreamExt;
 use futures_util::stream::TryStreamExt;
 
-const KAFKA_IMAGE: &'static str = "confluentinc/cp-kafka:5.0.1";
-const ZOOKEEPER_IMAGE: &'static str = "confluentinc/cp-zookeeper:5.0.1";
+const KAFKA_IMAGE: &str = "confluentinc/cp-kafka:5.0.1";
+const ZOOKEEPER_IMAGE: &str = "confluentinc/cp-zookeeper:5.0.1";
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error + 'static>> {

--- a/examples/top.rs
+++ b/examples/top.rs
@@ -48,13 +48,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error + 'static>> {
     {
         if let Some(p) = p.get(0) {
             print!("{}", name);
-            for mut v in p.to_vec() {
+            for mut v in p.iter().cloned() {
                 if v.len() > 30 {
                     v.truncate(30);
                 }
                 print!("\t{}", v);
             }
-            print!("\n");
+            println!();
         }
     }
 

--- a/src/docker.rs
+++ b/src/docker.rs
@@ -403,7 +403,9 @@ impl Docker {
 
         let mut root_store = rustls::RootCertStore::empty();
         for cert in rustls_native_certs::load_native_certs()? {
-            root_store.add(&rustls::Certificate(cert.0)).map_err(|err| NoNativeCertsError{ err })?;
+            root_store
+                .add(&rustls::Certificate(cert.0))
+                .map_err(|err| NoNativeCertsError { err })?;
         }
 
         root_store.add_server_trust_anchors(webpki_roots::TLS_SERVER_ROOTS.0.iter().map(|ta| {

--- a/src/read.rs
+++ b/src/read.rs
@@ -142,25 +142,24 @@ where
                         src.truncate(src.len() - 1); // Remove the newline
                         src.unsplit(remainder);
                         Ok(None)
-                    },
+                    }
                     Ok(json) => {
                         // Newline delimited json
                         src.unsplit(remainder);
                         src.advance(pos + 1);
                         Ok(json)
-                    },
-                    Err(e) => Err(e)
+                    }
+                    Err(e) => Err(e),
                 }
-            
             } else {
-                // No newline delimited json. 
+                // No newline delimited json.
                 match decode_json_from_slice(src) {
                     Ok(None) => Ok(None),
                     Ok(json) => {
                         src.clear();
                         Ok(json)
-                    },
-                    Err(e) => Err(e)
+                    }
+                    Err(e) => Err(e),
                 }
             }
         } else {
@@ -341,7 +340,10 @@ mod tests {
         let mut buf = BytesMut::from(&b"\"foo\\nbar\""[..]);
         let mut codec: JsonLineDecoder<String> = JsonLineDecoder::new();
 
-        assert_eq!(codec.decode(&mut buf).unwrap(), Some(String::from("foo\nbar")));
+        assert_eq!(
+            codec.decode(&mut buf).unwrap(),
+            Some(String::from("foo\nbar"))
+        );
     }
 
     #[test]

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -4,8 +4,6 @@ use futures_util::stream::TryStreamExt;
 use std::future::Future;
 use tokio::runtime::Runtime;
 
-use std;
-
 use bollard::auth::DockerCredentials;
 use bollard::container::*;
 use bollard::errors::Error;
@@ -92,9 +90,9 @@ where
     T: Future<Output = Result<(), Error>>,
 {
     rt.block_on(future)
-        .or_else(|e| {
+        .map_err(|e| {
             println!("{:?}", e);
-            Err(e)
+            e
         })
         .unwrap();
 }

--- a/tests/container_test.rs
+++ b/tests/container_test.rs
@@ -299,9 +299,9 @@ async fn attach_container_test(docker: Docker) -> Result<(), Error> {
         .await?;
 
     input
-        .write(format!("echo {}\n", unique_string).as_bytes())
+        .write_all(format!("echo {}\n", unique_string).as_bytes())
         .await?;
-    input.write("exit\n".as_bytes()).await?;
+    input.write_all("exit\n".as_bytes()).await?;
 
     let log = match tokio::time::timeout(tokio::time::Duration::from_secs(2), output.try_collect())
         .await
@@ -335,8 +335,7 @@ async fn attach_container_test(docker: Docker) -> Result<(), Error> {
 
     let input_found = log
         .iter()
-        .find(|val| val.to_string().contains(unique_string))
-        .is_some();
+        .any(|val| val.to_string().contains(unique_string));
 
     assert!(input_found);
 
@@ -517,7 +516,7 @@ async fn prune_containers_test(docker: Docker) -> Result<(), Error> {
     assert_eq!(
         0,
         result
-            .into_iter()
+            .iter()
             .filter(|r| vec![
                 "bollard",
                 "registry:2",
@@ -526,8 +525,7 @@ async fn prune_containers_test(docker: Docker) -> Result<(), Error> {
             ]
             .into_iter()
             .all(|v| v != r.image.as_ref().unwrap()))
-            .collect::<Vec<_>>()
-            .len()
+            .count()
     );
 
     Ok(())

--- a/tests/exec_test.rs
+++ b/tests/exec_test.rs
@@ -42,7 +42,7 @@ async fn start_exec_test(docker: Docker) -> Result<(), Error> {
     assert!(match results {
         StartExecResults::Attached { output, .. } => {
             let log: Vec<_> = output.try_collect().await?;
-            assert!(log.len() > 0);
+            assert!(!log.is_empty());
             match &log[0] {
                 LogOutput::StdOut { message } => {
                     let (n, expected) = if cfg!(windows) {
@@ -52,7 +52,7 @@ async fn start_exec_test(docker: Docker) -> Result<(), Error> {
                     };
 
                     let s = String::from_utf8_lossy(message);
-                    s.split("\n").skip(n).next().expect("log exists") == expected
+                    s.split('\n').nth(n).expect("log exists") == expected
                 }
                 _ => false,
             }

--- a/tests/image_test.rs
+++ b/tests/image_test.rs
@@ -36,7 +36,7 @@ async fn search_images_test(docker: Docker) -> Result<(), Error> {
         .await?;
 
     assert!(result
-        .into_iter()
+        .iter()
         .any(|api_image| &api_image.name.as_ref().unwrap()[..] == "hello-world"));
 
     Ok::<_, Error>(())
@@ -79,7 +79,7 @@ async fn list_images_test(docker: Docker) -> Result<(), Error> {
         }))
         .await?;
 
-    assert!(result.into_iter().any(|api_image| {
+    assert!(result.iter().any(|api_image| {
         api_image
             .repo_tags
             .iter()

--- a/tests/network_test.rs
+++ b/tests/network_test.rs
@@ -171,7 +171,7 @@ async fn connect_network_test(docker: Docker) -> Result<(), Error> {
 
     let _ = &docker
         .disconnect_network(
-            &id,
+            id,
             DisconnectNetworkOptions {
                 container: "integration_test_connect_network_test",
                 force: true,
@@ -179,7 +179,7 @@ async fn connect_network_test(docker: Docker) -> Result<(), Error> {
         )
         .await?;
 
-    let _ = &docker.remove_network(&id).await?;
+    let _ = &docker.remove_network(id).await?;
 
     let _ = &docker
         .kill_container(

--- a/tests/version_test.rs
+++ b/tests/version_test.rs
@@ -70,10 +70,7 @@ fn test_downversioning() {
 
         let _ = &docker.version().await.unwrap();
 
-        assert_eq!(
-            format!("{}", &docker.client_version()),
-            format!("{}", "1.24")
-        );
+        assert_eq!(docker.client_version().to_string(), "1.24".to_string());
     };
     rt.block_on(fut);
 }


### PR DESCRIPTION
And also run Clippy against examples and tests in CI.

Most changes here were generated via `cargo --all-targets --fix && cargo fmt`.

Fixes #211.