### PR TITLE
Add output_capacity to StartExecOptions

### DIFF
--- a/src/exec.rs
+++ b/src/exec.rs
@@ -63,6 +63,8 @@ pub struct CreateExecResults {
 pub struct StartExecOptions {
     /// Detach from the command.
     pub detach: bool,
+    /// The maximum size for a line of output. The default is 8 * 1024 (roughly 1024 characters).
+    pub output_capacity: Option<usize>,
 }
 
 /// Result type for the [Start Exec API](Docker::start_exec())
@@ -207,6 +209,11 @@ impl Docker {
                 Ok(StartExecResults::Detached)
             }
             _ => {
+                let capacity = match config {
+                    Some(StartExecOptions { output_capacity: Some(capacity), .. }) => capacity,
+                    _ => 8 * 1024,
+                };
+
                 let req = self.build_request(
                     &url,
                     Builder::new()
@@ -223,7 +230,7 @@ impl Docker {
 
                 let (read, write) = self.process_upgraded(req).await?;
 
-                let log = FramedRead::new(read, NewlineLogOutputDecoder::new());
+                let log = FramedRead::with_capacity(read, NewlineLogOutputDecoder::new(), capacity);
                 Ok(StartExecResults::Attached {
                     output: Box::pin(log),
                     input: Box::pin(write),

--- a/src/exec.rs
+++ b/src/exec.rs
@@ -210,7 +210,10 @@ impl Docker {
             }
             _ => {
                 let capacity = match config {
-                    Some(StartExecOptions { output_capacity: Some(capacity), .. }) => capacity,
+                    Some(StartExecOptions {
+                        output_capacity: Some(capacity),
+                        ..
+                    }) => capacity,
                     _ => 8 * 1024,
                 };
 

--- a/tests/exec_test.rs
+++ b/tests/exec_test.rs
@@ -160,7 +160,7 @@ async fn start_exec_output_capacity_test(docker: Docker) -> Result<(), Error> {
     create_daemon(&docker, "start_exec_output_capacity_test").await?;
 
     let text1 = "a".repeat(1024);
-    let text2 = "a".repeat(32 * 1024);
+    let text2 = "a".repeat(7 * 1024);
 
     let message = &docker
         .create_exec(

--- a/tests/exec_test.rs
+++ b/tests/exec_test.rs
@@ -109,7 +109,13 @@ async fn inspect_exec_test(docker: Docker) -> Result<(), Error> {
         .await?;
 
     docker
-        .start_exec(&message.id, Some(StartExecOptions { detach: true, ..Default::default() }))
+        .start_exec(
+            &message.id,
+            Some(StartExecOptions {
+                detach: true,
+                ..Default::default()
+            }),
+        )
         .await?;
 
     let exec_process = &docker.inspect_exec(&message.id).await?;
@@ -162,12 +168,7 @@ async fn start_exec_output_capacity_test(docker: Docker) -> Result<(), Error> {
             CreateExecOptions {
                 attach_stdout: Some(true),
                 cmd: if cfg!(windows) {
-                    Some(vec![
-                        "cmd.exe",
-                        "/C",
-                        "echo",
-                        &text1
-                    ])
+                    Some(vec!["cmd.exe", "/C", "echo", &text1])
                 } else {
                     Some(vec!["/bin/echo", &text1])
                 },
@@ -203,12 +204,7 @@ async fn start_exec_output_capacity_test(docker: Docker) -> Result<(), Error> {
             CreateExecOptions {
                 attach_stdout: Some(true),
                 cmd: if cfg!(windows) {
-                    Some(vec![
-                        "cmd.exe",
-                        "/C",
-                        "echo",
-                        &text2
-                    ])
+                    Some(vec!["cmd.exe", "/C", "echo", &text2])
                 } else {
                     Some(vec!["/bin/echo", &text2])
                 },
@@ -218,10 +214,13 @@ async fn start_exec_output_capacity_test(docker: Docker) -> Result<(), Error> {
         .await?;
 
     let results = docker
-        .start_exec(&message.id, Some(StartExecOptions {
-            output_capacity: Some(100 * 1024),
-            ..Default::default()
-        }))
+        .start_exec(
+            &message.id,
+            Some(StartExecOptions {
+                output_capacity: Some(100 * 1024),
+                ..Default::default()
+            }),
+        )
         .await?;
 
     assert!(match results {

--- a/tests/exec_test.rs
+++ b/tests/exec_test.rs
@@ -109,7 +109,7 @@ async fn inspect_exec_test(docker: Docker) -> Result<(), Error> {
         .await?;
 
     docker
-        .start_exec(&message.id, Some(StartExecOptions { detach: true }))
+        .start_exec(&message.id, Some(StartExecOptions { detach: true, ..Default::default() }))
         .await?;
 
     let exec_process = &docker.inspect_exec(&message.id).await?;
@@ -150,6 +150,122 @@ async fn inspect_exec_test(docker: Docker) -> Result<(), Error> {
     Ok(())
 }
 
+async fn start_exec_output_capacity_test(docker: Docker) -> Result<(), Error> {
+    create_daemon(&docker, "start_exec_output_capacity_test").await?;
+
+    let text1 = "a".repeat(1024);
+    let text2 = "a".repeat(32 * 1024);
+
+    let message = &docker
+        .create_exec(
+            "start_exec_output_capacity_test",
+            CreateExecOptions {
+                attach_stdout: Some(true),
+                cmd: if cfg!(windows) {
+                    Some(vec![
+                        "cmd.exe",
+                        "/C",
+                        "echo",
+                        &text1
+                    ])
+                } else {
+                    Some(vec!["/bin/echo", &text1])
+                },
+                ..Default::default()
+            },
+        )
+        .await?;
+
+    let results = docker
+        .start_exec(&message.id, None::<StartExecOptions>)
+        .await?;
+
+    assert!(match results {
+        StartExecResults::Attached { output, .. } => {
+            let log: Vec<_> = output.try_collect().await?;
+            assert!(!log.is_empty());
+            match &log[0] {
+                LogOutput::StdOut { message } => {
+                    let expected = if cfg!(windows) { text1 + "\r" } else { text1 };
+
+                    let s = String::from_utf8_lossy(message);
+                    s.split('\n').next().expect("log exists") == expected
+                }
+                _ => false,
+            }
+        }
+        _ => false,
+    });
+
+    let message = &docker
+        .create_exec(
+            "start_exec_output_capacity_test",
+            CreateExecOptions {
+                attach_stdout: Some(true),
+                cmd: if cfg!(windows) {
+                    Some(vec![
+                        "cmd.exe",
+                        "/C",
+                        "echo",
+                        &text2
+                    ])
+                } else {
+                    Some(vec!["/bin/echo", &text2])
+                },
+                ..Default::default()
+            },
+        )
+        .await?;
+
+    let results = docker
+        .start_exec(&message.id, Some(StartExecOptions {
+            output_capacity: Some(100 * 1024),
+            ..Default::default()
+        }))
+        .await?;
+
+    assert!(match results {
+        StartExecResults::Attached { output, .. } => {
+            let log: Vec<_> = output.try_collect().await?;
+            assert!(!log.is_empty());
+            match &log[0] {
+                LogOutput::StdOut { message } => {
+                    let expected = if cfg!(windows) { text2 + "\r" } else { text2 };
+
+                    let s = String::from_utf8_lossy(message);
+                    s.split('\n').next().expect("log exists") == expected
+                }
+                _ => false,
+            }
+        }
+        _ => false,
+    });
+
+    let _ = &docker
+        .kill_container(
+            "start_exec_output_capacity_test",
+            None::<KillContainerOptions<String>>,
+        )
+        .await?;
+
+    let _ = &docker
+        .wait_container(
+            "start_exec_output_capacity_test",
+            None::<WaitContainerOptions<String>>,
+        )
+        .try_collect::<Vec<_>>()
+        .await?;
+
+    let _ = &docker
+        .remove_container(
+            "start_exec_output_capacity_test",
+            None::<RemoveContainerOptions>,
+        )
+        .await?;
+
+    Ok(())
+}
+
 #[test]
 fn integration_test_start_exec() {
     connect_to_docker_and_run!(start_exec_test);
@@ -158,4 +274,9 @@ fn integration_test_start_exec() {
 #[test]
 fn integration_test_inspect_exec() {
     connect_to_docker_and_run!(inspect_exec_test);
+}
+
+#[test]
+fn integration_test_start_exec_output_capacity() {
+    connect_to_docker_and_run!(start_exec_output_capacity_test);
 }


### PR DESCRIPTION
This is a small change that allows controlling the capacity of the output reader. This should partially resolve #229.
Some things of note:

- The Linux unit tests have been tested. I cannot test the Windows unit tests, however.
- I've only managed to increase the limit to 32kB in my testing, which, while much better than the 1kB of before, is still restricting, but it should do unless a better solution is found.

Also, this PR shouldn't include any breaking changes granted that people set the config to None or use defaults.