### PR TITLE
remove default features from chrono

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ base64 = "0.21"
 bollard-stubs = { path = "codegen/swagger", version = "=1.42.0-rc.8", default-features = false }
 bollard-buildkit-proto = { path = "codegen/proto", version = "=0.1.0", optional = true }
 bytes = "1"
-chrono = { version = "0.4", features = ["serde"], optional = true }
+chrono = { version = "0.4", default-features = false, features = ["std", "clock", "serde"], optional = true }
 ct-logs = { version = "0.9.0", optional = true }
 dirs-next = { version = "2.0", optional = true }
 futures-core = "0.3"

--- a/codegen/swagger/Cargo.toml
+++ b/codegen/swagger/Cargo.toml
@@ -13,7 +13,7 @@ buildkit = ["base64", "bytes", "bollard-buildkit-proto", "prost"]
 base64 = { version = "0.13", optional = true }
 bollard-buildkit-proto = { path = "../proto", version = "=0.1.0", optional = true }
 bytes = { version = "1", optional = true }
-chrono = { version = "0.4", features = ["serde"], optional = true }
+chrono = { version = "0.4", default-features = false, features = ["serde"], optional = true }
 serde = { version = "1.0", features = ["derive"] }
 prost = { version = "0.11", optional = true }
 time = { version = "0.3", features = ["formatting", "parsing"], optional = true }

--- a/codegen/swagger/src/main/resources/bollard/Cargo.mustache
+++ b/codegen/swagger/src/main/resources/bollard/Cargo.mustache
@@ -13,7 +13,7 @@ buildkit = ["base64", "bytes", "bollard-buildkit-proto", "prost"]
 base64 = { version = "0.13", optional = true }
 bollard-buildkit-proto = { path = "../proto", version = "=0.1.0", optional = true }
 bytes = { version = "1", optional = true }
-chrono = { version = "0.4", features = ["serde"], optional = true }
+chrono = { version = "0.4", default-features = false, features = ["std", "clock", "serde"], optional = true }
 serde = { version = "1.0", features = ["derive"] }
 prost = { version = "0.11", optional = true }
 time = { version = "0.3", features = ["formatting", "parsing"], optional = true }


### PR DESCRIPTION
Hi,

`chrono`, by default, transitively depends on the crate `time 0.1` 
which has a known vulnerability: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-26235

But, as far as I can see, bollard does not need the `oldtime` feature enabled by default by chrono, and could therefore remove the transitive dependency on the vulnerable crate `time 0.1` by disabling chrono's default features.