### PR TITLE
Remove dbg! lines

### DIFF
--- a/src/docker.rs
+++ b/src/docker.rs
@@ -1017,11 +1017,6 @@ impl Docker {
         req: Result<Request<Body>, Error>,
     ) -> Result<(impl AsyncRead, impl AsyncWrite), Error> {
         let res = self.process_request(req).await?;
-        #[cfg(test)]
-        {
-            dbg!(res.status()); // this does return 101 at the moment so we good
-            dbg!(res.headers());
-        }
         let upgraded = hyper::upgrade::on(res).await?;
         Ok(split(upgraded))
     }

--- a/src/docker.rs
+++ b/src/docker.rs
@@ -1017,8 +1017,11 @@ impl Docker {
         req: Result<Request<Body>, Error>,
     ) -> Result<(impl AsyncRead, impl AsyncWrite), Error> {
         let res = self.process_request(req).await?;
-        dbg!(res.status()); // this does return 101 at the moment so we good
-        dbg!(res.headers());
+        #[cfg(test)]
+        {
+            dbg!(res.status()); // this does return 101 at the moment so we good
+            dbg!(res.headers());
+        }
         let upgraded = hyper::upgrade::on(res).await?;
         Ok(split(upgraded))
     }


### PR DESCRIPTION
Right now, every time the exec API is used, those statements print something to stderr which is not always desirable when bollard is used as a library