### PR TITLE
optimize: empty response

### DIFF
--- a/src/docker.rs
+++ b/src/docker.rs
@@ -1015,9 +1015,12 @@ impl Docker {
                 _ => {
                     let contents = Docker::decode_into_string(response).await?;
 
-                    let message = serde_json::from_str::<DockerServerErrorMessage>(&contents)
-                        .map(|msg| msg.message)
-                        .or_else(|e| if e.is_data() { Ok(contents) } else { Err(e) })?;
+                    let mut message = String::new();
+                    if !contents.is_empty() {
+                        message = serde_json::from_str::<DockerServerErrorMessage>(&contents)
+                            .map(|msg| msg.message)
+                            .or_else(|e| if e.is_data() { Ok(contents) } else { Err(e) })?;
+                    }
                     Err(DockerResponseServerError {
                         status_code: status.as_u16(),
                         message,


### PR DESCRIPTION
There is empty response but still try to deserialize it into `DockerServerErrorMessage`, then there will be an error: `EOF while parsing a value at line 1 column 0`, I think it's not necessary to deserialize the content while empty.

For example, start a running container, the response's status code will be 304, but its content is empty.