### PR TITLE
add platform parameter for create_container

### DIFF
--- a/examples/kafka.rs
+++ b/examples/kafka.rs
@@ -75,7 +75,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error + 'static>> {
 
     let _ = &docker
         .create_container(
-            Some(CreateContainerOptions { name: "zookeeper" }),
+            Some(CreateContainerOptions {
+                name: "zookeeper",
+                platform: None,
+            }),
             zookeeper_config,
         )
         .await?;
@@ -98,7 +101,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error + 'static>> {
 
     let _ = &docker
         .create_container(
-            Some(CreateContainerOptions { name: "kafka1" }),
+            Some(CreateContainerOptions {
+                name: "kafka1",
+                platform: None,
+            }),
             broker1_config,
         )
         .await?;
@@ -131,7 +137,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error + 'static>> {
 
     let _ = &docker
         .create_container(
-            Some(CreateContainerOptions { name: "kafka2" }),
+            Some(CreateContainerOptions {
+                name: "kafka2",
+                platform: None,
+            }),
             broker2_config,
         )
         .await?;

--- a/src/container.rs
+++ b/src/container.rs
@@ -1214,6 +1214,7 @@ impl Docker {
     ///
     /// let options = Some(CreateContainerOptions{
     ///     name: "my-new-container",
+    ///     platform: None,
     /// });
     ///
     /// let config = Config {

--- a/src/container.rs
+++ b/src/container.rs
@@ -88,6 +88,7 @@ where
 ///
 /// CreateContainerOptions{
 ///     name: "my-new-container",
+///     platform: Some("linux/amd64"),
 /// };
 /// ```
 #[derive(Debug, Clone, Default, PartialEq, Serialize)]
@@ -97,6 +98,11 @@ where
 {
     /// Assign the specified name to the container.
     pub name: T,
+
+    /// The platform to use for the container.
+    /// Added in API v1.41.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub platform: Option<T>,
 }
 
 /// This container's networking configuration.

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -108,6 +108,7 @@ pub async fn create_container_hello_world(
         .create_container(
             Some(CreateContainerOptions {
                 name: container_name.to_string(),
+                platform: None,
             }),
             Config {
                 cmd,
@@ -164,6 +165,7 @@ pub async fn create_shell_daemon(
         .create_container(
             Some(CreateContainerOptions {
                 name: container_name,
+                platform: None,
             }),
             Config {
                 image: Some(image),
@@ -227,6 +229,7 @@ pub async fn create_daemon(docker: &Docker, container_name: &'static str) -> Res
         .create_container(
             Some(CreateContainerOptions {
                 name: container_name,
+                platform: None,
             }),
             Config {
                 cmd,

--- a/tests/container_test.rs
+++ b/tests/container_test.rs
@@ -573,6 +573,7 @@ async fn archive_container_test(docker: Docker) -> Result<(), Error> {
         .create_container(
             Some(CreateContainerOptions {
                 name: "integration_test_archive_container",
+                platform: None,
             }),
             Config {
                 image: Some(&image[..]),
@@ -727,6 +728,7 @@ async fn mount_volume_container_test(docker: Docker) -> Result<(), Error> {
         .create_container(
             Some(CreateContainerOptions {
                 name: "integration_test_mount_volume_container",
+                platform: None,
             }),
             Config {
                 image: Some(&image[..]),

--- a/tests/image_test.rs
+++ b/tests/image_test.rs
@@ -170,6 +170,7 @@ async fn commit_container_test(docker: Docker) -> Result<(), Error> {
         .create_container(
             Some(CreateContainerOptions {
                 name: "integration_test_commit_container",
+                platform: None,
             }),
             Config {
                 cmd,
@@ -212,6 +213,7 @@ async fn commit_container_test(docker: Docker) -> Result<(), Error> {
         .create_container(
             Some(CreateContainerOptions {
                 name: "integration_test_commit_container_next",
+                platform: None,
             }),
             Config {
                 image: Some("integration_test_commit_container_next"),
@@ -329,6 +331,7 @@ RUN touch bollard.txt
         .create_container(
             Some(CreateContainerOptions {
                 name: "integration_test_build_image",
+                platform: None,
             }),
             Config {
                 image: Some("integration_test_build_image"),


### PR DESCRIPTION
Add `platform` parameter to `CreateContainerOptions`. The `platform` query parameter was added to Docker API in v1.41. See https://docs.docker.com/engine/api/version-history/#v141-api-changes.

Fixes https://github.com/fussybeaver/bollard/issues/258.