### PR TITLE
Update serde_with: 2.0 -> 3.0

### DIFF
--- a/codegen/swagger/src/main/resources/bollard/Cargo.mustache
+++ b/codegen/swagger/src/main/resources/bollard/Cargo.mustache
@@ -18,4 +18,4 @@ serde = { version = "1.0", features = ["derive"] }
 prost = { version = "0.11", optional = true }
 time = { version = "0.3", features = ["formatting", "parsing"], optional = true }
 
-serde_with = {version = "2.0", default-features = false, features = ["std"]}
+serde_with = {version = "3.0", default-features = false, features = ["std"]}


### PR DESCRIPTION
Updated serde_with dependency, to match version in "bollard" crate.

---

Closes #311 