### PR TITLE
Look for `Id` field instead of `id` when deserializing stats

### DIFF
--- a/src/container.rs
+++ b/src/container.rs
@@ -772,6 +772,9 @@ pub struct Stats {
     pub precpu_stats: CPUStats,
     pub storage_stats: StorageStats,
     pub name: String,
+
+    // Podman incorrectly capitalises the "id" field. See https://github.com/containers/podman/issues/17869
+    #[serde(alias = "Id")]
     pub id: String,
 }
 


### PR DESCRIPTION
This is needed for compatibility with Podman. I didn't test with Docker - I'm leaving that to CI.