### PR TITLE
fix: http 304 should be treated as success

### DIFF
--- a/src/docker.rs
+++ b/src/docker.rs
@@ -1006,8 +1006,8 @@ impl Docker {
 
             let status = response.status();
             match status {
-                // Status code 200 - 299
-                s if s.is_success() => Ok(response),
+                // Status code 200 - 299 or 304
+                s if s.is_success() || s == StatusCode::NOT_MODIFIED => Ok(response),
 
                 StatusCode::SWITCHING_PROTOCOLS => Ok(response),
 


### PR DESCRIPTION
According to https://docs.docker.com/engine/api/v1.41/, Docker API will return HTTP 304 in some cases, for example, trying to stop a container that's already stopped. Currently we only consider HTTP 200-299 as success, so 304 response ends up in the error branch. But since the response body is empty, serde_json will raise an error during deserialization.

PS: There's no other 3XX status codes, so we'll just write it explictly here.