### PR TITLE
bugfix: attach container

### DIFF
--- a/src/read.rs
+++ b/src/read.rs
@@ -45,19 +45,9 @@ impl Decoder for NewlineLogOutputDecoder {
                 NewlineLogOutputDecoderState::WaitingHeader => {
                     // `start_exec` API on unix socket will emit values without a header
                     if !src.is_empty() && src[0] > 2 {
-                        debug!(
-                            "NewlineLogOutputDecoder: no header found, return LogOutput::Console"
-                        );
-                        let nl_index = src.iter().position(|b| *b == b'\n');
-                        if let Some(pos) = nl_index {
-                            debug!("NewlineLogOutputDecoder: newline found, pos = {}", pos + 1);
-                            return Ok(Some(LogOutput::Console {
-                                message: src.split_to(pos + 1).freeze(),
-                            }));
-                        } else {
-                            debug!("NewlineLogOutputDecoder: no newline found");
-                            return Ok(None);
-                        }
+                        return Ok(Some(LogOutput::Console {
+                            message: src.split_to(src.len()).freeze(),
+                        }));
                     }
 
                     if src.len() < 8 {


### PR DESCRIPTION
Hey related to this issue: https://github.com/fussybeaver/bollard/issues/291

From docker documentation:

When the TTY setting is disabled in [POST /containers/create](https://docs.docker.com/engine/api/v1.42/#operation/ContainerCreate), the HTTP Content-Type header is set to application/vnd.docker.multiplexed-stream and the stream over the hijacked connected is multiplexed to separate out stdout and stderr. The stream consists of a series of frames, each containing a header and a payload.

The header contains the information which the stream writes (stdout or stderr). It also contains the size of the associated frame encoded in the last four bytes (uint32).

The problem was only new line was send where some output is emited without any.
That why the prompt doesn't display because the output send doesn't have new line inside the buffer.