### PR TITLE
Add container commit alias for id

### DIFF
--- a/codegen/swagger/src/models.rs
+++ b/codegen/swagger/src/models.rs
@@ -36,9 +36,7 @@ pub type BollardDate = chrono::DateTime<chrono::Utc>;
 pub type BollardDate = String;
 
 #[cfg(feature = "time")]
-fn deserialize_timestamp<'de, D: Deserializer<'de>>(
-    d: D
-) -> Result<Option<BollardDate>, D::Error> {
+fn deserialize_timestamp<'de, D: Deserializer<'de>>(d: D) -> Result<Option<BollardDate>, D::Error> {
     let opt: Option<String> = serde::Deserialize::deserialize(d)?;
     if let Some(s) = opt {
         Ok(Some(
@@ -51,18 +49,19 @@ fn deserialize_timestamp<'de, D: Deserializer<'de>>(
 }
 
 #[cfg(not(feature = "time"))]
-fn deserialize_timestamp<'de, D: Deserializer<'de>>(
-    d: D
-) -> Result<Option<BollardDate>, D::Error> {
+fn deserialize_timestamp<'de, D: Deserializer<'de>>(d: D) -> Result<Option<BollardDate>, D::Error> {
     serde::Deserialize::deserialize(d)
 }
 
 #[cfg(feature = "time")]
 fn serialize_timestamp<S: Serializer>(date: &Option<BollardDate>, s: S) -> Result<S::Ok, S::Error> {
     match date {
-        Some(inner) => Ok(s.serialize_str(&inner.format(&time::format_description::well_known::Rfc3339)
-                                          .map_err(|e| serde::ser::Error::custom(format!("{:?}", e)))?)?),
-        None => Ok(s.serialize_str("")?)
+        Some(inner) => Ok(s.serialize_str(
+            &inner
+                .format(&time::format_description::well_known::Rfc3339)
+                .map_err(|e| serde::ser::Error::custom(format!("{:?}", e)))?,
+        )?),
+        None => Ok(s.serialize_str("")?),
     }
 }
 
@@ -70,7 +69,7 @@ fn serialize_timestamp<S: Serializer>(date: &Option<BollardDate>, s: S) -> Resul
 fn serialize_timestamp<S: Serializer>(date: &Option<BollardDate>, s: S) -> Result<S::Ok, S::Error> {
     match date {
         Some(inner) => s.serialize_some(inner),
-        None => s.serialize_none()
+        None => s.serialize_none(),
     }
 }
 
@@ -93,9 +92,8 @@ fn deserialize_buildinfo_aux<'de, D: Deserializer<'de>>(
 pub enum BuildInfoAux {
     #[serde(deserialize_with = "deserialize_buildinfo_aux")]
     BuildKit(crate::moby::buildkit::v1::StatusResponse),
-    Default(ImageId)
+    Default(ImageId),
 }
-
 
 /// Address represents an IPv4 or IPv6 IP address.
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
@@ -109,7 +107,6 @@ pub struct Address {
     #[serde(rename = "PrefixLen")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub prefix_len: Option<i64>,
-
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
@@ -129,7 +126,6 @@ pub struct AuthConfig {
     #[serde(rename = "serveraddress")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub serveraddress: Option<String>,
-
 }
 
 /// Volume configuration
@@ -138,53 +134,52 @@ pub struct Body {
     #[serde(rename = "Spec")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub spec: Option<ClusterVolumeSpec>,
-
 }
 
-/// BuildCache contains information about a build cache record. 
+/// BuildCache contains information about a build cache record.
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 pub struct BuildCache {
-    /// Unique ID of the build cache record. 
+    /// Unique ID of the build cache record.
     #[serde(rename = "ID")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub id: Option<String>,
 
-    /// ID of the parent build cache record.  > **Deprecated**: This field is deprecated, and omitted if empty. 
+    /// ID of the parent build cache record.  > **Deprecated**: This field is deprecated, and omitted if empty.
     #[serde(rename = "Parent")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub parent: Option<String>,
 
-    /// List of parent build cache record IDs. 
+    /// List of parent build cache record IDs.
     #[serde(rename = "Parents")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub parents: Option<Vec<String>>,
 
-    /// Cache record type. 
+    /// Cache record type.
     #[serde(rename = "Type")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub typ: Option<BuildCacheTypeEnum>,
 
-    /// Description of the build-step that produced the build cache. 
+    /// Description of the build-step that produced the build cache.
     #[serde(rename = "Description")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
 
-    /// Indicates if the build cache is in use. 
+    /// Indicates if the build cache is in use.
     #[serde(rename = "InUse")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub in_use: Option<bool>,
 
-    /// Indicates if the build cache is shared. 
+    /// Indicates if the build cache is shared.
     #[serde(rename = "Shared")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub shared: Option<bool>,
 
-    /// Amount of disk space used by the build cache (in bytes). 
+    /// Amount of disk space used by the build cache (in bytes).
     #[serde(rename = "Size")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub size: Option<i64>,
 
-    /// Date and time at which the build cache was created in [RFC 3339](https://www.ietf.org/rfc/rfc3339.txt) format with nano-seconds. 
+    /// Date and time at which the build cache was created in [RFC 3339](https://www.ietf.org/rfc/rfc3339.txt) format with nano-seconds.
     #[serde(rename = "CreatedAt")]
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(
@@ -194,7 +189,7 @@ pub struct BuildCache {
     )]
     pub created_at: Option<BollardDate>,
 
-    /// Date and time at which the build cache was last used in [RFC 3339](https://www.ietf.org/rfc/rfc3339.txt) format with nano-seconds. 
+    /// Date and time at which the build cache was last used in [RFC 3339](https://www.ietf.org/rfc/rfc3339.txt) format with nano-seconds.
     #[serde(rename = "LastUsedAt")]
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(
@@ -207,12 +202,11 @@ pub struct BuildCache {
     #[serde(rename = "UsageCount")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub usage_count: Option<i64>,
-
 }
 
 #[allow(non_camel_case_types)]
 #[derive(Debug, Clone, Copy, PartialEq, PartialOrd, Serialize, Deserialize, Eq, Ord)]
-pub enum BuildCacheTypeEnum { 
+pub enum BuildCacheTypeEnum {
     #[serde(rename = "")]
     EMPTY,
     #[serde(rename = "internal")]
@@ -231,7 +225,7 @@ pub enum BuildCacheTypeEnum {
 
 impl ::std::fmt::Display for BuildCacheTypeEnum {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        match *self { 
+        match *self {
             BuildCacheTypeEnum::EMPTY => write!(f, ""),
             BuildCacheTypeEnum::INTERNAL => write!(f, "{}", "internal"),
             BuildCacheTypeEnum::FRONTEND => write!(f, "{}", "frontend"),
@@ -239,7 +233,6 @@ impl ::std::fmt::Display for BuildCacheTypeEnum {
             BuildCacheTypeEnum::SOURCE_GIT_CHECKOUT => write!(f, "{}", "source.git.checkout"),
             BuildCacheTypeEnum::EXEC_CACHEMOUNT => write!(f, "{}", "exec.cachemount"),
             BuildCacheTypeEnum::REGULAR => write!(f, "{}", "regular"),
-
         }
     }
 }
@@ -247,7 +240,7 @@ impl ::std::fmt::Display for BuildCacheTypeEnum {
 impl ::std::str::FromStr for BuildCacheTypeEnum {
     type Err = String;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s { 
+        match s {
             "" => Ok(BuildCacheTypeEnum::EMPTY),
             "internal" => Ok(BuildCacheTypeEnum::INTERNAL),
             "frontend" => Ok(BuildCacheTypeEnum::FRONTEND),
@@ -262,7 +255,7 @@ impl ::std::str::FromStr for BuildCacheTypeEnum {
 
 impl ::std::convert::AsRef<str> for BuildCacheTypeEnum {
     fn as_ref(&self) -> &str {
-        match self { 
+        match self {
             BuildCacheTypeEnum::EMPTY => "",
             BuildCacheTypeEnum::INTERNAL => "internal",
             BuildCacheTypeEnum::FRONTEND => "frontend",
@@ -313,7 +306,6 @@ pub struct BuildInfo {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[cfg(not(feature = "buildkit"))]
     pub aux: Option<ImageId>,
-    
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
@@ -326,10 +318,9 @@ pub struct BuildPruneResponse {
     #[serde(rename = "SpaceReclaimed")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub space_reclaimed: Option<i64>,
-
 }
 
-/// ClusterInfo represents information about the swarm as is returned by the \"/info\" endpoint. Join-tokens are not included. 
+/// ClusterInfo represents information about the swarm as is returned by the \"/info\" endpoint. Join-tokens are not included.
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 pub struct ClusterInfo {
     /// The ID of the swarm.
@@ -341,7 +332,7 @@ pub struct ClusterInfo {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub version: Option<ObjectVersion>,
 
-    /// Date and time at which the swarm was initialised in [RFC 3339](https://www.ietf.org/rfc/rfc3339.txt) format with nano-seconds. 
+    /// Date and time at which the swarm was initialised in [RFC 3339](https://www.ietf.org/rfc/rfc3339.txt) format with nano-seconds.
     #[serde(rename = "CreatedAt")]
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(
@@ -351,7 +342,7 @@ pub struct ClusterInfo {
     )]
     pub created_at: Option<BollardDate>,
 
-    /// Date and time at which the swarm was last updated in [RFC 3339](https://www.ietf.org/rfc/rfc3339.txt) format with nano-seconds. 
+    /// Date and time at which the swarm was last updated in [RFC 3339](https://www.ietf.org/rfc/rfc3339.txt) format with nano-seconds.
     #[serde(rename = "UpdatedAt")]
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(
@@ -369,32 +360,31 @@ pub struct ClusterInfo {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub tls_info: Option<TlsInfo>,
 
-    /// Whether there is currently a root CA rotation in progress for the swarm 
+    /// Whether there is currently a root CA rotation in progress for the swarm
     #[serde(rename = "RootRotationInProgress")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub root_rotation_in_progress: Option<bool>,
 
-    /// DataPathPort specifies the data path port number for data traffic. Acceptable port range is 1024 to 49151. If no port is set or is set to 0, the default port (4789) is used. 
+    /// DataPathPort specifies the data path port number for data traffic. Acceptable port range is 1024 to 49151. If no port is set or is set to 0, the default port (4789) is used.
     #[serde(rename = "DataPathPort")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub data_path_port: Option<u32>,
 
-    /// Default Address Pool specifies default subnet pools for global scope networks. 
+    /// Default Address Pool specifies default subnet pools for global scope networks.
     #[serde(rename = "DefaultAddrPool")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub default_addr_pool: Option<Vec<String>>,
 
-    /// SubnetSize specifies the subnet size of the networks created from the default subnet pool. 
+    /// SubnetSize specifies the subnet size of the networks created from the default subnet pool.
     #[serde(rename = "SubnetSize")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub subnet_size: Option<u32>,
-
 }
 
-/// Options and information specific to, and only present on, Swarm CSI cluster volumes. 
+/// Options and information specific to, and only present on, Swarm CSI cluster volumes.
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 pub struct ClusterVolume {
-    /// The Swarm ID of this volume. Because cluster volumes are Swarm objects, they have an ID, unlike non-cluster volumes. This ID can be used to refer to the Volume instead of the name. 
+    /// The Swarm ID of this volume. Because cluster volumes are Swarm objects, they have an ID, unlike non-cluster volumes. This ID can be used to refer to the Volume instead of the name.
     #[serde(rename = "ID")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub id: Option<String>,
@@ -429,60 +419,57 @@ pub struct ClusterVolume {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub info: Option<ClusterVolumeInfo>,
 
-    /// The status of the volume as it pertains to its publishing and use on specific nodes 
+    /// The status of the volume as it pertains to its publishing and use on specific nodes
     #[serde(rename = "PublishStatus")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub publish_status: Option<Vec<ClusterVolumePublishStatus>>,
-
 }
 
-/// Information about the global status of the volume. 
+/// Information about the global status of the volume.
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 pub struct ClusterVolumeInfo {
-    /// The capacity of the volume in bytes. A value of 0 indicates that the capacity is unknown. 
+    /// The capacity of the volume in bytes. A value of 0 indicates that the capacity is unknown.
     #[serde(rename = "CapacityBytes")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub capacity_bytes: Option<i64>,
 
-    /// A map of strings to strings returned from the storage plugin when the volume is created. 
+    /// A map of strings to strings returned from the storage plugin when the volume is created.
     #[serde(rename = "VolumeContext")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub volume_context: Option<HashMap<String, String>>,
 
-    /// The ID of the volume as returned by the CSI storage plugin. This is distinct from the volume's ID as provided by Docker. This ID is never used by the user when communicating with Docker to refer to this volume. If the ID is blank, then the Volume has not been successfully created in the plugin yet. 
+    /// The ID of the volume as returned by the CSI storage plugin. This is distinct from the volume's ID as provided by Docker. This ID is never used by the user when communicating with Docker to refer to this volume. If the ID is blank, then the Volume has not been successfully created in the plugin yet.
     #[serde(rename = "VolumeID")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub volume_id: Option<String>,
 
-    /// The topology this volume is actually accessible from. 
+    /// The topology this volume is actually accessible from.
     #[serde(rename = "AccessibleTopology")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub accessible_topology: Option<Vec<Topology>>,
-
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 pub struct ClusterVolumePublishStatus {
-    /// The ID of the Swarm node the volume is published on. 
+    /// The ID of the Swarm node the volume is published on.
     #[serde(rename = "NodeID")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub node_id: Option<String>,
 
-    /// The published state of the volume. * `pending-publish` The volume should be published to this node, but the call to the controller plugin to do so has not yet been successfully completed. * `published` The volume is published successfully to the node. * `pending-node-unpublish` The volume should be unpublished from the node, and the manager is awaiting confirmation from the worker that it has done so. * `pending-controller-unpublish` The volume is successfully unpublished from the node, but has not yet been successfully unpublished on the controller. 
+    /// The published state of the volume. * `pending-publish` The volume should be published to this node, but the call to the controller plugin to do so has not yet been successfully completed. * `published` The volume is published successfully to the node. * `pending-node-unpublish` The volume should be unpublished from the node, and the manager is awaiting confirmation from the worker that it has done so. * `pending-controller-unpublish` The volume is successfully unpublished from the node, but has not yet been successfully unpublished on the controller.
     #[serde(rename = "State")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub state: Option<ClusterVolumePublishStatusStateEnum>,
 
-    /// A map of strings to strings returned by the CSI controller plugin when a volume is published. 
+    /// A map of strings to strings returned by the CSI controller plugin when a volume is published.
     #[serde(rename = "PublishContext")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub publish_context: Option<HashMap<String, String>>,
-
 }
 
 #[allow(non_camel_case_types)]
 #[derive(Debug, Clone, Copy, PartialEq, PartialOrd, Serialize, Deserialize, Eq, Ord)]
-pub enum ClusterVolumePublishStatusStateEnum { 
+pub enum ClusterVolumePublishStatusStateEnum {
     #[serde(rename = "")]
     EMPTY,
     #[serde(rename = "pending-publish")]
@@ -497,13 +484,18 @@ pub enum ClusterVolumePublishStatusStateEnum {
 
 impl ::std::fmt::Display for ClusterVolumePublishStatusStateEnum {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        match *self { 
+        match *self {
             ClusterVolumePublishStatusStateEnum::EMPTY => write!(f, ""),
-            ClusterVolumePublishStatusStateEnum::PENDING_PUBLISH => write!(f, "{}", "pending-publish"),
+            ClusterVolumePublishStatusStateEnum::PENDING_PUBLISH => {
+                write!(f, "{}", "pending-publish")
+            }
             ClusterVolumePublishStatusStateEnum::PUBLISHED => write!(f, "{}", "published"),
-            ClusterVolumePublishStatusStateEnum::PENDING_NODE_UNPUBLISH => write!(f, "{}", "pending-node-unpublish"),
-            ClusterVolumePublishStatusStateEnum::PENDING_CONTROLLER_UNPUBLISH => write!(f, "{}", "pending-controller-unpublish"),
-
+            ClusterVolumePublishStatusStateEnum::PENDING_NODE_UNPUBLISH => {
+                write!(f, "{}", "pending-node-unpublish")
+            }
+            ClusterVolumePublishStatusStateEnum::PENDING_CONTROLLER_UNPUBLISH => {
+                write!(f, "{}", "pending-controller-unpublish")
+            }
         }
     }
 }
@@ -511,12 +503,16 @@ impl ::std::fmt::Display for ClusterVolumePublishStatusStateEnum {
 impl ::std::str::FromStr for ClusterVolumePublishStatusStateEnum {
     type Err = String;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s { 
+        match s {
             "" => Ok(ClusterVolumePublishStatusStateEnum::EMPTY),
             "pending-publish" => Ok(ClusterVolumePublishStatusStateEnum::PENDING_PUBLISH),
             "published" => Ok(ClusterVolumePublishStatusStateEnum::PUBLISHED),
-            "pending-node-unpublish" => Ok(ClusterVolumePublishStatusStateEnum::PENDING_NODE_UNPUBLISH),
-            "pending-controller-unpublish" => Ok(ClusterVolumePublishStatusStateEnum::PENDING_CONTROLLER_UNPUBLISH),
+            "pending-node-unpublish" => {
+                Ok(ClusterVolumePublishStatusStateEnum::PENDING_NODE_UNPUBLISH)
+            }
+            "pending-controller-unpublish" => {
+                Ok(ClusterVolumePublishStatusStateEnum::PENDING_CONTROLLER_UNPUBLISH)
+            }
             x => Err(format!("Invalid enum type: {}", x)),
         }
     }
@@ -524,20 +520,22 @@ impl ::std::str::FromStr for ClusterVolumePublishStatusStateEnum {
 
 impl ::std::convert::AsRef<str> for ClusterVolumePublishStatusStateEnum {
     fn as_ref(&self) -> &str {
-        match self { 
+        match self {
             ClusterVolumePublishStatusStateEnum::EMPTY => "",
             ClusterVolumePublishStatusStateEnum::PENDING_PUBLISH => "pending-publish",
             ClusterVolumePublishStatusStateEnum::PUBLISHED => "published",
             ClusterVolumePublishStatusStateEnum::PENDING_NODE_UNPUBLISH => "pending-node-unpublish",
-            ClusterVolumePublishStatusStateEnum::PENDING_CONTROLLER_UNPUBLISH => "pending-controller-unpublish",
+            ClusterVolumePublishStatusStateEnum::PENDING_CONTROLLER_UNPUBLISH => {
+                "pending-controller-unpublish"
+            }
         }
     }
 }
 
-/// Cluster-specific options used to create the volume. 
+/// Cluster-specific options used to create the volume.
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 pub struct ClusterVolumeSpec {
-    /// Group defines the volume group of this volume. Volumes belonging to the same group can be referred to by group name when creating Services.  Referring to a volume by group instructs Swarm to treat volumes in that group interchangeably for the purpose of scheduling. Volumes with an empty string for a group technically all belong to the same, emptystring group. 
+    /// Group defines the volume group of this volume. Volumes belonging to the same group can be referred to by group name when creating Services.  Referring to a volume by group instructs Swarm to treat volumes in that group interchangeably for the purpose of scheduling. Volumes with an empty string for a group technically all belong to the same, emptystring group.
     #[serde(rename = "Group")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub group: Option<String>,
@@ -545,28 +543,27 @@ pub struct ClusterVolumeSpec {
     #[serde(rename = "AccessMode")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub access_mode: Option<ClusterVolumeSpecAccessMode>,
-
 }
 
-/// Defines how the volume is used by tasks. 
+/// Defines how the volume is used by tasks.
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 pub struct ClusterVolumeSpecAccessMode {
-    /// The set of nodes this volume can be used on at one time. - `single` The volume may only be scheduled to one node at a time. - `multi` the volume may be scheduled to any supported number of nodes at a time. 
+    /// The set of nodes this volume can be used on at one time. - `single` The volume may only be scheduled to one node at a time. - `multi` the volume may be scheduled to any supported number of nodes at a time.
     #[serde(rename = "Scope")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub scope: Option<ClusterVolumeSpecAccessModeScopeEnum>,
 
-    /// The number and way that different tasks can use this volume at one time. - `none` The volume may only be used by one task at a time. - `readonly` The volume may be used by any number of tasks, but they all must mount the volume as readonly - `onewriter` The volume may be used by any number of tasks, but only one may mount it as read/write. - `all` The volume may have any number of readers and writers. 
+    /// The number and way that different tasks can use this volume at one time. - `none` The volume may only be used by one task at a time. - `readonly` The volume may be used by any number of tasks, but they all must mount the volume as readonly - `onewriter` The volume may be used by any number of tasks, but only one may mount it as read/write. - `all` The volume may have any number of readers and writers.
     #[serde(rename = "Sharing")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub sharing: Option<ClusterVolumeSpecAccessModeSharingEnum>,
 
-    /// Options for using this volume as a Mount-type volume.      Either MountVolume or BlockVolume, but not both, must be     present.   properties:     FsType:       type: \"string\"       description: |         Specifies the filesystem type for the mount volume.         Optional.     MountFlags:       type: \"array\"       description: |         Flags to pass when mounting the volume. Optional.       items:         type: \"string\" BlockVolume:   type: \"object\"   description: |     Options for using this volume as a Block-type volume.     Intentionally empty. 
+    /// Options for using this volume as a Mount-type volume.      Either MountVolume or BlockVolume, but not both, must be     present.   properties:     FsType:       type: \"string\"       description: |         Specifies the filesystem type for the mount volume.         Optional.     MountFlags:       type: \"array\"       description: |         Flags to pass when mounting the volume. Optional.       items:         type: \"string\" BlockVolume:   type: \"object\"   description: |     Options for using this volume as a Block-type volume.     Intentionally empty.
     #[serde(rename = "MountVolume")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub mount_volume: Option<HashMap<(), ()>>,
 
-    /// Swarm Secrets that are passed to the CSI storage plugin when operating on this volume. 
+    /// Swarm Secrets that are passed to the CSI storage plugin when operating on this volume.
     #[serde(rename = "Secrets")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub secrets: Option<Vec<ClusterVolumeSpecAccessModeSecrets>>,
@@ -579,16 +576,15 @@ pub struct ClusterVolumeSpecAccessMode {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub capacity_range: Option<ClusterVolumeSpecAccessModeCapacityRange>,
 
-    /// The availability of the volume for use in tasks. - `active` The volume is fully available for scheduling on the cluster - `pause` No new workloads should use the volume, but existing workloads are not stopped. - `drain` All workloads using this volume should be stopped and rescheduled, and no new ones should be started. 
+    /// The availability of the volume for use in tasks. - `active` The volume is fully available for scheduling on the cluster - `pause` No new workloads should use the volume, but existing workloads are not stopped. - `drain` All workloads using this volume should be stopped and rescheduled, and no new ones should be started.
     #[serde(rename = "Availability")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub availability: Option<ClusterVolumeSpecAccessModeAvailabilityEnum>,
-
 }
 
 #[allow(non_camel_case_types)]
 #[derive(Debug, Clone, Copy, PartialEq, PartialOrd, Serialize, Deserialize, Eq, Ord)]
-pub enum ClusterVolumeSpecAccessModeScopeEnum { 
+pub enum ClusterVolumeSpecAccessModeScopeEnum {
     #[serde(rename = "")]
     EMPTY,
     #[serde(rename = "single")]
@@ -599,11 +595,10 @@ pub enum ClusterVolumeSpecAccessModeScopeEnum {
 
 impl ::std::fmt::Display for ClusterVolumeSpecAccessModeScopeEnum {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        match *self { 
+        match *self {
             ClusterVolumeSpecAccessModeScopeEnum::EMPTY => write!(f, ""),
             ClusterVolumeSpecAccessModeScopeEnum::SINGLE => write!(f, "{}", "single"),
             ClusterVolumeSpecAccessModeScopeEnum::MULTI => write!(f, "{}", "multi"),
-
         }
     }
 }
@@ -611,7 +606,7 @@ impl ::std::fmt::Display for ClusterVolumeSpecAccessModeScopeEnum {
 impl ::std::str::FromStr for ClusterVolumeSpecAccessModeScopeEnum {
     type Err = String;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s { 
+        match s {
             "" => Ok(ClusterVolumeSpecAccessModeScopeEnum::EMPTY),
             "single" => Ok(ClusterVolumeSpecAccessModeScopeEnum::SINGLE),
             "multi" => Ok(ClusterVolumeSpecAccessModeScopeEnum::MULTI),
@@ -622,7 +617,7 @@ impl ::std::str::FromStr for ClusterVolumeSpecAccessModeScopeEnum {
 
 impl ::std::convert::AsRef<str> for ClusterVolumeSpecAccessModeScopeEnum {
     fn as_ref(&self) -> &str {
-        match self { 
+        match self {
             ClusterVolumeSpecAccessModeScopeEnum::EMPTY => "",
             ClusterVolumeSpecAccessModeScopeEnum::SINGLE => "single",
             ClusterVolumeSpecAccessModeScopeEnum::MULTI => "multi",
@@ -632,7 +627,7 @@ impl ::std::convert::AsRef<str> for ClusterVolumeSpecAccessModeScopeEnum {
 
 #[allow(non_camel_case_types)]
 #[derive(Debug, Clone, Copy, PartialEq, PartialOrd, Serialize, Deserialize, Eq, Ord)]
-pub enum ClusterVolumeSpecAccessModeSharingEnum { 
+pub enum ClusterVolumeSpecAccessModeSharingEnum {
     #[serde(rename = "")]
     EMPTY,
     #[serde(rename = "none")]
@@ -647,13 +642,12 @@ pub enum ClusterVolumeSpecAccessModeSharingEnum {
 
 impl ::std::fmt::Display for ClusterVolumeSpecAccessModeSharingEnum {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        match *self { 
+        match *self {
             ClusterVolumeSpecAccessModeSharingEnum::EMPTY => write!(f, ""),
             ClusterVolumeSpecAccessModeSharingEnum::NONE => write!(f, "{}", "none"),
             ClusterVolumeSpecAccessModeSharingEnum::READONLY => write!(f, "{}", "readonly"),
             ClusterVolumeSpecAccessModeSharingEnum::ONEWRITER => write!(f, "{}", "onewriter"),
             ClusterVolumeSpecAccessModeSharingEnum::ALL => write!(f, "{}", "all"),
-
         }
     }
 }
@@ -661,7 +655,7 @@ impl ::std::fmt::Display for ClusterVolumeSpecAccessModeSharingEnum {
 impl ::std::str::FromStr for ClusterVolumeSpecAccessModeSharingEnum {
     type Err = String;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s { 
+        match s {
             "" => Ok(ClusterVolumeSpecAccessModeSharingEnum::EMPTY),
             "none" => Ok(ClusterVolumeSpecAccessModeSharingEnum::NONE),
             "readonly" => Ok(ClusterVolumeSpecAccessModeSharingEnum::READONLY),
@@ -674,7 +668,7 @@ impl ::std::str::FromStr for ClusterVolumeSpecAccessModeSharingEnum {
 
 impl ::std::convert::AsRef<str> for ClusterVolumeSpecAccessModeSharingEnum {
     fn as_ref(&self) -> &str {
-        match self { 
+        match self {
             ClusterVolumeSpecAccessModeSharingEnum::EMPTY => "",
             ClusterVolumeSpecAccessModeSharingEnum::NONE => "none",
             ClusterVolumeSpecAccessModeSharingEnum::READONLY => "readonly",
@@ -686,7 +680,7 @@ impl ::std::convert::AsRef<str> for ClusterVolumeSpecAccessModeSharingEnum {
 
 #[allow(non_camel_case_types)]
 #[derive(Debug, Clone, Copy, PartialEq, PartialOrd, Serialize, Deserialize, Eq, Ord)]
-pub enum ClusterVolumeSpecAccessModeAvailabilityEnum { 
+pub enum ClusterVolumeSpecAccessModeAvailabilityEnum {
     #[serde(rename = "")]
     EMPTY,
     #[serde(rename = "active")]
@@ -699,12 +693,11 @@ pub enum ClusterVolumeSpecAccessModeAvailabilityEnum {
 
 impl ::std::fmt::Display for ClusterVolumeSpecAccessModeAvailabilityEnum {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        match *self { 
+        match *self {
             ClusterVolumeSpecAccessModeAvailabilityEnum::EMPTY => write!(f, ""),
             ClusterVolumeSpecAccessModeAvailabilityEnum::ACTIVE => write!(f, "{}", "active"),
             ClusterVolumeSpecAccessModeAvailabilityEnum::PAUSE => write!(f, "{}", "pause"),
             ClusterVolumeSpecAccessModeAvailabilityEnum::DRAIN => write!(f, "{}", "drain"),
-
         }
     }
 }
@@ -712,7 +705,7 @@ impl ::std::fmt::Display for ClusterVolumeSpecAccessModeAvailabilityEnum {
 impl ::std::str::FromStr for ClusterVolumeSpecAccessModeAvailabilityEnum {
     type Err = String;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s { 
+        match s {
             "" => Ok(ClusterVolumeSpecAccessModeAvailabilityEnum::EMPTY),
             "active" => Ok(ClusterVolumeSpecAccessModeAvailabilityEnum::ACTIVE),
             "pause" => Ok(ClusterVolumeSpecAccessModeAvailabilityEnum::PAUSE),
@@ -724,7 +717,7 @@ impl ::std::str::FromStr for ClusterVolumeSpecAccessModeAvailabilityEnum {
 
 impl ::std::convert::AsRef<str> for ClusterVolumeSpecAccessModeAvailabilityEnum {
     fn as_ref(&self) -> &str {
-        match self { 
+        match self {
             ClusterVolumeSpecAccessModeAvailabilityEnum::EMPTY => "",
             ClusterVolumeSpecAccessModeAvailabilityEnum::ACTIVE => "active",
             ClusterVolumeSpecAccessModeAvailabilityEnum::PAUSE => "pause",
@@ -733,64 +726,61 @@ impl ::std::convert::AsRef<str> for ClusterVolumeSpecAccessModeAvailabilityEnum 
     }
 }
 
-/// Requirements for the accessible topology of the volume. These fields are optional. For an in-depth description of what these fields mean, see the CSI specification. 
+/// Requirements for the accessible topology of the volume. These fields are optional. For an in-depth description of what these fields mean, see the CSI specification.
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 pub struct ClusterVolumeSpecAccessModeAccessibilityRequirements {
-    /// A list of required topologies, at least one of which the volume must be accessible from. 
+    /// A list of required topologies, at least one of which the volume must be accessible from.
     #[serde(rename = "Requisite")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub requisite: Option<Vec<Topology>>,
 
-    /// A list of topologies that the volume should attempt to be provisioned in. 
+    /// A list of topologies that the volume should attempt to be provisioned in.
     #[serde(rename = "Preferred")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub preferred: Option<Vec<Topology>>,
-
 }
 
-/// The desired capacity that the volume should be created with. If empty, the plugin will decide the capacity. 
+/// The desired capacity that the volume should be created with. If empty, the plugin will decide the capacity.
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 pub struct ClusterVolumeSpecAccessModeCapacityRange {
-    /// The volume must be at least this big. The value of 0 indicates an unspecified minimum 
+    /// The volume must be at least this big. The value of 0 indicates an unspecified minimum
     #[serde(rename = "RequiredBytes")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub required_bytes: Option<i64>,
 
-    /// The volume must not be bigger than this. The value of 0 indicates an unspecified maximum. 
+    /// The volume must not be bigger than this. The value of 0 indicates an unspecified maximum.
     #[serde(rename = "LimitBytes")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub limit_bytes: Option<i64>,
-
 }
 
-/// One cluster volume secret entry. Defines a key-value pair that is passed to the plugin. 
+/// One cluster volume secret entry. Defines a key-value pair that is passed to the plugin.
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 pub struct ClusterVolumeSpecAccessModeSecrets {
-    /// Key is the name of the key of the key-value pair passed to the plugin. 
+    /// Key is the name of the key of the key-value pair passed to the plugin.
     #[serde(rename = "Key")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub key: Option<String>,
 
-    /// Secret is the swarm Secret object from which to read data. This can be a Secret name or ID. The Secret data is retrieved by swarm and used as the value of the key-value pair passed to the plugin. 
+    /// Secret is the swarm Secret object from which to read data. This can be a Secret name or ID. The Secret data is retrieved by swarm and used as the value of the key-value pair passed to the plugin.
     #[serde(rename = "Secret")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub secret: Option<String>,
-
 }
 
-/// Commit holds the Git-commit (SHA1) that a binary was built from, as reported in the version-string of external tools, such as `containerd`, or `runC`. 
+/// Commit holds the Git-commit (SHA1) that a binary was built from, as reported in the version-string of external tools, such as `containerd`, or `runC`.
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 pub struct Commit {
     /// Actual commit ID of external tool.
     #[serde(rename = "ID")]
+    #[serde(alias = "Id")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub id: Option<String>,
 
-    /// Commit ID of external tool expected by dockerd as set at build time. 
+    /// Commit ID of external tool expected by dockerd as set at build time.
     #[serde(rename = "Expected")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub expected: Option<String>,
-
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
@@ -824,7 +814,6 @@ pub struct Config {
     #[serde(rename = "Spec")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub spec: Option<ConfigSpec>,
-
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
@@ -839,16 +828,15 @@ pub struct ConfigSpec {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub labels: Option<HashMap<String, String>>,
 
-    /// Base64-url-safe-encoded ([RFC 4648](https://tools.ietf.org/html/rfc4648#section-5)) config data. 
+    /// Base64-url-safe-encoded ([RFC 4648](https://tools.ietf.org/html/rfc4648#section-5)) config data.
     #[serde(rename = "Data")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub data: Option<String>,
 
-    /// Templating driver, if applicable  Templating controls whether and how to evaluate the config payload as a template. If no driver is set, no templating is used. 
+    /// Templating driver, if applicable  Templating controls whether and how to evaluate the config payload as a template. If no driver is set, no templating is used.
     #[serde(rename = "Templating")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub templating: Option<Driver>,
-
 }
 
 /// change item in response to ContainerChanges operation
@@ -861,18 +849,17 @@ pub struct ContainerChangeResponseItem {
     /// Kind of change
     #[serde(rename = "Kind")]
     pub kind: i64,
-
 }
 
-/// Configuration for a container that is portable between hosts.  When used as `ContainerConfig` field in an image, `ContainerConfig` is an optional field containing the configuration of the container that was last committed when creating the image.  Previous versions of Docker builder used this field to store build cache, and it is not in active use anymore. 
+/// Configuration for a container that is portable between hosts.  When used as `ContainerConfig` field in an image, `ContainerConfig` is an optional field containing the configuration of the container that was last committed when creating the image.  Previous versions of Docker builder used this field to store build cache, and it is not in active use anymore.
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 pub struct ContainerConfig {
-    /// The hostname to use for the container, as a valid RFC 1123 hostname. 
+    /// The hostname to use for the container, as a valid RFC 1123 hostname.
     #[serde(rename = "Hostname")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub hostname: Option<String>,
 
-    /// The domain name to use for the container. 
+    /// The domain name to use for the container.
     #[serde(rename = "Domainname")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub domainname: Option<String>,
@@ -897,12 +884,12 @@ pub struct ContainerConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub attach_stderr: Option<bool>,
 
-    /// An object mapping ports to an empty object in the form:  `{\"<port>/<tcp|udp|sctp>\": {}}` 
+    /// An object mapping ports to an empty object in the form:  `{\"<port>/<tcp|udp|sctp>\": {}}`
     #[serde(rename = "ExposedPorts")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub exposed_ports: Option<HashMap<String, HashMap<(), ()>>>,
 
-    /// Attach standard streams to a TTY, including `stdin` if it is not closed. 
+    /// Attach standard streams to a TTY, including `stdin` if it is not closed.
     #[serde(rename = "Tty")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub tty: Option<bool>,
@@ -917,12 +904,12 @@ pub struct ContainerConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub stdin_once: Option<bool>,
 
-    /// A list of environment variables to set inside the container in the form `[\"VAR=value\", ...]`. A variable without `=` is removed from the environment, rather than to have an empty value. 
+    /// A list of environment variables to set inside the container in the form `[\"VAR=value\", ...]`. A variable without `=` is removed from the environment, rather than to have an empty value.
     #[serde(rename = "Env")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub env: Option<Vec<String>>,
 
-    /// Command to run specified as a string or an array of strings. 
+    /// Command to run specified as a string or an array of strings.
     #[serde(rename = "Cmd")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cmd: Option<Vec<String>>,
@@ -936,12 +923,12 @@ pub struct ContainerConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub args_escaped: Option<bool>,
 
-    /// The name (or reference) of the image to use when creating the container, or which was used when the container was created. 
+    /// The name (or reference) of the image to use when creating the container, or which was used when the container was created.
     #[serde(rename = "Image")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub image: Option<String>,
 
-    /// An object mapping mount point paths inside the container to empty objects. 
+    /// An object mapping mount point paths inside the container to empty objects.
     #[serde(rename = "Volumes")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub volumes: Option<HashMap<String, HashMap<(), ()>>>,
@@ -951,7 +938,7 @@ pub struct ContainerConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub working_dir: Option<String>,
 
-    /// The entry point for the container as a string or an array of strings.  If the array consists of exactly one empty string (`[\"\"]`) then the entry point is reset to system default (i.e., the entry point used by docker when there is no `ENTRYPOINT` instruction in the `Dockerfile`). 
+    /// The entry point for the container as a string or an array of strings.  If the array consists of exactly one empty string (`[\"\"]`) then the entry point is reset to system default (i.e., the entry point used by docker when there is no `ENTRYPOINT` instruction in the `Dockerfile`).
     #[serde(rename = "Entrypoint")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub entrypoint: Option<Vec<String>>,
@@ -966,7 +953,7 @@ pub struct ContainerConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub mac_address: Option<String>,
 
-    /// `ONBUILD` metadata that were defined in the image's `Dockerfile`. 
+    /// `ONBUILD` metadata that were defined in the image's `Dockerfile`.
     #[serde(rename = "OnBuild")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub on_build: Option<Vec<String>>,
@@ -976,7 +963,7 @@ pub struct ContainerConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub labels: Option<HashMap<String, String>>,
 
-    /// Signal to stop a container as a string or unsigned integer. 
+    /// Signal to stop a container as a string or unsigned integer.
     #[serde(rename = "StopSignal")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub stop_signal: Option<String>,
@@ -986,11 +973,10 @@ pub struct ContainerConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub stop_timeout: Option<i64>,
 
-    /// Shell for when `RUN`, `CMD`, and `ENTRYPOINT` uses a shell. 
+    /// Shell for when `RUN`, `CMD`, and `ENTRYPOINT` uses a shell.
     #[serde(rename = "Shell")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub shell: Option<Vec<String>>,
-
 }
 
 /// OK response to ContainerCreate operation
@@ -1004,7 +990,6 @@ pub struct ContainerCreateResponse {
     #[serde(rename = "Warnings")]
     #[serde(deserialize_with = "deserialize_nonoptional_vec")]
     pub warnings: Vec<String>,
-
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
@@ -1095,7 +1080,7 @@ pub struct ContainerInspectResponse {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub graph_driver: Option<GraphDriverData>,
 
-    /// The size of files that have been created or changed by this container. 
+    /// The size of files that have been created or changed by this container.
     #[serde(rename = "SizeRw")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub size_rw: Option<i64>,
@@ -1116,7 +1101,6 @@ pub struct ContainerInspectResponse {
     #[serde(rename = "NetworkSettings")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub network_settings: Option<NetworkSettings>,
-
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
@@ -1130,18 +1114,17 @@ pub struct ContainerPruneResponse {
     #[serde(rename = "SpaceReclaimed")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub space_reclaimed: Option<i64>,
-
 }
 
-/// ContainerState stores container's running state. It's part of ContainerJSONBase and will be returned by the \"inspect\" command. 
+/// ContainerState stores container's running state. It's part of ContainerJSONBase and will be returned by the \"inspect\" command.
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 pub struct ContainerState {
-    /// String representation of the container state. Can be one of \"created\", \"running\", \"paused\", \"restarting\", \"removing\", \"exited\", or \"dead\". 
+    /// String representation of the container state. Can be one of \"created\", \"running\", \"paused\", \"restarting\", \"removing\", \"exited\", or \"dead\".
     #[serde(rename = "Status")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub status: Option<ContainerStateStatusEnum>,
 
-    /// Whether this container is running.  Note that a running container can be _paused_. The `Running` and `Paused` booleans are not mutually exclusive:  When pausing a container (on Linux), the freezer cgroup is used to suspend all processes in the container. Freezing the process requires the process to be running. As a result, paused containers are both `Running` _and_ `Paused`.  Use the `Status` field instead to determine if a container's state is \"running\". 
+    /// Whether this container is running.  Note that a running container can be _paused_. The `Running` and `Paused` booleans are not mutually exclusive:  When pausing a container (on Linux), the freezer cgroup is used to suspend all processes in the container. Freezing the process requires the process to be running. As a result, paused containers are both `Running` _and_ `Paused`.  Use the `Status` field instead to determine if a container's state is \"running\".
     #[serde(rename = "Running")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub running: Option<bool>,
@@ -1156,7 +1139,7 @@ pub struct ContainerState {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub restarting: Option<bool>,
 
-    /// Whether this container has been killed because it ran out of memory. 
+    /// Whether this container has been killed because it ran out of memory.
     #[serde(rename = "OOMKilled")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub oom_killed: Option<bool>,
@@ -1192,12 +1175,11 @@ pub struct ContainerState {
     #[serde(rename = "Health")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub health: Option<Health>,
-
 }
 
 #[allow(non_camel_case_types)]
 #[derive(Debug, Clone, Copy, PartialEq, PartialOrd, Serialize, Deserialize, Eq, Ord)]
-pub enum ContainerStateStatusEnum { 
+pub enum ContainerStateStatusEnum {
     #[serde(rename = "")]
     EMPTY,
     #[serde(rename = "created")]
@@ -1218,7 +1200,7 @@ pub enum ContainerStateStatusEnum {
 
 impl ::std::fmt::Display for ContainerStateStatusEnum {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        match *self { 
+        match *self {
             ContainerStateStatusEnum::EMPTY => write!(f, ""),
             ContainerStateStatusEnum::CREATED => write!(f, "{}", "created"),
             ContainerStateStatusEnum::RUNNING => write!(f, "{}", "running"),
@@ -1227,7 +1209,6 @@ impl ::std::fmt::Display for ContainerStateStatusEnum {
             ContainerStateStatusEnum::REMOVING => write!(f, "{}", "removing"),
             ContainerStateStatusEnum::EXITED => write!(f, "{}", "exited"),
             ContainerStateStatusEnum::DEAD => write!(f, "{}", "dead"),
-
         }
     }
 }
@@ -1235,7 +1216,7 @@ impl ::std::fmt::Display for ContainerStateStatusEnum {
 impl ::std::str::FromStr for ContainerStateStatusEnum {
     type Err = String;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s { 
+        match s {
             "" => Ok(ContainerStateStatusEnum::EMPTY),
             "created" => Ok(ContainerStateStatusEnum::CREATED),
             "running" => Ok(ContainerStateStatusEnum::RUNNING),
@@ -1251,7 +1232,7 @@ impl ::std::str::FromStr for ContainerStateStatusEnum {
 
 impl ::std::convert::AsRef<str> for ContainerStateStatusEnum {
     fn as_ref(&self) -> &str {
-        match self { 
+        match self {
             ContainerStateStatusEnum::EMPTY => "",
             ContainerStateStatusEnum::CREATED => "created",
             ContainerStateStatusEnum::RUNNING => "running",
@@ -1337,7 +1318,6 @@ pub struct ContainerSummary {
     #[serde(rename = "Mounts")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub mounts: Option<Vec<MountPoint>>,
-
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
@@ -1345,7 +1325,6 @@ pub struct ContainerSummaryHostConfig {
     #[serde(rename = "NetworkMode")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub network_mode: Option<String>,
-
 }
 
 /// A summary of the container's network settings
@@ -1354,7 +1333,6 @@ pub struct ContainerSummaryNetworkSettings {
     #[serde(rename = "Networks")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub networks: Option<HashMap<String, EndpointSettings>>,
-
 }
 
 /// OK response to ContainerTop operation
@@ -1365,11 +1343,10 @@ pub struct ContainerTopResponse {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub titles: Option<Vec<String>>,
 
-    /// Each process running in the container, where each is process is an array of values corresponding to the titles. 
+    /// Each process running in the container, where each is process is an array of values corresponding to the titles.
     #[serde(rename = "Processes")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub processes: Option<Vec<Vec<String>>>,
-
 }
 
 /// OK response to ContainerUpdate operation
@@ -1378,7 +1355,6 @@ pub struct ContainerUpdateResponse {
     #[serde(rename = "Warnings")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub warnings: Option<Vec<String>>,
-
 }
 
 /// container waiting error, if any
@@ -1388,7 +1364,6 @@ pub struct ContainerWaitExitError {
     #[serde(rename = "Message")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub message: Option<String>,
-
 }
 
 /// OK response to ContainerWait operation
@@ -1401,7 +1376,6 @@ pub struct ContainerWaitResponse {
     #[serde(rename = "Error")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub error: Option<ContainerWaitExitError>,
-
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
@@ -1429,7 +1403,6 @@ pub struct CreateImageInfo {
     #[serde(rename = "progressDetail")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub progress_detail: Option<ProgressDetail>,
-
 }
 
 /// A device mapping between the host and container
@@ -1446,7 +1419,6 @@ pub struct DeviceMapping {
     #[serde(rename = "CgroupPermissions")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cgroup_permissions: Option<String>,
-
 }
 
 /// A request for devices to be sent to device drivers
@@ -1464,29 +1436,27 @@ pub struct DeviceRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub device_ids: Option<Vec<String>>,
 
-    /// A list of capabilities; an OR list of AND lists of capabilities. 
+    /// A list of capabilities; an OR list of AND lists of capabilities.
     #[serde(rename = "Capabilities")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub capabilities: Option<Vec<Vec<String>>>,
 
-    /// Driver-specific options, specified as a key/value pairs. These options are passed directly to the driver. 
+    /// Driver-specific options, specified as a key/value pairs. These options are passed directly to the driver.
     #[serde(rename = "Options")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub options: Option<HashMap<String, String>>,
-
 }
 
-/// Describes the result obtained from contacting the registry to retrieve image metadata. 
+/// Describes the result obtained from contacting the registry to retrieve image metadata.
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 pub struct DistributionInspect {
     #[serde(rename = "Descriptor")]
     pub descriptor: OciDescriptor,
 
-    /// An array containing all platforms supported by the image. 
+    /// An array containing all platforms supported by the image.
     #[serde(rename = "Platforms")]
     #[serde(deserialize_with = "deserialize_nonoptional_vec")]
     pub platforms: Vec<OciPlatform>,
-
 }
 
 /// Driver represents a driver (network, logging, secrets).
@@ -1500,10 +1470,9 @@ pub struct Driver {
     #[serde(rename = "Options")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub options: Option<HashMap<String, String>>,
-
 }
 
-/// EndpointIPAMConfig represents an endpoint's IPAM configuration. 
+/// EndpointIPAMConfig represents an endpoint's IPAM configuration.
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 pub struct EndpointIpamConfig {
     #[serde(rename = "IPv4Address")]
@@ -1517,7 +1486,6 @@ pub struct EndpointIpamConfig {
     #[serde(rename = "LinkLocalIPs")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub link_local_ips: Option<Vec<String>>,
-
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
@@ -1540,16 +1508,15 @@ pub struct EndpointPortConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub published_port: Option<i64>,
 
-    /// The mode in which port is published.  <p><br /></p>  - \"ingress\" makes the target port accessible on every node,   regardless of whether there is a task for the service running on   that node or not. - \"host\" bypasses the routing mesh and publish the port directly on   the swarm node where that service is running. 
+    /// The mode in which port is published.  <p><br /></p>  - \"ingress\" makes the target port accessible on every node,   regardless of whether there is a task for the service running on   that node or not. - \"host\" bypasses the routing mesh and publish the port directly on   the swarm node where that service is running.
     #[serde(rename = "PublishMode")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub publish_mode: Option<EndpointPortConfigPublishModeEnum>,
-
 }
 
 #[allow(non_camel_case_types)]
 #[derive(Debug, Clone, Copy, PartialEq, PartialOrd, Serialize, Deserialize, Eq, Ord)]
-pub enum EndpointPortConfigProtocolEnum { 
+pub enum EndpointPortConfigProtocolEnum {
     #[serde(rename = "")]
     EMPTY,
     #[serde(rename = "tcp")]
@@ -1562,12 +1529,11 @@ pub enum EndpointPortConfigProtocolEnum {
 
 impl ::std::fmt::Display for EndpointPortConfigProtocolEnum {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        match *self { 
+        match *self {
             EndpointPortConfigProtocolEnum::EMPTY => write!(f, ""),
             EndpointPortConfigProtocolEnum::TCP => write!(f, "{}", "tcp"),
             EndpointPortConfigProtocolEnum::UDP => write!(f, "{}", "udp"),
             EndpointPortConfigProtocolEnum::SCTP => write!(f, "{}", "sctp"),
-
         }
     }
 }
@@ -1575,7 +1541,7 @@ impl ::std::fmt::Display for EndpointPortConfigProtocolEnum {
 impl ::std::str::FromStr for EndpointPortConfigProtocolEnum {
     type Err = String;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s { 
+        match s {
             "" => Ok(EndpointPortConfigProtocolEnum::EMPTY),
             "tcp" => Ok(EndpointPortConfigProtocolEnum::TCP),
             "udp" => Ok(EndpointPortConfigProtocolEnum::UDP),
@@ -1587,7 +1553,7 @@ impl ::std::str::FromStr for EndpointPortConfigProtocolEnum {
 
 impl ::std::convert::AsRef<str> for EndpointPortConfigProtocolEnum {
     fn as_ref(&self) -> &str {
-        match self { 
+        match self {
             EndpointPortConfigProtocolEnum::EMPTY => "",
             EndpointPortConfigProtocolEnum::TCP => "tcp",
             EndpointPortConfigProtocolEnum::UDP => "udp",
@@ -1598,7 +1564,7 @@ impl ::std::convert::AsRef<str> for EndpointPortConfigProtocolEnum {
 
 #[allow(non_camel_case_types)]
 #[derive(Debug, Clone, Copy, PartialEq, PartialOrd, Serialize, Deserialize, Eq, Ord)]
-pub enum EndpointPortConfigPublishModeEnum { 
+pub enum EndpointPortConfigPublishModeEnum {
     #[serde(rename = "")]
     EMPTY,
     #[serde(rename = "ingress")]
@@ -1609,11 +1575,10 @@ pub enum EndpointPortConfigPublishModeEnum {
 
 impl ::std::fmt::Display for EndpointPortConfigPublishModeEnum {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        match *self { 
+        match *self {
             EndpointPortConfigPublishModeEnum::EMPTY => write!(f, ""),
             EndpointPortConfigPublishModeEnum::INGRESS => write!(f, "{}", "ingress"),
             EndpointPortConfigPublishModeEnum::HOST => write!(f, "{}", "host"),
-
         }
     }
 }
@@ -1621,7 +1586,7 @@ impl ::std::fmt::Display for EndpointPortConfigPublishModeEnum {
 impl ::std::str::FromStr for EndpointPortConfigPublishModeEnum {
     type Err = String;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s { 
+        match s {
             "" => Ok(EndpointPortConfigPublishModeEnum::EMPTY),
             "ingress" => Ok(EndpointPortConfigPublishModeEnum::INGRESS),
             "host" => Ok(EndpointPortConfigPublishModeEnum::HOST),
@@ -1632,7 +1597,7 @@ impl ::std::str::FromStr for EndpointPortConfigPublishModeEnum {
 
 impl ::std::convert::AsRef<str> for EndpointPortConfigPublishModeEnum {
     fn as_ref(&self) -> &str {
-        match self { 
+        match self {
             EndpointPortConfigPublishModeEnum::EMPTY => "",
             EndpointPortConfigPublishModeEnum::INGRESS => "ingress",
             EndpointPortConfigPublishModeEnum::HOST => "host",
@@ -1655,76 +1620,74 @@ pub struct EndpointSettings {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub aliases: Option<Vec<String>>,
 
-    /// Unique ID of the network. 
+    /// Unique ID of the network.
     #[serde(rename = "NetworkID")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub network_id: Option<String>,
 
-    /// Unique ID for the service endpoint in a Sandbox. 
+    /// Unique ID for the service endpoint in a Sandbox.
     #[serde(rename = "EndpointID")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub endpoint_id: Option<String>,
 
-    /// Gateway address for this network. 
+    /// Gateway address for this network.
     #[serde(rename = "Gateway")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub gateway: Option<String>,
 
-    /// IPv4 address. 
+    /// IPv4 address.
     #[serde(rename = "IPAddress")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub ip_address: Option<String>,
 
-    /// Mask length of the IPv4 address. 
+    /// Mask length of the IPv4 address.
     #[serde(rename = "IPPrefixLen")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub ip_prefix_len: Option<i64>,
 
-    /// IPv6 gateway address. 
+    /// IPv6 gateway address.
     #[serde(rename = "IPv6Gateway")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub ipv6_gateway: Option<String>,
 
-    /// Global IPv6 address. 
+    /// Global IPv6 address.
     #[serde(rename = "GlobalIPv6Address")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub global_ipv6_address: Option<String>,
 
-    /// Mask length of the global IPv6 address. 
+    /// Mask length of the global IPv6 address.
     #[serde(rename = "GlobalIPv6PrefixLen")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub global_ipv6_prefix_len: Option<i64>,
 
-    /// MAC address for the endpoint on this network. 
+    /// MAC address for the endpoint on this network.
     #[serde(rename = "MacAddress")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub mac_address: Option<String>,
 
-    /// DriverOpts is a mapping of driver options and values. These options are passed directly to the driver and are driver specific. 
+    /// DriverOpts is a mapping of driver options and values. These options are passed directly to the driver and are driver specific.
     #[serde(rename = "DriverOpts")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub driver_opts: Option<HashMap<String, String>>,
-
 }
 
 /// Properties that can be configured to access and load balance a service.
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 pub struct EndpointSpec {
-    /// The mode of resolution to use for internal load balancing between tasks. 
+    /// The mode of resolution to use for internal load balancing between tasks.
     #[serde(rename = "Mode")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub mode: Option<EndpointSpecModeEnum>,
 
-    /// List of exposed ports that this service is accessible on from the outside. Ports can only be provided if `vip` resolution mode is used. 
+    /// List of exposed ports that this service is accessible on from the outside. Ports can only be provided if `vip` resolution mode is used.
     #[serde(rename = "Ports")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub ports: Option<Vec<EndpointPortConfig>>,
-
 }
 
 #[allow(non_camel_case_types)]
 #[derive(Debug, Clone, Copy, PartialEq, PartialOrd, Serialize, Deserialize, Eq, Ord)]
-pub enum EndpointSpecModeEnum { 
+pub enum EndpointSpecModeEnum {
     #[serde(rename = "")]
     EMPTY,
     #[serde(rename = "vip")]
@@ -1735,11 +1698,10 @@ pub enum EndpointSpecModeEnum {
 
 impl ::std::fmt::Display for EndpointSpecModeEnum {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        match *self { 
+        match *self {
             EndpointSpecModeEnum::EMPTY => write!(f, ""),
             EndpointSpecModeEnum::VIP => write!(f, "{}", "vip"),
             EndpointSpecModeEnum::DNSRR => write!(f, "{}", "dnsrr"),
-
         }
     }
 }
@@ -1747,7 +1709,7 @@ impl ::std::fmt::Display for EndpointSpecModeEnum {
 impl ::std::str::FromStr for EndpointSpecModeEnum {
     type Err = String;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s { 
+        match s {
             "" => Ok(EndpointSpecModeEnum::EMPTY),
             "vip" => Ok(EndpointSpecModeEnum::VIP),
             "dnsrr" => Ok(EndpointSpecModeEnum::DNSRR),
@@ -1758,7 +1720,7 @@ impl ::std::str::FromStr for EndpointSpecModeEnum {
 
 impl ::std::convert::AsRef<str> for EndpointSpecModeEnum {
     fn as_ref(&self) -> &str {
-        match self { 
+        match self {
             EndpointSpecModeEnum::EMPTY => "",
             EndpointSpecModeEnum::VIP => "vip",
             EndpointSpecModeEnum::DNSRR => "dnsrr",
@@ -1780,7 +1742,6 @@ pub struct EngineDescription {
     #[serde(rename = "Plugins")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub plugins: Option<Vec<EngineDescriptionPlugins>>,
-
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
@@ -1792,7 +1753,6 @@ pub struct EngineDescriptionPlugins {
     #[serde(rename = "Name")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
-
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
@@ -1804,7 +1764,6 @@ pub struct ErrorDetail {
     #[serde(rename = "message")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub message: Option<String>,
-
 }
 
 /// Represents an error.
@@ -1813,10 +1772,9 @@ pub struct ErrorResponse {
     /// The error message.
     #[serde(rename = "message")]
     pub message: String,
-
 }
 
-/// Actor describes something that generates events, like a container, network, or a volume. 
+/// Actor describes something that generates events, like a container, network, or a volume.
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 pub struct EventActor {
     /// The ID of the object emitting the event
@@ -1824,14 +1782,13 @@ pub struct EventActor {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub id: Option<String>,
 
-    /// Various key/value attributes of the object, depending on its type. 
+    /// Various key/value attributes of the object, depending on its type.
     #[serde(rename = "Attributes")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub attributes: Option<HashMap<String, String>>,
-
 }
 
-/// EventMessage represents the information an event contains. 
+/// EventMessage represents the information an event contains.
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 pub struct EventMessage {
     /// The type of object emitting the event
@@ -1848,7 +1805,7 @@ pub struct EventMessage {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub actor: Option<EventActor>,
 
-    /// Scope of the event. Engine events are `local` scope. Cluster (Swarm) events are `swarm` scope. 
+    /// Scope of the event. Engine events are `local` scope. Cluster (Swarm) events are `swarm` scope.
     #[serde(rename = "scope")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub scope: Option<EventMessageScopeEnum>,
@@ -1862,12 +1819,11 @@ pub struct EventMessage {
     #[serde(rename = "timeNano")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub time_nano: Option<i64>,
-
 }
 
 #[allow(non_camel_case_types)]
 #[derive(Debug, Clone, Copy, PartialEq, PartialOrd, Serialize, Deserialize, Eq, Ord)]
-pub enum EventMessageTypeEnum { 
+pub enum EventMessageTypeEnum {
     #[serde(rename = "")]
     EMPTY,
     #[serde(rename = "builder")]
@@ -1896,7 +1852,7 @@ pub enum EventMessageTypeEnum {
 
 impl ::std::fmt::Display for EventMessageTypeEnum {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        match *self { 
+        match *self {
             EventMessageTypeEnum::EMPTY => write!(f, ""),
             EventMessageTypeEnum::BUILDER => write!(f, "{}", "builder"),
             EventMessageTypeEnum::CONFIG => write!(f, "{}", "config"),
@@ -1909,7 +1865,6 @@ impl ::std::fmt::Display for EventMessageTypeEnum {
             EventMessageTypeEnum::SECRET => write!(f, "{}", "secret"),
             EventMessageTypeEnum::SERVICE => write!(f, "{}", "service"),
             EventMessageTypeEnum::VOLUME => write!(f, "{}", "volume"),
-
         }
     }
 }
@@ -1917,7 +1872,7 @@ impl ::std::fmt::Display for EventMessageTypeEnum {
 impl ::std::str::FromStr for EventMessageTypeEnum {
     type Err = String;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s { 
+        match s {
             "" => Ok(EventMessageTypeEnum::EMPTY),
             "builder" => Ok(EventMessageTypeEnum::BUILDER),
             "config" => Ok(EventMessageTypeEnum::CONFIG),
@@ -1937,7 +1892,7 @@ impl ::std::str::FromStr for EventMessageTypeEnum {
 
 impl ::std::convert::AsRef<str> for EventMessageTypeEnum {
     fn as_ref(&self) -> &str {
-        match self { 
+        match self {
             EventMessageTypeEnum::EMPTY => "",
             EventMessageTypeEnum::BUILDER => "builder",
             EventMessageTypeEnum::CONFIG => "config",
@@ -1956,7 +1911,7 @@ impl ::std::convert::AsRef<str> for EventMessageTypeEnum {
 
 #[allow(non_camel_case_types)]
 #[derive(Debug, Clone, Copy, PartialEq, PartialOrd, Serialize, Deserialize, Eq, Ord)]
-pub enum EventMessageScopeEnum { 
+pub enum EventMessageScopeEnum {
     #[serde(rename = "")]
     EMPTY,
     #[serde(rename = "local")]
@@ -1967,11 +1922,10 @@ pub enum EventMessageScopeEnum {
 
 impl ::std::fmt::Display for EventMessageScopeEnum {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        match *self { 
+        match *self {
             EventMessageScopeEnum::EMPTY => write!(f, ""),
             EventMessageScopeEnum::LOCAL => write!(f, "{}", "local"),
             EventMessageScopeEnum::SWARM => write!(f, "{}", "swarm"),
-
         }
     }
 }
@@ -1979,7 +1933,7 @@ impl ::std::fmt::Display for EventMessageScopeEnum {
 impl ::std::str::FromStr for EventMessageScopeEnum {
     type Err = String;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s { 
+        match s {
             "" => Ok(EventMessageScopeEnum::EMPTY),
             "local" => Ok(EventMessageScopeEnum::LOCAL),
             "swarm" => Ok(EventMessageScopeEnum::SWARM),
@@ -1990,7 +1944,7 @@ impl ::std::str::FromStr for EventMessageScopeEnum {
 
 impl ::std::convert::AsRef<str> for EventMessageScopeEnum {
     fn as_ref(&self) -> &str {
-        match self { 
+        match self {
             EventMessageScopeEnum::EMPTY => "",
             EventMessageScopeEnum::LOCAL => "local",
             EventMessageScopeEnum::SWARM => "swarm",
@@ -2020,7 +1974,7 @@ pub struct ExecConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub console_size: Option<Vec<i32>>,
 
-    /// Override the key sequence for detaching a container. Format is a single character `[a-Z]` or `ctrl-<value>` where `<value>` is one of: `a-z`, `@`, `^`, `[`, `,` or `_`. 
+    /// Override the key sequence for detaching a container. Format is a single character `[a-Z]` or `ctrl-<value>` where `<value>` is one of: `a-z`, `@`, `^`, `[`, `,` or `_`.
     #[serde(rename = "DetachKeys")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub detach_keys: Option<String>,
@@ -2030,7 +1984,7 @@ pub struct ExecConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub tty: Option<bool>,
 
-    /// A list of environment variables in the form `[\"VAR=value\", ...]`. 
+    /// A list of environment variables in the form `[\"VAR=value\", ...]`.
     #[serde(rename = "Env")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub env: Option<Vec<String>>,
@@ -2045,16 +1999,15 @@ pub struct ExecConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub privileged: Option<bool>,
 
-    /// The user, and optionally, group to run the exec process inside the container. Format is one of: `user`, `user:group`, `uid`, or `uid:gid`. 
+    /// The user, and optionally, group to run the exec process inside the container. Format is one of: `user`, `user:group`, `uid`, or `uid:gid`.
     #[serde(rename = "User")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub user: Option<String>,
 
-    /// The working directory for the exec process inside the container. 
+    /// The working directory for the exec process inside the container.
     #[serde(rename = "WorkingDir")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub working_dir: Option<String>,
-
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
@@ -2103,7 +2056,6 @@ pub struct ExecInspectResponse {
     #[serde(rename = "Pid")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub pid: Option<i64>,
-
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
@@ -2122,10 +2074,9 @@ pub struct ExecStartConfig {
     #[serde(rename = "ConsoleSize")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub console_size: Option<Vec<i32>>,
-
 }
 
-/// User-defined resources can be either Integer resources (e.g, `SSD=3`) or String resources (e.g, `GPU=UUID1`). 
+/// User-defined resources can be either Integer resources (e.g, `SSD=3`) or String resources (e.g, `GPU=UUID1`).
 
 pub type GenericResources = GenericResourcesInner;
 
@@ -2138,7 +2089,6 @@ pub struct GenericResourcesInner {
     #[serde(rename = "DiscreteResourceSpec")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub discrete_resource_spec: Option<GenericResourcesInnerDiscreteResourceSpec>,
-
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
@@ -2150,7 +2100,6 @@ pub struct GenericResourcesInnerDiscreteResourceSpec {
     #[serde(rename = "Value")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub value: Option<i64>,
-
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
@@ -2162,27 +2111,25 @@ pub struct GenericResourcesInnerNamedResourceSpec {
     #[serde(rename = "Value")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub value: Option<String>,
-
 }
 
-/// Information about the storage driver used to store the container's and image's filesystem. 
+/// Information about the storage driver used to store the container's and image's filesystem.
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 pub struct GraphDriverData {
     /// Name of the storage driver.
     #[serde(rename = "Name")]
     pub name: String,
 
-    /// Low-level storage metadata, provided as key/value pairs.  This information is driver-specific, and depends on the storage-driver in use, and should be used for informational purposes only. 
+    /// Low-level storage metadata, provided as key/value pairs.  This information is driver-specific, and depends on the storage-driver in use, and should be used for informational purposes only.
     #[serde(rename = "Data")]
     #[serde(deserialize_with = "deserialize_nonoptional_map")]
     pub data: HashMap<String, String>,
-
 }
 
-/// Health stores information about the container's healthcheck results. 
+/// Health stores information about the container's healthcheck results.
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 pub struct Health {
-    /// Status is one of `none`, `starting`, `healthy` or `unhealthy`  - \"none\"      Indicates there is no healthcheck - \"starting\"  Starting indicates that the container is not yet ready - \"healthy\"   Healthy indicates that the container is running correctly - \"unhealthy\" Unhealthy indicates that the container has a problem 
+    /// Status is one of `none`, `starting`, `healthy` or `unhealthy`  - \"none\"      Indicates there is no healthcheck - \"starting\"  Starting indicates that the container is not yet ready - \"healthy\"   Healthy indicates that the container is running correctly - \"unhealthy\" Unhealthy indicates that the container has a problem
     #[serde(rename = "Status")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub status: Option<HealthStatusEnum>,
@@ -2192,16 +2139,15 @@ pub struct Health {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub failing_streak: Option<i64>,
 
-    /// Log contains the last few results (oldest first) 
+    /// Log contains the last few results (oldest first)
     #[serde(rename = "Log")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub log: Option<Vec<HealthcheckResult>>,
-
 }
 
 #[allow(non_camel_case_types)]
 #[derive(Debug, Clone, Copy, PartialEq, PartialOrd, Serialize, Deserialize, Eq, Ord)]
-pub enum HealthStatusEnum { 
+pub enum HealthStatusEnum {
     #[serde(rename = "")]
     EMPTY,
     #[serde(rename = "none")]
@@ -2216,13 +2162,12 @@ pub enum HealthStatusEnum {
 
 impl ::std::fmt::Display for HealthStatusEnum {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        match *self { 
+        match *self {
             HealthStatusEnum::EMPTY => write!(f, ""),
             HealthStatusEnum::NONE => write!(f, "{}", "none"),
             HealthStatusEnum::STARTING => write!(f, "{}", "starting"),
             HealthStatusEnum::HEALTHY => write!(f, "{}", "healthy"),
             HealthStatusEnum::UNHEALTHY => write!(f, "{}", "unhealthy"),
-
         }
     }
 }
@@ -2230,7 +2175,7 @@ impl ::std::fmt::Display for HealthStatusEnum {
 impl ::std::str::FromStr for HealthStatusEnum {
     type Err = String;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s { 
+        match s {
             "" => Ok(HealthStatusEnum::EMPTY),
             "none" => Ok(HealthStatusEnum::NONE),
             "starting" => Ok(HealthStatusEnum::STARTING),
@@ -2243,7 +2188,7 @@ impl ::std::str::FromStr for HealthStatusEnum {
 
 impl ::std::convert::AsRef<str> for HealthStatusEnum {
     fn as_ref(&self) -> &str {
-        match self { 
+        match self {
             HealthStatusEnum::EMPTY => "",
             HealthStatusEnum::NONE => "none",
             HealthStatusEnum::STARTING => "starting",
@@ -2256,37 +2201,36 @@ impl ::std::convert::AsRef<str> for HealthStatusEnum {
 /// A test to perform to check that the container is healthy.
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 pub struct HealthConfig {
-    /// The test to perform. Possible values are:  - `[]` inherit healthcheck from image or parent image - `[\"NONE\"]` disable healthcheck - `[\"CMD\", args...]` exec arguments directly - `[\"CMD-SHELL\", command]` run command with system's default shell 
+    /// The test to perform. Possible values are:  - `[]` inherit healthcheck from image or parent image - `[\"NONE\"]` disable healthcheck - `[\"CMD\", args...]` exec arguments directly - `[\"CMD-SHELL\", command]` run command with system's default shell
     #[serde(rename = "Test")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub test: Option<Vec<String>>,
 
-    /// The time to wait between checks in nanoseconds. It should be 0 or at least 1000000 (1 ms). 0 means inherit. 
+    /// The time to wait between checks in nanoseconds. It should be 0 or at least 1000000 (1 ms). 0 means inherit.
     #[serde(rename = "Interval")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub interval: Option<i64>,
 
-    /// The time to wait before considering the check to have hung. It should be 0 or at least 1000000 (1 ms). 0 means inherit. 
+    /// The time to wait before considering the check to have hung. It should be 0 or at least 1000000 (1 ms). 0 means inherit.
     #[serde(rename = "Timeout")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub timeout: Option<i64>,
 
-    /// The number of consecutive failures needed to consider a container as unhealthy. 0 means inherit. 
+    /// The number of consecutive failures needed to consider a container as unhealthy. 0 means inherit.
     #[serde(rename = "Retries")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub retries: Option<i64>,
 
-    /// Start period for the container to initialize before starting health-retries countdown in nanoseconds. It should be 0 or at least 1000000 (1 ms). 0 means inherit. 
+    /// Start period for the container to initialize before starting health-retries countdown in nanoseconds. It should be 0 or at least 1000000 (1 ms). 0 means inherit.
     #[serde(rename = "StartPeriod")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub start_period: Option<i64>,
-
 }
 
-/// HealthcheckResult stores information about a single run of a healthcheck probe 
+/// HealthcheckResult stores information about a single run of a healthcheck probe
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 pub struct HealthcheckResult {
-    /// Date and time at which this check started in [RFC 3339](https://www.ietf.org/rfc/rfc3339.txt) format with nano-seconds. 
+    /// Date and time at which this check started in [RFC 3339](https://www.ietf.org/rfc/rfc3339.txt) format with nano-seconds.
     #[serde(rename = "Start")]
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(
@@ -2296,7 +2240,7 @@ pub struct HealthcheckResult {
     )]
     pub start: Option<BollardDate>,
 
-    /// Date and time at which this check ended in [RFC 3339](https://www.ietf.org/rfc/rfc3339.txt) format with nano-seconds. 
+    /// Date and time at which this check ended in [RFC 3339](https://www.ietf.org/rfc/rfc3339.txt) format with nano-seconds.
     #[serde(rename = "End")]
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(
@@ -2306,7 +2250,7 @@ pub struct HealthcheckResult {
     )]
     pub end: Option<BollardDate>,
 
-    /// ExitCode meanings:  - `0` healthy - `1` unhealthy - `2` reserved (considered unhealthy) - other values: error running probe 
+    /// ExitCode meanings:  - `0` healthy - `1` unhealthy - `2` reserved (considered unhealthy) - other values: error running probe
     #[serde(rename = "ExitCode")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub exit_code: Option<i64>,
@@ -2315,7 +2259,6 @@ pub struct HealthcheckResult {
     #[serde(rename = "Output")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub output: Option<String>,
-
 }
 
 /// individual image layer information in response to ImageHistory operation
@@ -2339,13 +2282,12 @@ pub struct HistoryResponseItem {
 
     #[serde(rename = "Comment")]
     pub comment: String,
-
 }
 
 /// Container configuration that depends on the host we are running on
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 pub struct HostConfig {
-    /// An integer value representing this container's relative CPU weight versus other containers. 
+    /// An integer value representing this container's relative CPU weight versus other containers.
     #[serde(rename = "CpuShares")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cpu_shares: Option<i64>,
@@ -2355,7 +2297,7 @@ pub struct HostConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub memory: Option<i64>,
 
-    /// Path to `cgroups` under which the container's `cgroup` is created. If the path is not absolute, the path is considered to be relative to the `cgroups` path of the init process. Cgroups are created if they do not already exist. 
+    /// Path to `cgroups` under which the container's `cgroup` is created. If the path is not absolute, the path is considered to be relative to the `cgroups` path of the init process. Cgroups are created if they do not already exist.
     #[serde(rename = "CgroupParent")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cgroup_parent: Option<String>,
@@ -2365,27 +2307,27 @@ pub struct HostConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub blkio_weight: Option<u16>,
 
-    /// Block IO weight (relative device weight) in the form:  ``` [{\"Path\": \"device_path\", \"Weight\": weight}] ``` 
+    /// Block IO weight (relative device weight) in the form:  ``` [{\"Path\": \"device_path\", \"Weight\": weight}] ```
     #[serde(rename = "BlkioWeightDevice")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub blkio_weight_device: Option<Vec<ResourcesBlkioWeightDevice>>,
 
-    /// Limit read rate (bytes per second) from a device, in the form:  ``` [{\"Path\": \"device_path\", \"Rate\": rate}] ``` 
+    /// Limit read rate (bytes per second) from a device, in the form:  ``` [{\"Path\": \"device_path\", \"Rate\": rate}] ```
     #[serde(rename = "BlkioDeviceReadBps")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub blkio_device_read_bps: Option<Vec<ThrottleDevice>>,
 
-    /// Limit write rate (bytes per second) to a device, in the form:  ``` [{\"Path\": \"device_path\", \"Rate\": rate}] ``` 
+    /// Limit write rate (bytes per second) to a device, in the form:  ``` [{\"Path\": \"device_path\", \"Rate\": rate}] ```
     #[serde(rename = "BlkioDeviceWriteBps")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub blkio_device_write_bps: Option<Vec<ThrottleDevice>>,
 
-    /// Limit read rate (IO per second) from a device, in the form:  ``` [{\"Path\": \"device_path\", \"Rate\": rate}] ``` 
+    /// Limit read rate (IO per second) from a device, in the form:  ``` [{\"Path\": \"device_path\", \"Rate\": rate}] ```
     #[serde(rename = "BlkioDeviceReadIOps")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub blkio_device_read_iops: Option<Vec<ThrottleDevice>>,
 
-    /// Limit write rate (IO per second) to a device, in the form:  ``` [{\"Path\": \"device_path\", \"Rate\": rate}] ``` 
+    /// Limit write rate (IO per second) to a device, in the form:  ``` [{\"Path\": \"device_path\", \"Rate\": rate}] ```
     #[serde(rename = "BlkioDeviceWriteIOps")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub blkio_device_write_iops: Option<Vec<ThrottleDevice>>,
@@ -2395,27 +2337,27 @@ pub struct HostConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cpu_period: Option<i64>,
 
-    /// Microseconds of CPU time that the container can get in a CPU period. 
+    /// Microseconds of CPU time that the container can get in a CPU period.
     #[serde(rename = "CpuQuota")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cpu_quota: Option<i64>,
 
-    /// The length of a CPU real-time period in microseconds. Set to 0 to allocate no time allocated to real-time tasks. 
+    /// The length of a CPU real-time period in microseconds. Set to 0 to allocate no time allocated to real-time tasks.
     #[serde(rename = "CpuRealtimePeriod")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cpu_realtime_period: Option<i64>,
 
-    /// The length of a CPU real-time runtime in microseconds. Set to 0 to allocate no time allocated to real-time tasks. 
+    /// The length of a CPU real-time runtime in microseconds. Set to 0 to allocate no time allocated to real-time tasks.
     #[serde(rename = "CpuRealtimeRuntime")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cpu_realtime_runtime: Option<i64>,
 
-    /// CPUs in which to allow execution (e.g., `0-3`, `0,1`). 
+    /// CPUs in which to allow execution (e.g., `0-3`, `0,1`).
     #[serde(rename = "CpusetCpus")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cpuset_cpus: Option<String>,
 
-    /// Memory nodes (MEMs) in which to allow execution (0-3, 0,1). Only effective on NUMA systems. 
+    /// Memory nodes (MEMs) in which to allow execution (0-3, 0,1). Only effective on NUMA systems.
     #[serde(rename = "CpusetMems")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cpuset_mems: Option<String>,
@@ -2430,12 +2372,12 @@ pub struct HostConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub device_cgroup_rules: Option<Vec<String>>,
 
-    /// A list of requests for devices to be sent to device drivers. 
+    /// A list of requests for devices to be sent to device drivers.
     #[serde(rename = "DeviceRequests")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub device_requests: Option<Vec<DeviceRequest>>,
 
-    /// Hard limit for kernel TCP buffer memory (in bytes). Depending on the OCI runtime in use, this option may be ignored. It is no longer supported by the default (runc) runtime.  This field is omitted when empty. 
+    /// Hard limit for kernel TCP buffer memory (in bytes). Depending on the OCI runtime in use, this option may be ignored. It is no longer supported by the default (runc) runtime.  This field is omitted when empty.
     #[serde(rename = "KernelMemoryTCP")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub kernel_memory_tcp: Option<i64>,
@@ -2445,12 +2387,12 @@ pub struct HostConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub memory_reservation: Option<i64>,
 
-    /// Total memory limit (memory + swap). Set as `-1` to enable unlimited swap. 
+    /// Total memory limit (memory + swap). Set as `-1` to enable unlimited swap.
     #[serde(rename = "MemorySwap")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub memory_swap: Option<i64>,
 
-    /// Tune a container's memory swappiness behavior. Accepts an integer between 0 and 100. 
+    /// Tune a container's memory swappiness behavior. Accepts an integer between 0 and 100.
     #[serde(rename = "MemorySwappiness")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub memory_swappiness: Option<i64>,
@@ -2465,27 +2407,27 @@ pub struct HostConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub oom_kill_disable: Option<bool>,
 
-    /// Run an init inside the container that forwards signals and reaps processes. This field is omitted if empty, and the default (as configured on the daemon) is used. 
+    /// Run an init inside the container that forwards signals and reaps processes. This field is omitted if empty, and the default (as configured on the daemon) is used.
     #[serde(rename = "Init")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub init: Option<bool>,
 
-    /// Tune a container's PIDs limit. Set `0` or `-1` for unlimited, or `null` to not change. 
+    /// Tune a container's PIDs limit. Set `0` or `-1` for unlimited, or `null` to not change.
     #[serde(rename = "PidsLimit")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub pids_limit: Option<i64>,
 
-    /// A list of resource limits to set in the container. For example:  ``` {\"Name\": \"nofile\", \"Soft\": 1024, \"Hard\": 2048} ``` 
+    /// A list of resource limits to set in the container. For example:  ``` {\"Name\": \"nofile\", \"Soft\": 1024, \"Hard\": 2048} ```
     #[serde(rename = "Ulimits")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub ulimits: Option<Vec<ResourcesUlimits>>,
 
-    /// The number of usable CPUs (Windows only).  On Windows Server containers, the processor resource controls are mutually exclusive. The order of precedence is `CPUCount` first, then `CPUShares`, and `CPUPercent` last. 
+    /// The number of usable CPUs (Windows only).  On Windows Server containers, the processor resource controls are mutually exclusive. The order of precedence is `CPUCount` first, then `CPUShares`, and `CPUPercent` last.
     #[serde(rename = "CpuCount")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cpu_count: Option<i64>,
 
-    /// The usable percentage of the available CPUs (Windows only).  On Windows Server containers, the processor resource controls are mutually exclusive. The order of precedence is `CPUCount` first, then `CPUShares`, and `CPUPercent` last. 
+    /// The usable percentage of the available CPUs (Windows only).  On Windows Server containers, the processor resource controls are mutually exclusive. The order of precedence is `CPUCount` first, then `CPUShares`, and `CPUPercent` last.
     #[serde(rename = "CpuPercent")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cpu_percent: Option<i64>,
@@ -2495,12 +2437,12 @@ pub struct HostConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub io_maximum_iops: Option<i64>,
 
-    /// Maximum IO in bytes per second for the container system drive (Windows only). 
+    /// Maximum IO in bytes per second for the container system drive (Windows only).
     #[serde(rename = "IOMaximumBandwidth")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub io_maximum_bandwidth: Option<i64>,
 
-    /// A list of volume bindings for this container. Each volume binding is a string in one of these forms:  - `host-src:container-dest[:options]` to bind-mount a host path   into the container. Both `host-src`, and `container-dest` must   be an _absolute_ path. - `volume-name:container-dest[:options]` to bind-mount a volume   managed by a volume driver into the container. `container-dest`   must be an _absolute_ path.  `options` is an optional, comma-delimited list of:  - `nocopy` disables automatic copying of data from the container   path to the volume. The `nocopy` flag only applies to named volumes. - `[ro|rw]` mounts a volume read-only or read-write, respectively.   If omitted or set to `rw`, volumes are mounted read-write. - `[z|Z]` applies SELinux labels to allow or deny multiple containers   to read and write to the same volume.     - `z`: a _shared_ content label is applied to the content. This       label indicates that multiple containers can share the volume       content, for both reading and writing.     - `Z`: a _private unshared_ label is applied to the content.       This label indicates that only the current container can use       a private volume. Labeling systems such as SELinux require       proper labels to be placed on volume content that is mounted       into a container. Without a label, the security system can       prevent a container's processes from using the content. By       default, the labels set by the host operating system are not       modified. - `[[r]shared|[r]slave|[r]private]` specifies mount   [propagation behavior](https://www.kernel.org/doc/Documentation/filesystems/sharedsubtree.txt).   This only applies to bind-mounted volumes, not internal volumes   or named volumes. Mount propagation requires the source mount   point (the location where the source directory is mounted in the   host operating system) to have the correct propagation properties.   For shared volumes, the source mount point must be set to `shared`.   For slave volumes, the mount must be set to either `shared` or   `slave`. 
+    /// A list of volume bindings for this container. Each volume binding is a string in one of these forms:  - `host-src:container-dest[:options]` to bind-mount a host path   into the container. Both `host-src`, and `container-dest` must   be an _absolute_ path. - `volume-name:container-dest[:options]` to bind-mount a volume   managed by a volume driver into the container. `container-dest`   must be an _absolute_ path.  `options` is an optional, comma-delimited list of:  - `nocopy` disables automatic copying of data from the container   path to the volume. The `nocopy` flag only applies to named volumes. - `[ro|rw]` mounts a volume read-only or read-write, respectively.   If omitted or set to `rw`, volumes are mounted read-write. - `[z|Z]` applies SELinux labels to allow or deny multiple containers   to read and write to the same volume.     - `z`: a _shared_ content label is applied to the content. This       label indicates that multiple containers can share the volume       content, for both reading and writing.     - `Z`: a _private unshared_ label is applied to the content.       This label indicates that only the current container can use       a private volume. Labeling systems such as SELinux require       proper labels to be placed on volume content that is mounted       into a container. Without a label, the security system can       prevent a container's processes from using the content. By       default, the labels set by the host operating system are not       modified. - `[[r]shared|[r]slave|[r]private]` specifies mount   [propagation behavior](https://www.kernel.org/doc/Documentation/filesystems/sharedsubtree.txt).   This only applies to bind-mounted volumes, not internal volumes   or named volumes. Mount propagation requires the source mount   point (the location where the source directory is mounted in the   host operating system) to have the correct propagation properties.   For shared volumes, the source mount point must be set to `shared`.   For slave volumes, the mount must be set to either `shared` or   `slave`.
     #[serde(rename = "Binds")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub binds: Option<Vec<String>>,
@@ -2514,7 +2456,7 @@ pub struct HostConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub log_config: Option<HostConfigLogConfig>,
 
-    /// Network mode to use for this container. Supported standard values are: `bridge`, `host`, `none`, and `container:<name|id>`. Any other value is taken as a custom network's name to which this container should connect to. 
+    /// Network mode to use for this container. Supported standard values are: `bridge`, `host`, `none`, and `container:<name|id>`. Any other value is taken as a custom network's name to which this container should connect to.
     #[serde(rename = "NetworkMode")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub network_mode: Option<String>,
@@ -2527,7 +2469,7 @@ pub struct HostConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub restart_policy: Option<RestartPolicy>,
 
-    /// Automatically remove the container when the container's process exits. This has no effect if `RestartPolicy` is set. 
+    /// Automatically remove the container when the container's process exits. This has no effect if `RestartPolicy` is set.
     #[serde(rename = "AutoRemove")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub auto_remove: Option<bool>,
@@ -2537,32 +2479,32 @@ pub struct HostConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub volume_driver: Option<String>,
 
-    /// A list of volumes to inherit from another container, specified in the form `<container name>[:<ro|rw>]`. 
+    /// A list of volumes to inherit from another container, specified in the form `<container name>[:<ro|rw>]`.
     #[serde(rename = "VolumesFrom")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub volumes_from: Option<Vec<String>>,
 
-    /// Specification for mounts to be added to the container. 
+    /// Specification for mounts to be added to the container.
     #[serde(rename = "Mounts")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub mounts: Option<Vec<Mount>>,
 
-    /// Initial console size, as an `[height, width]` array. 
+    /// Initial console size, as an `[height, width]` array.
     #[serde(rename = "ConsoleSize")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub console_size: Option<Vec<i32>>,
 
-    /// A list of kernel capabilities to add to the container. Conflicts with option 'Capabilities'. 
+    /// A list of kernel capabilities to add to the container. Conflicts with option 'Capabilities'.
     #[serde(rename = "CapAdd")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cap_add: Option<Vec<String>>,
 
-    /// A list of kernel capabilities to drop from the container. Conflicts with option 'Capabilities'. 
+    /// A list of kernel capabilities to drop from the container. Conflicts with option 'Capabilities'.
     #[serde(rename = "CapDrop")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cap_drop: Option<Vec<String>>,
 
-    /// cgroup namespace mode for the container. Possible values are:  - `\"private\"`: the container runs in its own private cgroup namespace - `\"host\"`: use the host system's cgroup namespace  If not specified, the daemon default is used, which can either be `\"private\"` or `\"host\"`, depending on daemon version, kernel support and configuration. 
+    /// cgroup namespace mode for the container. Possible values are:  - `\"private\"`: the container runs in its own private cgroup namespace - `\"host\"`: use the host system's cgroup namespace  If not specified, the daemon default is used, which can either be `\"private\"` or `\"host\"`, depending on daemon version, kernel support and configuration.
     #[serde(rename = "CgroupnsMode")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cgroupns_mode: Option<HostConfigCgroupnsModeEnum>,
@@ -2582,17 +2524,17 @@ pub struct HostConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub dns_search: Option<Vec<String>>,
 
-    /// A list of hostnames/IP mappings to add to the container's `/etc/hosts` file. Specified in the form `[\"hostname:IP\"]`. 
+    /// A list of hostnames/IP mappings to add to the container's `/etc/hosts` file. Specified in the form `[\"hostname:IP\"]`.
     #[serde(rename = "ExtraHosts")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub extra_hosts: Option<Vec<String>>,
 
-    /// A list of additional groups that the container process will run as. 
+    /// A list of additional groups that the container process will run as.
     #[serde(rename = "GroupAdd")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub group_add: Option<Vec<String>>,
 
-    /// IPC sharing mode for the container. Possible values are:  - `\"none\"`: own private IPC namespace, with /dev/shm not mounted - `\"private\"`: own private IPC namespace - `\"shareable\"`: own private IPC namespace, with a possibility to share it with other containers - `\"container:<name|id>\"`: join another (shareable) container's IPC namespace - `\"host\"`: use the host system's IPC namespace  If not specified, daemon default is used, which can either be `\"private\"` or `\"shareable\"`, depending on daemon version and configuration. 
+    /// IPC sharing mode for the container. Possible values are:  - `\"none\"`: own private IPC namespace, with /dev/shm not mounted - `\"private\"`: own private IPC namespace - `\"shareable\"`: own private IPC namespace, with a possibility to share it with other containers - `\"container:<name|id>\"`: join another (shareable) container's IPC namespace - `\"host\"`: use the host system's IPC namespace  If not specified, daemon default is used, which can either be `\"private\"` or `\"shareable\"`, depending on daemon version and configuration.
     #[serde(rename = "IpcMode")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub ipc_mode: Option<String>,
@@ -2602,17 +2544,17 @@ pub struct HostConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cgroup: Option<String>,
 
-    /// A list of links for the container in the form `container_name:alias`. 
+    /// A list of links for the container in the form `container_name:alias`.
     #[serde(rename = "Links")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub links: Option<Vec<String>>,
 
-    /// An integer value containing the score given to the container in order to tune OOM killer preferences. 
+    /// An integer value containing the score given to the container in order to tune OOM killer preferences.
     #[serde(rename = "OomScoreAdj")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub oom_score_adj: Option<i64>,
 
-    /// Set the PID (Process) Namespace mode for the container. It can be either:  - `\"container:<name|id>\"`: joins another container's PID namespace - `\"host\"`: use the host's PID namespace inside the container 
+    /// Set the PID (Process) Namespace mode for the container. It can be either:  - `\"container:<name|id>\"`: joins another container's PID namespace - `\"host\"`: use the host's PID namespace inside the container
     #[serde(rename = "PidMode")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub pid_mode: Option<String>,
@@ -2622,7 +2564,7 @@ pub struct HostConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub privileged: Option<bool>,
 
-    /// Allocates an ephemeral host port for all of a container's exposed ports.  Ports are de-allocated when the container stops and allocated when the container starts. The allocated port might be changed when restarting the container.  The port is selected from the ephemeral port range that depends on the kernel. For example, on Linux the range is defined by `/proc/sys/net/ipv4/ip_local_port_range`. 
+    /// Allocates an ephemeral host port for all of a container's exposed ports.  Ports are de-allocated when the container stops and allocated when the container starts. The allocated port might be changed when restarting the container.  The port is selected from the ephemeral port range that depends on the kernel. For example, on Linux the range is defined by `/proc/sys/net/ipv4/ip_local_port_range`.
     #[serde(rename = "PublishAllPorts")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub publish_all_ports: Option<bool>,
@@ -2632,17 +2574,17 @@ pub struct HostConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub readonly_rootfs: Option<bool>,
 
-    /// A list of string values to customize labels for MLS systems, such as SELinux. 
+    /// A list of string values to customize labels for MLS systems, such as SELinux.
     #[serde(rename = "SecurityOpt")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub security_opt: Option<Vec<String>>,
 
-    /// Storage driver options for this container, in the form `{\"size\": \"120G\"}`. 
+    /// Storage driver options for this container, in the form `{\"size\": \"120G\"}`.
     #[serde(rename = "StorageOpt")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub storage_opt: Option<HashMap<String, String>>,
 
-    /// A map of container directories which should be replaced by tmpfs mounts, and their corresponding mount options. For example:  ``` { \"/run\": \"rw,noexec,nosuid,size=65536k\" } ``` 
+    /// A map of container directories which should be replaced by tmpfs mounts, and their corresponding mount options. For example:  ``` { \"/run\": \"rw,noexec,nosuid,size=65536k\" } ```
     #[serde(rename = "Tmpfs")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub tmpfs: Option<HashMap<String, String>>,
@@ -2652,17 +2594,17 @@ pub struct HostConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub uts_mode: Option<String>,
 
-    /// Sets the usernamespace mode for the container when usernamespace remapping option is enabled. 
+    /// Sets the usernamespace mode for the container when usernamespace remapping option is enabled.
     #[serde(rename = "UsernsMode")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub userns_mode: Option<String>,
 
-    /// Size of `/dev/shm` in bytes. If omitted, the system uses 64MB. 
+    /// Size of `/dev/shm` in bytes. If omitted, the system uses 64MB.
     #[serde(rename = "ShmSize")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub shm_size: Option<i64>,
 
-    /// A list of kernel parameters (sysctls) to set in the container. For example:  ``` {\"net.ipv4.ip_forward\": \"1\"} ``` 
+    /// A list of kernel parameters (sysctls) to set in the container. For example:  ``` {\"net.ipv4.ip_forward\": \"1\"} ```
     #[serde(rename = "Sysctls")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub sysctls: Option<HashMap<String, String>>,
@@ -2672,26 +2614,25 @@ pub struct HostConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub runtime: Option<String>,
 
-    /// Isolation technology of the container. (Windows only) 
+    /// Isolation technology of the container. (Windows only)
     #[serde(rename = "Isolation")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub isolation: Option<HostConfigIsolationEnum>,
 
-    /// The list of paths to be masked inside the container (this overrides the default set of paths). 
+    /// The list of paths to be masked inside the container (this overrides the default set of paths).
     #[serde(rename = "MaskedPaths")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub masked_paths: Option<Vec<String>>,
 
-    /// The list of paths to be set as read-only inside the container (this overrides the default set of paths). 
+    /// The list of paths to be set as read-only inside the container (this overrides the default set of paths).
     #[serde(rename = "ReadonlyPaths")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub readonly_paths: Option<Vec<String>>,
-
 }
 
 #[allow(non_camel_case_types)]
 #[derive(Debug, Clone, Copy, PartialEq, PartialOrd, Serialize, Deserialize, Eq, Ord)]
-pub enum HostConfigCgroupnsModeEnum { 
+pub enum HostConfigCgroupnsModeEnum {
     #[serde(rename = "")]
     EMPTY,
     #[serde(rename = "private")]
@@ -2702,11 +2643,10 @@ pub enum HostConfigCgroupnsModeEnum {
 
 impl ::std::fmt::Display for HostConfigCgroupnsModeEnum {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        match *self { 
+        match *self {
             HostConfigCgroupnsModeEnum::EMPTY => write!(f, ""),
             HostConfigCgroupnsModeEnum::PRIVATE => write!(f, "{}", "private"),
             HostConfigCgroupnsModeEnum::HOST => write!(f, "{}", "host"),
-
         }
     }
 }
@@ -2714,7 +2654,7 @@ impl ::std::fmt::Display for HostConfigCgroupnsModeEnum {
 impl ::std::str::FromStr for HostConfigCgroupnsModeEnum {
     type Err = String;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s { 
+        match s {
             "" => Ok(HostConfigCgroupnsModeEnum::EMPTY),
             "private" => Ok(HostConfigCgroupnsModeEnum::PRIVATE),
             "host" => Ok(HostConfigCgroupnsModeEnum::HOST),
@@ -2725,7 +2665,7 @@ impl ::std::str::FromStr for HostConfigCgroupnsModeEnum {
 
 impl ::std::convert::AsRef<str> for HostConfigCgroupnsModeEnum {
     fn as_ref(&self) -> &str {
-        match self { 
+        match self {
             HostConfigCgroupnsModeEnum::EMPTY => "",
             HostConfigCgroupnsModeEnum::PRIVATE => "private",
             HostConfigCgroupnsModeEnum::HOST => "host",
@@ -2735,7 +2675,7 @@ impl ::std::convert::AsRef<str> for HostConfigCgroupnsModeEnum {
 
 #[allow(non_camel_case_types)]
 #[derive(Debug, Clone, Copy, PartialEq, PartialOrd, Serialize, Deserialize, Eq, Ord)]
-pub enum HostConfigIsolationEnum { 
+pub enum HostConfigIsolationEnum {
     #[serde(rename = "")]
     EMPTY,
     #[serde(rename = "default")]
@@ -2748,12 +2688,11 @@ pub enum HostConfigIsolationEnum {
 
 impl ::std::fmt::Display for HostConfigIsolationEnum {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        match *self { 
+        match *self {
             HostConfigIsolationEnum::EMPTY => write!(f, ""),
             HostConfigIsolationEnum::DEFAULT => write!(f, "{}", "default"),
             HostConfigIsolationEnum::PROCESS => write!(f, "{}", "process"),
             HostConfigIsolationEnum::HYPERV => write!(f, "{}", "hyperv"),
-
         }
     }
 }
@@ -2761,7 +2700,7 @@ impl ::std::fmt::Display for HostConfigIsolationEnum {
 impl ::std::str::FromStr for HostConfigIsolationEnum {
     type Err = String;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s { 
+        match s {
             "" => Ok(HostConfigIsolationEnum::EMPTY),
             "default" => Ok(HostConfigIsolationEnum::DEFAULT),
             "process" => Ok(HostConfigIsolationEnum::PROCESS),
@@ -2773,7 +2712,7 @@ impl ::std::str::FromStr for HostConfigIsolationEnum {
 
 impl ::std::convert::AsRef<str> for HostConfigIsolationEnum {
     fn as_ref(&self) -> &str {
-        match self { 
+        match self {
             HostConfigIsolationEnum::EMPTY => "",
             HostConfigIsolationEnum::DEFAULT => "default",
             HostConfigIsolationEnum::PROCESS => "process",
@@ -2792,7 +2731,6 @@ pub struct HostConfigLogConfig {
     #[serde(rename = "Config")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub config: Option<HashMap<String, String>>,
-
 }
 
 /// Response to an API call that returns just an Id
@@ -2800,9 +2738,7 @@ pub struct HostConfigLogConfig {
 #[serde(rename_all = "UPPERCASE")]
 pub struct IdResponse {
     /// The id of the newly created object.
-    
     pub id: String,
-
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
@@ -2816,7 +2752,6 @@ pub struct ImageDeleteResponseItem {
     #[serde(rename = "Deleted")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub deleted: Option<String>,
-
 }
 
 /// Image ID or Digest
@@ -2825,43 +2760,42 @@ pub struct ImageId {
     #[serde(rename = "ID")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub id: Option<String>,
-
 }
 
-/// Information about an image in the local image cache. 
+/// Information about an image in the local image cache.
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 pub struct ImageInspect {
-    /// ID is the content-addressable ID of an image.  This identifier is a content-addressable digest calculated from the image's configuration (which includes the digests of layers used by the image).  Note that this digest differs from the `RepoDigests` below, which holds digests of image manifests that reference the image. 
+    /// ID is the content-addressable ID of an image.  This identifier is a content-addressable digest calculated from the image's configuration (which includes the digests of layers used by the image).  Note that this digest differs from the `RepoDigests` below, which holds digests of image manifests that reference the image.
     #[serde(rename = "Id")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub id: Option<String>,
 
-    /// List of image names/tags in the local image cache that reference this image.  Multiple image tags can refer to the same image, and this list may be empty if no tags reference the image, in which case the image is \"untagged\", in which case it can still be referenced by its ID. 
+    /// List of image names/tags in the local image cache that reference this image.  Multiple image tags can refer to the same image, and this list may be empty if no tags reference the image, in which case the image is \"untagged\", in which case it can still be referenced by its ID.
     #[serde(rename = "RepoTags")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub repo_tags: Option<Vec<String>>,
 
-    /// List of content-addressable digests of locally available image manifests that the image is referenced from. Multiple manifests can refer to the same image.  These digests are usually only available if the image was either pulled from a registry, or if the image was pushed to a registry, which is when the manifest is generated and its digest calculated. 
+    /// List of content-addressable digests of locally available image manifests that the image is referenced from. Multiple manifests can refer to the same image.  These digests are usually only available if the image was either pulled from a registry, or if the image was pushed to a registry, which is when the manifest is generated and its digest calculated.
     #[serde(rename = "RepoDigests")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub repo_digests: Option<Vec<String>>,
 
-    /// ID of the parent image.  Depending on how the image was created, this field may be empty and is only set for images that were built/created locally. This field is empty if the image was pulled from an image registry. 
+    /// ID of the parent image.  Depending on how the image was created, this field may be empty and is only set for images that were built/created locally. This field is empty if the image was pulled from an image registry.
     #[serde(rename = "Parent")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub parent: Option<String>,
 
-    /// Optional message that was set when committing or importing the image. 
+    /// Optional message that was set when committing or importing the image.
     #[serde(rename = "Comment")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub comment: Option<String>,
 
-    /// Date and time at which the image was created, formatted in [RFC 3339](https://www.ietf.org/rfc/rfc3339.txt) format with nano-seconds. 
+    /// Date and time at which the image was created, formatted in [RFC 3339](https://www.ietf.org/rfc/rfc3339.txt) format with nano-seconds.
     #[serde(rename = "Created")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub created: Option<String>,
 
-    /// The ID of the container that was used to create the image.  Depending on how the image was created, this field may be empty. 
+    /// The ID of the container that was used to create the image.  Depending on how the image was created, this field may be empty.
     #[serde(rename = "Container")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub container: Option<String>,
@@ -2870,12 +2804,12 @@ pub struct ImageInspect {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub container_config: Option<ContainerConfig>,
 
-    /// The version of Docker that was used to build the image.  Depending on how the image was created, this field may be empty. 
+    /// The version of Docker that was used to build the image.  Depending on how the image was created, this field may be empty.
     #[serde(rename = "DockerVersion")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub docker_version: Option<String>,
 
-    /// Name of the author that was specified when committing the image, or as specified through MAINTAINER (deprecated) in the Dockerfile. 
+    /// Name of the author that was specified when committing the image, or as specified through MAINTAINER (deprecated) in the Dockerfile.
     #[serde(rename = "Author")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub author: Option<String>,
@@ -2884,32 +2818,32 @@ pub struct ImageInspect {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub config: Option<ContainerConfig>,
 
-    /// Hardware CPU architecture that the image runs on. 
+    /// Hardware CPU architecture that the image runs on.
     #[serde(rename = "Architecture")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub architecture: Option<String>,
 
-    /// CPU architecture variant (presently ARM-only). 
+    /// CPU architecture variant (presently ARM-only).
     #[serde(rename = "Variant")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub variant: Option<String>,
 
-    /// Operating System the image is built to run on. 
+    /// Operating System the image is built to run on.
     #[serde(rename = "Os")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub os: Option<String>,
 
-    /// Operating System version the image is built to run on (especially for Windows). 
+    /// Operating System version the image is built to run on (especially for Windows).
     #[serde(rename = "OsVersion")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub os_version: Option<String>,
 
-    /// Total size of the image including all layers it is composed of. 
+    /// Total size of the image including all layers it is composed of.
     #[serde(rename = "Size")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub size: Option<i64>,
 
-    /// Total size of the image including all layers it is composed of.  In versions of Docker before v1.10, this field was calculated from the image itself and all of its parent images. Docker v1.10 and up store images self-contained, and no longer use a parent-chain, making this field an equivalent of the Size field.  This field is kept for backward compatibility, but may be removed in a future version of the API. 
+    /// Total size of the image including all layers it is composed of.  In versions of Docker before v1.10, this field was calculated from the image itself and all of its parent images. Docker v1.10 and up store images self-contained, and no longer use a parent-chain, making this field an equivalent of the Size field.  This field is kept for backward compatibility, but may be removed in a future version of the API.
     #[serde(rename = "VirtualSize")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub virtual_size: Option<i64>,
@@ -2925,13 +2859,12 @@ pub struct ImageInspect {
     #[serde(rename = "Metadata")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub metadata: Option<ImageInspectMetadata>,
-
 }
 
-/// Additional metadata of the image in the local cache. This information is local to the daemon, and not part of the image itself. 
+/// Additional metadata of the image in the local cache. This information is local to the daemon, and not part of the image itself.
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 pub struct ImageInspectMetadata {
-    /// Date and time at which the image was last tagged in [RFC 3339](https://www.ietf.org/rfc/rfc3339.txt) format with nano-seconds.  This information is only available if the image was tagged locally, and omitted otherwise. 
+    /// Date and time at which the image was last tagged in [RFC 3339](https://www.ietf.org/rfc/rfc3339.txt) format with nano-seconds.  This information is only available if the image was tagged locally, and omitted otherwise.
     #[serde(rename = "LastTagTime")]
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(
@@ -2940,10 +2873,9 @@ pub struct ImageInspectMetadata {
         serialize_with = "serialize_timestamp"
     )]
     pub last_tag_time: Option<BollardDate>,
-
 }
 
-/// Information about the image's RootFS, including the layer IDs. 
+/// Information about the image's RootFS, including the layer IDs.
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 pub struct ImageInspectRootFs {
     #[serde(rename = "Type")]
@@ -2952,7 +2884,6 @@ pub struct ImageInspectRootFs {
     #[serde(rename = "Layers")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub layers: Option<Vec<String>>,
-
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
@@ -2966,7 +2897,6 @@ pub struct ImagePruneResponse {
     #[serde(rename = "SpaceReclaimed")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub space_reclaimed: Option<i64>,
-
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
@@ -2990,42 +2920,41 @@ pub struct ImageSearchResponseItem {
     #[serde(rename = "star_count")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub star_count: Option<i64>,
-
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 pub struct ImageSummary {
-    /// ID is the content-addressable ID of an image.  This identifier is a content-addressable digest calculated from the image's configuration (which includes the digests of layers used by the image).  Note that this digest differs from the `RepoDigests` below, which holds digests of image manifests that reference the image. 
+    /// ID is the content-addressable ID of an image.  This identifier is a content-addressable digest calculated from the image's configuration (which includes the digests of layers used by the image).  Note that this digest differs from the `RepoDigests` below, which holds digests of image manifests that reference the image.
     #[serde(rename = "Id")]
     pub id: String,
 
-    /// ID of the parent image.  Depending on how the image was created, this field may be empty and is only set for images that were built/created locally. This field is empty if the image was pulled from an image registry. 
+    /// ID of the parent image.  Depending on how the image was created, this field may be empty and is only set for images that were built/created locally. This field is empty if the image was pulled from an image registry.
     #[serde(rename = "ParentId")]
     pub parent_id: String,
 
-    /// List of image names/tags in the local image cache that reference this image.  Multiple image tags can refer to the same image, and this list may be empty if no tags reference the image, in which case the image is \"untagged\", in which case it can still be referenced by its ID. 
+    /// List of image names/tags in the local image cache that reference this image.  Multiple image tags can refer to the same image, and this list may be empty if no tags reference the image, in which case the image is \"untagged\", in which case it can still be referenced by its ID.
     #[serde(rename = "RepoTags")]
     #[serde(deserialize_with = "deserialize_nonoptional_vec")]
     pub repo_tags: Vec<String>,
 
-    /// List of content-addressable digests of locally available image manifests that the image is referenced from. Multiple manifests can refer to the same image.  These digests are usually only available if the image was either pulled from a registry, or if the image was pushed to a registry, which is when the manifest is generated and its digest calculated. 
+    /// List of content-addressable digests of locally available image manifests that the image is referenced from. Multiple manifests can refer to the same image.  These digests are usually only available if the image was either pulled from a registry, or if the image was pushed to a registry, which is when the manifest is generated and its digest calculated.
     #[serde(rename = "RepoDigests")]
     #[serde(deserialize_with = "deserialize_nonoptional_vec")]
     pub repo_digests: Vec<String>,
 
-    /// Date and time at which the image was created as a Unix timestamp (number of seconds sinds EPOCH). 
+    /// Date and time at which the image was created as a Unix timestamp (number of seconds sinds EPOCH).
     #[serde(rename = "Created")]
     pub created: i64,
 
-    /// Total size of the image including all layers it is composed of. 
+    /// Total size of the image including all layers it is composed of.
     #[serde(rename = "Size")]
     pub size: i64,
 
-    /// Total size of image layers that are shared between this image and other images.  This size is not calculated by default. `-1` indicates that the value has not been set / calculated. 
+    /// Total size of image layers that are shared between this image and other images.  This size is not calculated by default. `-1` indicates that the value has not been set / calculated.
     #[serde(rename = "SharedSize")]
     pub shared_size: i64,
 
-    /// Total size of the image including all layers it is composed of.  In versions of Docker before v1.10, this field was calculated from the image itself and all of its parent images. Docker v1.10 and up store images self-contained, and no longer use a parent-chain, making this field an equivalent of the Size field.  This field is kept for backward compatibility, but may be removed in a future version of the API. 
+    /// Total size of the image including all layers it is composed of.  In versions of Docker before v1.10, this field was calculated from the image itself and all of its parent images. Docker v1.10 and up store images self-contained, and no longer use a parent-chain, making this field an equivalent of the Size field.  This field is kept for backward compatibility, but may be removed in a future version of the API.
     #[serde(rename = "VirtualSize")]
     pub virtual_size: i64,
 
@@ -3034,35 +2963,33 @@ pub struct ImageSummary {
     #[serde(deserialize_with = "deserialize_nonoptional_map")]
     pub labels: HashMap<String, String>,
 
-    /// Number of containers using this image. Includes both stopped and running containers.  This size is not calculated by default, and depends on which API endpoint is used. `-1` indicates that the value has not been set / calculated. 
+    /// Number of containers using this image. Includes both stopped and running containers.  This size is not calculated by default, and depends on which API endpoint is used. `-1` indicates that the value has not been set / calculated.
     #[serde(rename = "Containers")]
     pub containers: i64,
-
 }
 
 /// IndexInfo contains information about a registry.
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 pub struct IndexInfo {
-    /// Name of the registry, such as \"docker.io\". 
+    /// Name of the registry, such as \"docker.io\".
     #[serde(rename = "Name")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
 
-    /// List of mirrors, expressed as URIs. 
+    /// List of mirrors, expressed as URIs.
     #[serde(rename = "Mirrors")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub mirrors: Option<Vec<String>>,
 
-    /// Indicates if the registry is part of the list of insecure registries.  If `false`, the registry is insecure. Insecure registries accept un-encrypted (HTTP) and/or untrusted (HTTPS with certificates from unknown CAs) communication.  > **Warning**: Insecure registries can be useful when running a local > registry. However, because its use creates security vulnerabilities > it should ONLY be enabled for testing purposes. For increased > security, users should add their CA to their system's list of > trusted CAs instead of enabling this option. 
+    /// Indicates if the registry is part of the list of insecure registries.  If `false`, the registry is insecure. Insecure registries accept un-encrypted (HTTP) and/or untrusted (HTTPS with certificates from unknown CAs) communication.  > **Warning**: Insecure registries can be useful when running a local > registry. However, because its use creates security vulnerabilities > it should ONLY be enabled for testing purposes. For increased > security, users should add their CA to their system's list of > trusted CAs instead of enabling this option.
     #[serde(rename = "Secure")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub secure: Option<bool>,
 
-    /// Indicates whether this is an official registry (i.e., Docker Hub / docker.io) 
+    /// Indicates whether this is an official registry (i.e., Docker Hub / docker.io)
     #[serde(rename = "Official")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub official: Option<bool>,
-
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
@@ -3072,7 +2999,7 @@ pub struct Ipam {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub driver: Option<String>,
 
-    /// List of IPAM configuration options, specified as a map:  ``` {\"Subnet\": <CIDR>, \"IPRange\": <CIDR>, \"Gateway\": <IP address>, \"AuxAddress\": <device_name:IP address>} ``` 
+    /// List of IPAM configuration options, specified as a map:  ``` {\"Subnet\": <CIDR>, \"IPRange\": <CIDR>, \"Gateway\": <IP address>, \"AuxAddress\": <device_name:IP address>} ```
     #[serde(rename = "Config")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub config: Option<Vec<IpamConfig>>,
@@ -3081,7 +3008,6 @@ pub struct Ipam {
     #[serde(rename = "Options")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub options: Option<HashMap<String, String>>,
-
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
@@ -3101,25 +3027,23 @@ pub struct IpamConfig {
     #[serde(rename = "AuxiliaryAddresses")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub auxiliary_addresses: Option<HashMap<String, String>>,
-
 }
 
-/// JoinTokens contains the tokens workers and managers need to join the swarm. 
+/// JoinTokens contains the tokens workers and managers need to join the swarm.
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 pub struct JoinTokens {
-    /// The token workers can use to join the swarm. 
+    /// The token workers can use to join the swarm.
     #[serde(rename = "Worker")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub worker: Option<String>,
 
-    /// The token managers can use to join the swarm. 
+    /// The token managers can use to join the swarm.
     #[serde(rename = "Manager")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub manager: Option<String>,
-
 }
 
-/// An object describing a limit on resources which can be requested by a task. 
+/// An object describing a limit on resources which can be requested by a task.
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 pub struct Limit {
     #[serde(rename = "NanoCPUs")]
@@ -3130,11 +3054,10 @@ pub struct Limit {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub memory_bytes: Option<i64>,
 
-    /// Limits the maximum number of PIDs in the container. Set `0` for unlimited. 
+    /// Limits the maximum number of PIDs in the container. Set `0` for unlimited.
     #[serde(rename = "Pids")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub pids: Option<i64>,
-
 }
 
 /// Current local status of this node.
@@ -3144,7 +3067,7 @@ pub struct Limit {
 #[allow(non_camel_case_types)]
 #[repr(C)]
 #[derive(Debug, Clone, Copy, PartialEq, PartialOrd, Serialize, Deserialize, Eq, Ord)]
-pub enum LocalNodeState { 
+pub enum LocalNodeState {
     #[serde(rename = "")]
     EMPTY,
     #[serde(rename = "inactive")]
@@ -3161,7 +3084,7 @@ pub enum LocalNodeState {
 
 impl ::std::fmt::Display for LocalNodeState {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        match *self { 
+        match *self {
             LocalNodeState::EMPTY => write!(f, "{}", ""),
             LocalNodeState::INACTIVE => write!(f, "{}", "inactive"),
             LocalNodeState::PENDING => write!(f, "{}", "pending"),
@@ -3187,7 +3110,7 @@ impl ::std::str::FromStr for LocalNodeState {
     }
 }
 
-/// ManagerStatus represents the status of a manager.  It provides the current status of a node's manager component, if the node is a manager. 
+/// ManagerStatus represents the status of a manager.  It provides the current status of a node's manager component, if the node is a manager.
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 pub struct ManagerStatus {
     #[serde(rename = "Leader")]
@@ -3198,11 +3121,10 @@ pub struct ManagerStatus {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub reachability: Option<Reachability>,
 
-    /// The IP address and port at which the manager is reachable. 
+    /// The IP address and port at which the manager is reachable.
     #[serde(rename = "Addr")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub addr: Option<String>,
-
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
@@ -3217,7 +3139,7 @@ pub struct Mount {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub source: Option<String>,
 
-    /// The mount type. Available types:  - `bind` Mounts a file or directory from the host into the container. Must exist prior to creating the container. - `volume` Creates a volume with the given name and options (or uses a pre-existing volume with the same name and options). These are **not** removed when the container is removed. - `tmpfs` Create a tmpfs with the given options. The mount source cannot be specified for tmpfs. - `npipe` Mounts a named pipe from the host into the container. Must exist prior to creating the container. - `cluster` a Swarm cluster volume 
+    /// The mount type. Available types:  - `bind` Mounts a file or directory from the host into the container. Must exist prior to creating the container. - `volume` Creates a volume with the given name and options (or uses a pre-existing volume with the same name and options). These are **not** removed when the container is removed. - `tmpfs` Create a tmpfs with the given options. The mount source cannot be specified for tmpfs. - `npipe` Mounts a named pipe from the host into the container. Must exist prior to creating the container. - `cluster` a Swarm cluster volume
     #[serde(rename = "Type")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub typ: Option<MountTypeEnum>,
@@ -3243,12 +3165,11 @@ pub struct Mount {
     #[serde(rename = "TmpfsOptions")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub tmpfs_options: Option<MountTmpfsOptions>,
-
 }
 
 #[allow(non_camel_case_types)]
 #[derive(Debug, Clone, Copy, PartialEq, PartialOrd, Serialize, Deserialize, Eq, Ord)]
-pub enum MountTypeEnum { 
+pub enum MountTypeEnum {
     #[serde(rename = "")]
     EMPTY,
     #[serde(rename = "bind")]
@@ -3265,14 +3186,13 @@ pub enum MountTypeEnum {
 
 impl ::std::fmt::Display for MountTypeEnum {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        match *self { 
+        match *self {
             MountTypeEnum::EMPTY => write!(f, ""),
             MountTypeEnum::BIND => write!(f, "{}", "bind"),
             MountTypeEnum::VOLUME => write!(f, "{}", "volume"),
             MountTypeEnum::TMPFS => write!(f, "{}", "tmpfs"),
             MountTypeEnum::NPIPE => write!(f, "{}", "npipe"),
             MountTypeEnum::CLUSTER => write!(f, "{}", "cluster"),
-
         }
     }
 }
@@ -3280,7 +3200,7 @@ impl ::std::fmt::Display for MountTypeEnum {
 impl ::std::str::FromStr for MountTypeEnum {
     type Err = String;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s { 
+        match s {
             "" => Ok(MountTypeEnum::EMPTY),
             "bind" => Ok(MountTypeEnum::BIND),
             "volume" => Ok(MountTypeEnum::VOLUME),
@@ -3294,7 +3214,7 @@ impl ::std::str::FromStr for MountTypeEnum {
 
 impl ::std::convert::AsRef<str> for MountTypeEnum {
     fn as_ref(&self) -> &str {
-        match self { 
+        match self {
             MountTypeEnum::EMPTY => "",
             MountTypeEnum::BIND => "bind",
             MountTypeEnum::VOLUME => "volume",
@@ -3322,12 +3242,11 @@ pub struct MountBindOptions {
     #[serde(rename = "CreateMountpoint")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub create_mountpoint: Option<bool>,
-
 }
 
 #[allow(non_camel_case_types)]
 #[derive(Debug, Clone, Copy, PartialEq, PartialOrd, Serialize, Deserialize, Eq, Ord)]
-pub enum MountBindOptionsPropagationEnum { 
+pub enum MountBindOptionsPropagationEnum {
     #[serde(rename = "")]
     EMPTY,
     #[serde(rename = "private")]
@@ -3346,7 +3265,7 @@ pub enum MountBindOptionsPropagationEnum {
 
 impl ::std::fmt::Display for MountBindOptionsPropagationEnum {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        match *self { 
+        match *self {
             MountBindOptionsPropagationEnum::EMPTY => write!(f, ""),
             MountBindOptionsPropagationEnum::PRIVATE => write!(f, "{}", "private"),
             MountBindOptionsPropagationEnum::RPRIVATE => write!(f, "{}", "rprivate"),
@@ -3354,7 +3273,6 @@ impl ::std::fmt::Display for MountBindOptionsPropagationEnum {
             MountBindOptionsPropagationEnum::RSHARED => write!(f, "{}", "rshared"),
             MountBindOptionsPropagationEnum::SLAVE => write!(f, "{}", "slave"),
             MountBindOptionsPropagationEnum::RSLAVE => write!(f, "{}", "rslave"),
-
         }
     }
 }
@@ -3362,7 +3280,7 @@ impl ::std::fmt::Display for MountBindOptionsPropagationEnum {
 impl ::std::str::FromStr for MountBindOptionsPropagationEnum {
     type Err = String;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s { 
+        match s {
             "" => Ok(MountBindOptionsPropagationEnum::EMPTY),
             "private" => Ok(MountBindOptionsPropagationEnum::PRIVATE),
             "rprivate" => Ok(MountBindOptionsPropagationEnum::RPRIVATE),
@@ -3377,7 +3295,7 @@ impl ::std::str::FromStr for MountBindOptionsPropagationEnum {
 
 impl ::std::convert::AsRef<str> for MountBindOptionsPropagationEnum {
     fn as_ref(&self) -> &str {
-        match self { 
+        match self {
             MountBindOptionsPropagationEnum::EMPTY => "",
             MountBindOptionsPropagationEnum::PRIVATE => "private",
             MountBindOptionsPropagationEnum::RPRIVATE => "rprivate",
@@ -3389,54 +3307,53 @@ impl ::std::convert::AsRef<str> for MountBindOptionsPropagationEnum {
     }
 }
 
-/// MountPoint represents a mount point configuration inside the container. This is used for reporting the mountpoints in use by a container. 
+/// MountPoint represents a mount point configuration inside the container. This is used for reporting the mountpoints in use by a container.
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 pub struct MountPoint {
-    /// The mount type:  - `bind` a mount of a file or directory from the host into the container. - `volume` a docker volume with the given `Name`. - `tmpfs` a `tmpfs`. - `npipe` a named pipe from the host into the container. - `cluster` a Swarm cluster volume 
+    /// The mount type:  - `bind` a mount of a file or directory from the host into the container. - `volume` a docker volume with the given `Name`. - `tmpfs` a `tmpfs`. - `npipe` a named pipe from the host into the container. - `cluster` a Swarm cluster volume
     #[serde(rename = "Type")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub typ: Option<MountPointTypeEnum>,
 
-    /// Name is the name reference to the underlying data defined by `Source` e.g., the volume name. 
+    /// Name is the name reference to the underlying data defined by `Source` e.g., the volume name.
     #[serde(rename = "Name")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
 
-    /// Source location of the mount.  For volumes, this contains the storage location of the volume (within `/var/lib/docker/volumes/`). For bind-mounts, and `npipe`, this contains the source (host) part of the bind-mount. For `tmpfs` mount points, this field is empty. 
+    /// Source location of the mount.  For volumes, this contains the storage location of the volume (within `/var/lib/docker/volumes/`). For bind-mounts, and `npipe`, this contains the source (host) part of the bind-mount. For `tmpfs` mount points, this field is empty.
     #[serde(rename = "Source")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub source: Option<String>,
 
-    /// Destination is the path relative to the container root (`/`) where the `Source` is mounted inside the container. 
+    /// Destination is the path relative to the container root (`/`) where the `Source` is mounted inside the container.
     #[serde(rename = "Destination")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub destination: Option<String>,
 
-    /// Driver is the volume driver used to create the volume (if it is a volume). 
+    /// Driver is the volume driver used to create the volume (if it is a volume).
     #[serde(rename = "Driver")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub driver: Option<String>,
 
-    /// Mode is a comma separated list of options supplied by the user when creating the bind/volume mount.  The default is platform-specific (`\"z\"` on Linux, empty on Windows). 
+    /// Mode is a comma separated list of options supplied by the user when creating the bind/volume mount.  The default is platform-specific (`\"z\"` on Linux, empty on Windows).
     #[serde(rename = "Mode")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub mode: Option<String>,
 
-    /// Whether the mount is mounted writable (read-write). 
+    /// Whether the mount is mounted writable (read-write).
     #[serde(rename = "RW")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub rw: Option<bool>,
 
-    /// Propagation describes how mounts are propagated from the host into the mount point, and vice-versa. Refer to the [Linux kernel documentation](https://www.kernel.org/doc/Documentation/filesystems/sharedsubtree.txt) for details. This field is not used on Windows. 
+    /// Propagation describes how mounts are propagated from the host into the mount point, and vice-versa. Refer to the [Linux kernel documentation](https://www.kernel.org/doc/Documentation/filesystems/sharedsubtree.txt) for details. This field is not used on Windows.
     #[serde(rename = "Propagation")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub propagation: Option<String>,
-
 }
 
 #[allow(non_camel_case_types)]
 #[derive(Debug, Clone, Copy, PartialEq, PartialOrd, Serialize, Deserialize, Eq, Ord)]
-pub enum MountPointTypeEnum { 
+pub enum MountPointTypeEnum {
     #[serde(rename = "")]
     EMPTY,
     #[serde(rename = "bind")]
@@ -3453,14 +3370,13 @@ pub enum MountPointTypeEnum {
 
 impl ::std::fmt::Display for MountPointTypeEnum {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        match *self { 
+        match *self {
             MountPointTypeEnum::EMPTY => write!(f, ""),
             MountPointTypeEnum::BIND => write!(f, "{}", "bind"),
             MountPointTypeEnum::VOLUME => write!(f, "{}", "volume"),
             MountPointTypeEnum::TMPFS => write!(f, "{}", "tmpfs"),
             MountPointTypeEnum::NPIPE => write!(f, "{}", "npipe"),
             MountPointTypeEnum::CLUSTER => write!(f, "{}", "cluster"),
-
         }
     }
 }
@@ -3468,7 +3384,7 @@ impl ::std::fmt::Display for MountPointTypeEnum {
 impl ::std::str::FromStr for MountPointTypeEnum {
     type Err = String;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s { 
+        match s {
             "" => Ok(MountPointTypeEnum::EMPTY),
             "bind" => Ok(MountPointTypeEnum::BIND),
             "volume" => Ok(MountPointTypeEnum::VOLUME),
@@ -3482,7 +3398,7 @@ impl ::std::str::FromStr for MountPointTypeEnum {
 
 impl ::std::convert::AsRef<str> for MountPointTypeEnum {
     fn as_ref(&self) -> &str {
-        match self { 
+        match self {
             MountPointTypeEnum::EMPTY => "",
             MountPointTypeEnum::BIND => "bind",
             MountPointTypeEnum::VOLUME => "volume",
@@ -3505,7 +3421,6 @@ pub struct MountTmpfsOptions {
     #[serde(rename = "Mode")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub mode: Option<i64>,
-
 }
 
 /// Optional configuration for the `volume` type.
@@ -3524,7 +3439,6 @@ pub struct MountVolumeOptions {
     #[serde(rename = "DriverConfig")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub driver_config: Option<MountVolumeOptionsDriverConfig>,
-
 }
 
 /// Map of driver specific options
@@ -3539,7 +3453,6 @@ pub struct MountVolumeOptionsDriverConfig {
     #[serde(rename = "Options")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub options: Option<HashMap<String, String>>,
-
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
@@ -3600,27 +3513,25 @@ pub struct Network {
     #[serde(rename = "Labels")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub labels: Option<HashMap<String, String>>,
-
 }
 
-/// Specifies how a service should be attached to a particular network. 
+/// Specifies how a service should be attached to a particular network.
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 pub struct NetworkAttachmentConfig {
-    /// The target network for attachment. Must be a network name or ID. 
+    /// The target network for attachment. Must be a network name or ID.
     #[serde(rename = "Target")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub target: Option<String>,
 
-    /// Discoverable alternate names for the service on this network. 
+    /// Discoverable alternate names for the service on this network.
     #[serde(rename = "Aliases")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub aliases: Option<Vec<String>>,
 
-    /// Driver attachment options for the network target. 
+    /// Driver attachment options for the network target.
     #[serde(rename = "DriverOpts")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub driver_opts: Option<HashMap<String, String>>,
-
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
@@ -3633,7 +3544,6 @@ pub struct NetworkConnectRequest {
     #[serde(rename = "EndpointConfig")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub endpoint_config: Option<EndpointSettings>,
-
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
@@ -3657,7 +3567,6 @@ pub struct NetworkContainer {
     #[serde(rename = "IPv6Address")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub ipv6_address: Option<String>,
-
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
@@ -3666,7 +3575,7 @@ pub struct NetworkCreateRequest {
     #[serde(rename = "Name")]
     pub name: String,
 
-    /// Check for networks with duplicate names. Since Network is primarily keyed based on a random ID and not on the name, and network name is strictly a user-friendly alias to the network which is uniquely identified using ID, there is no guaranteed way to check for duplicates. CheckDuplicate is there to provide a best effort checking of any networks which has the same name but it is not guaranteed to catch all name collisions. 
+    /// Check for networks with duplicate names. Since Network is primarily keyed based on a random ID and not on the name, and network name is strictly a user-friendly alias to the network which is uniquely identified using ID, there is no guaranteed way to check for duplicates. CheckDuplicate is there to provide a best effort checking of any networks which has the same name but it is not guaranteed to catch all name collisions.
     #[serde(rename = "CheckDuplicate")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub check_duplicate: Option<bool>,
@@ -3681,12 +3590,12 @@ pub struct NetworkCreateRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub internal: Option<bool>,
 
-    /// Globally scoped network is manually attachable by regular containers from workers in swarm mode. 
+    /// Globally scoped network is manually attachable by regular containers from workers in swarm mode.
     #[serde(rename = "Attachable")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub attachable: Option<bool>,
 
-    /// Ingress network is the network which provides the routing-mesh in swarm mode. 
+    /// Ingress network is the network which provides the routing-mesh in swarm mode.
     #[serde(rename = "Ingress")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub ingress: Option<bool>,
@@ -3710,7 +3619,6 @@ pub struct NetworkCreateRequest {
     #[serde(rename = "Labels")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub labels: Option<HashMap<String, String>>,
-
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
@@ -3723,21 +3631,19 @@ pub struct NetworkCreateResponse {
     #[serde(rename = "Warning")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub warning: Option<String>,
-
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 pub struct NetworkDisconnectRequest {
-    /// The ID or name of the container to disconnect from the network. 
+    /// The ID or name of the container to disconnect from the network.
     #[serde(rename = "Container")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub container: Option<String>,
 
-    /// Force the container to disconnect from the network. 
+    /// Force the container to disconnect from the network.
     #[serde(rename = "Force")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub force: Option<bool>,
-
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
@@ -3746,7 +3652,6 @@ pub struct NetworkPruneResponse {
     #[serde(rename = "NetworksDeleted")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub networks_deleted: Option<Vec<String>>,
-
 }
 
 /// NetworkSettings exposes the network settings in the API
@@ -3762,7 +3667,7 @@ pub struct NetworkSettings {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub sandbox_id: Option<String>,
 
-    /// Indicates if hairpin NAT should be enabled on the virtual interface. 
+    /// Indicates if hairpin NAT should be enabled on the virtual interface.
     #[serde(rename = "HairpinMode")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub hairpin_mode: Option<bool>,
@@ -3786,71 +3691,69 @@ pub struct NetworkSettings {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub sandbox_key: Option<String>,
 
-    /// 
+    ///
     #[serde(rename = "SecondaryIPAddresses")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub secondary_ip_addresses: Option<Vec<Address>>,
 
-    /// 
+    ///
     #[serde(rename = "SecondaryIPv6Addresses")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub secondary_ipv6_addresses: Option<Vec<Address>>,
 
-    /// EndpointID uniquely represents a service endpoint in a Sandbox.  <p><br /></p>  > **Deprecated**: This field is only propagated when attached to the > default \"bridge\" network. Use the information from the \"bridge\" > network inside the `Networks` map instead, which contains the same > information. This field was deprecated in Docker 1.9 and is scheduled > to be removed in Docker 17.12.0 
+    /// EndpointID uniquely represents a service endpoint in a Sandbox.  <p><br /></p>  > **Deprecated**: This field is only propagated when attached to the > default \"bridge\" network. Use the information from the \"bridge\" > network inside the `Networks` map instead, which contains the same > information. This field was deprecated in Docker 1.9 and is scheduled > to be removed in Docker 17.12.0
     #[serde(rename = "EndpointID")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub endpoint_id: Option<String>,
 
-    /// Gateway address for the default \"bridge\" network.  <p><br /></p>  > **Deprecated**: This field is only propagated when attached to the > default \"bridge\" network. Use the information from the \"bridge\" > network inside the `Networks` map instead, which contains the same > information. This field was deprecated in Docker 1.9 and is scheduled > to be removed in Docker 17.12.0 
+    /// Gateway address for the default \"bridge\" network.  <p><br /></p>  > **Deprecated**: This field is only propagated when attached to the > default \"bridge\" network. Use the information from the \"bridge\" > network inside the `Networks` map instead, which contains the same > information. This field was deprecated in Docker 1.9 and is scheduled > to be removed in Docker 17.12.0
     #[serde(rename = "Gateway")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub gateway: Option<String>,
 
-    /// Global IPv6 address for the default \"bridge\" network.  <p><br /></p>  > **Deprecated**: This field is only propagated when attached to the > default \"bridge\" network. Use the information from the \"bridge\" > network inside the `Networks` map instead, which contains the same > information. This field was deprecated in Docker 1.9 and is scheduled > to be removed in Docker 17.12.0 
+    /// Global IPv6 address for the default \"bridge\" network.  <p><br /></p>  > **Deprecated**: This field is only propagated when attached to the > default \"bridge\" network. Use the information from the \"bridge\" > network inside the `Networks` map instead, which contains the same > information. This field was deprecated in Docker 1.9 and is scheduled > to be removed in Docker 17.12.0
     #[serde(rename = "GlobalIPv6Address")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub global_ipv6_address: Option<String>,
 
-    /// Mask length of the global IPv6 address.  <p><br /></p>  > **Deprecated**: This field is only propagated when attached to the > default \"bridge\" network. Use the information from the \"bridge\" > network inside the `Networks` map instead, which contains the same > information. This field was deprecated in Docker 1.9 and is scheduled > to be removed in Docker 17.12.0 
+    /// Mask length of the global IPv6 address.  <p><br /></p>  > **Deprecated**: This field is only propagated when attached to the > default \"bridge\" network. Use the information from the \"bridge\" > network inside the `Networks` map instead, which contains the same > information. This field was deprecated in Docker 1.9 and is scheduled > to be removed in Docker 17.12.0
     #[serde(rename = "GlobalIPv6PrefixLen")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub global_ipv6_prefix_len: Option<i64>,
 
-    /// IPv4 address for the default \"bridge\" network.  <p><br /></p>  > **Deprecated**: This field is only propagated when attached to the > default \"bridge\" network. Use the information from the \"bridge\" > network inside the `Networks` map instead, which contains the same > information. This field was deprecated in Docker 1.9 and is scheduled > to be removed in Docker 17.12.0 
+    /// IPv4 address for the default \"bridge\" network.  <p><br /></p>  > **Deprecated**: This field is only propagated when attached to the > default \"bridge\" network. Use the information from the \"bridge\" > network inside the `Networks` map instead, which contains the same > information. This field was deprecated in Docker 1.9 and is scheduled > to be removed in Docker 17.12.0
     #[serde(rename = "IPAddress")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub ip_address: Option<String>,
 
-    /// Mask length of the IPv4 address.  <p><br /></p>  > **Deprecated**: This field is only propagated when attached to the > default \"bridge\" network. Use the information from the \"bridge\" > network inside the `Networks` map instead, which contains the same > information. This field was deprecated in Docker 1.9 and is scheduled > to be removed in Docker 17.12.0 
+    /// Mask length of the IPv4 address.  <p><br /></p>  > **Deprecated**: This field is only propagated when attached to the > default \"bridge\" network. Use the information from the \"bridge\" > network inside the `Networks` map instead, which contains the same > information. This field was deprecated in Docker 1.9 and is scheduled > to be removed in Docker 17.12.0
     #[serde(rename = "IPPrefixLen")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub ip_prefix_len: Option<i64>,
 
-    /// IPv6 gateway address for this network.  <p><br /></p>  > **Deprecated**: This field is only propagated when attached to the > default \"bridge\" network. Use the information from the \"bridge\" > network inside the `Networks` map instead, which contains the same > information. This field was deprecated in Docker 1.9 and is scheduled > to be removed in Docker 17.12.0 
+    /// IPv6 gateway address for this network.  <p><br /></p>  > **Deprecated**: This field is only propagated when attached to the > default \"bridge\" network. Use the information from the \"bridge\" > network inside the `Networks` map instead, which contains the same > information. This field was deprecated in Docker 1.9 and is scheduled > to be removed in Docker 17.12.0
     #[serde(rename = "IPv6Gateway")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub ipv6_gateway: Option<String>,
 
-    /// MAC address for the container on the default \"bridge\" network.  <p><br /></p>  > **Deprecated**: This field is only propagated when attached to the > default \"bridge\" network. Use the information from the \"bridge\" > network inside the `Networks` map instead, which contains the same > information. This field was deprecated in Docker 1.9 and is scheduled > to be removed in Docker 17.12.0 
+    /// MAC address for the container on the default \"bridge\" network.  <p><br /></p>  > **Deprecated**: This field is only propagated when attached to the > default \"bridge\" network. Use the information from the \"bridge\" > network inside the `Networks` map instead, which contains the same > information. This field was deprecated in Docker 1.9 and is scheduled > to be removed in Docker 17.12.0
     #[serde(rename = "MacAddress")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub mac_address: Option<String>,
 
-    /// Information about all networks that the container is connected to. 
+    /// Information about all networks that the container is connected to.
     #[serde(rename = "Networks")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub networks: Option<HashMap<String, EndpointSettings>>,
-
 }
 
-/// NetworkingConfig represents the container's networking configuration for each of its interfaces. It is used for the networking configs specified in the `docker create` and `docker network connect` commands. 
+/// NetworkingConfig represents the container's networking configuration for each of its interfaces. It is used for the networking configs specified in the `docker create` and `docker network connect` commands.
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 pub struct NetworkingConfig {
-    /// A mapping of network name to endpoint configuration for that network. 
+    /// A mapping of network name to endpoint configuration for that network.
     #[serde(rename = "EndpointsConfig")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub endpoints_config: Option<HashMap<String, EndpointSettings>>,
-
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
@@ -3863,7 +3766,7 @@ pub struct Node {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub version: Option<ObjectVersion>,
 
-    /// Date and time at which the node was added to the swarm in [RFC 3339](https://www.ietf.org/rfc/rfc3339.txt) format with nano-seconds. 
+    /// Date and time at which the node was added to the swarm in [RFC 3339](https://www.ietf.org/rfc/rfc3339.txt) format with nano-seconds.
     #[serde(rename = "CreatedAt")]
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(
@@ -3873,7 +3776,7 @@ pub struct Node {
     )]
     pub created_at: Option<BollardDate>,
 
-    /// Date and time at which the node was last updated in [RFC 3339](https://www.ietf.org/rfc/rfc3339.txt) format with nano-seconds. 
+    /// Date and time at which the node was last updated in [RFC 3339](https://www.ietf.org/rfc/rfc3339.txt) format with nano-seconds.
     #[serde(rename = "UpdatedAt")]
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(
@@ -3898,10 +3801,9 @@ pub struct Node {
     #[serde(rename = "ManagerStatus")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub manager_status: Option<ManagerStatus>,
-
 }
 
-/// NodeDescription encapsulates the properties of the Node as reported by the agent. 
+/// NodeDescription encapsulates the properties of the Node as reported by the agent.
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 pub struct NodeDescription {
     #[serde(rename = "Hostname")]
@@ -3923,7 +3825,6 @@ pub struct NodeDescription {
     #[serde(rename = "TLSInfo")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub tls_info: Option<TlsInfo>,
-
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
@@ -3947,12 +3848,11 @@ pub struct NodeSpec {
     #[serde(rename = "Availability")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub availability: Option<NodeSpecAvailabilityEnum>,
-
 }
 
 #[allow(non_camel_case_types)]
 #[derive(Debug, Clone, Copy, PartialEq, PartialOrd, Serialize, Deserialize, Eq, Ord)]
-pub enum NodeSpecRoleEnum { 
+pub enum NodeSpecRoleEnum {
     #[serde(rename = "")]
     EMPTY,
     #[serde(rename = "worker")]
@@ -3963,11 +3863,10 @@ pub enum NodeSpecRoleEnum {
 
 impl ::std::fmt::Display for NodeSpecRoleEnum {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        match *self { 
+        match *self {
             NodeSpecRoleEnum::EMPTY => write!(f, ""),
             NodeSpecRoleEnum::WORKER => write!(f, "{}", "worker"),
             NodeSpecRoleEnum::MANAGER => write!(f, "{}", "manager"),
-
         }
     }
 }
@@ -3975,7 +3874,7 @@ impl ::std::fmt::Display for NodeSpecRoleEnum {
 impl ::std::str::FromStr for NodeSpecRoleEnum {
     type Err = String;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s { 
+        match s {
             "" => Ok(NodeSpecRoleEnum::EMPTY),
             "worker" => Ok(NodeSpecRoleEnum::WORKER),
             "manager" => Ok(NodeSpecRoleEnum::MANAGER),
@@ -3986,7 +3885,7 @@ impl ::std::str::FromStr for NodeSpecRoleEnum {
 
 impl ::std::convert::AsRef<str> for NodeSpecRoleEnum {
     fn as_ref(&self) -> &str {
-        match self { 
+        match self {
             NodeSpecRoleEnum::EMPTY => "",
             NodeSpecRoleEnum::WORKER => "worker",
             NodeSpecRoleEnum::MANAGER => "manager",
@@ -3996,7 +3895,7 @@ impl ::std::convert::AsRef<str> for NodeSpecRoleEnum {
 
 #[allow(non_camel_case_types)]
 #[derive(Debug, Clone, Copy, PartialEq, PartialOrd, Serialize, Deserialize, Eq, Ord)]
-pub enum NodeSpecAvailabilityEnum { 
+pub enum NodeSpecAvailabilityEnum {
     #[serde(rename = "")]
     EMPTY,
     #[serde(rename = "active")]
@@ -4009,12 +3908,11 @@ pub enum NodeSpecAvailabilityEnum {
 
 impl ::std::fmt::Display for NodeSpecAvailabilityEnum {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        match *self { 
+        match *self {
             NodeSpecAvailabilityEnum::EMPTY => write!(f, ""),
             NodeSpecAvailabilityEnum::ACTIVE => write!(f, "{}", "active"),
             NodeSpecAvailabilityEnum::PAUSE => write!(f, "{}", "pause"),
             NodeSpecAvailabilityEnum::DRAIN => write!(f, "{}", "drain"),
-
         }
     }
 }
@@ -4022,7 +3920,7 @@ impl ::std::fmt::Display for NodeSpecAvailabilityEnum {
 impl ::std::str::FromStr for NodeSpecAvailabilityEnum {
     type Err = String;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s { 
+        match s {
             "" => Ok(NodeSpecAvailabilityEnum::EMPTY),
             "active" => Ok(NodeSpecAvailabilityEnum::ACTIVE),
             "pause" => Ok(NodeSpecAvailabilityEnum::PAUSE),
@@ -4034,7 +3932,7 @@ impl ::std::str::FromStr for NodeSpecAvailabilityEnum {
 
 impl ::std::convert::AsRef<str> for NodeSpecAvailabilityEnum {
     fn as_ref(&self) -> &str {
-        match self { 
+        match self {
             NodeSpecAvailabilityEnum::EMPTY => "",
             NodeSpecAvailabilityEnum::ACTIVE => "active",
             NodeSpecAvailabilityEnum::PAUSE => "pause",
@@ -4050,7 +3948,7 @@ impl ::std::convert::AsRef<str> for NodeSpecAvailabilityEnum {
 #[allow(non_camel_case_types)]
 #[repr(C)]
 #[derive(Debug, Clone, Copy, PartialEq, PartialOrd, Serialize, Deserialize, Eq, Ord)]
-pub enum NodeState { 
+pub enum NodeState {
     #[serde(rename = "unknown")]
     UNKNOWN,
     #[serde(rename = "down")]
@@ -4063,7 +3961,7 @@ pub enum NodeState {
 
 impl ::std::fmt::Display for NodeState {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        match *self { 
+        match *self {
             NodeState::UNKNOWN => write!(f, "{}", "unknown"),
             NodeState::DOWN => write!(f, "{}", "down"),
             NodeState::READY => write!(f, "{}", "ready"),
@@ -4085,7 +3983,7 @@ impl ::std::str::FromStr for NodeState {
     }
 }
 
-/// NodeStatus represents the status of a node.  It provides the current status of the node, as seen by the manager. 
+/// NodeStatus represents the status of a node.  It provides the current status of the node, as seen by the manager.
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 pub struct NodeStatus {
     #[serde(rename = "State")]
@@ -4100,66 +3998,62 @@ pub struct NodeStatus {
     #[serde(rename = "Addr")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub addr: Option<String>,
-
 }
 
-/// The version number of the object such as node, service, etc. This is needed to avoid conflicting writes. The client must send the version number along with the modified specification when updating these objects.  This approach ensures safe concurrency and determinism in that the change on the object may not be applied if the version number has changed from the last read. In other words, if two update requests specify the same base version, only one of the requests can succeed. As a result, two separate update requests that happen at the same time will not unintentionally overwrite each other. 
+/// The version number of the object such as node, service, etc. This is needed to avoid conflicting writes. The client must send the version number along with the modified specification when updating these objects.  This approach ensures safe concurrency and determinism in that the change on the object may not be applied if the version number has changed from the last read. In other words, if two update requests specify the same base version, only one of the requests can succeed. As a result, two separate update requests that happen at the same time will not unintentionally overwrite each other.
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 pub struct ObjectVersion {
     #[serde(rename = "Index")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub index: Option<u64>,
-
 }
 
-/// A descriptor struct containing digest, media type, and size, as defined in the [OCI Content Descriptors Specification](https://github.com/opencontainers/image-spec/blob/v1.0.1/descriptor.md). 
+/// A descriptor struct containing digest, media type, and size, as defined in the [OCI Content Descriptors Specification](https://github.com/opencontainers/image-spec/blob/v1.0.1/descriptor.md).
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 pub struct OciDescriptor {
-    /// The media type of the object this schema refers to. 
+    /// The media type of the object this schema refers to.
     #[serde(rename = "mediaType")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub media_type: Option<String>,
 
-    /// The digest of the targeted content. 
+    /// The digest of the targeted content.
     #[serde(rename = "digest")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub digest: Option<String>,
 
-    /// The size in bytes of the blob. 
+    /// The size in bytes of the blob.
     #[serde(rename = "size")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub size: Option<i64>,
-
 }
 
-/// Describes the platform which the image in the manifest runs on, as defined in the [OCI Image Index Specification](https://github.com/opencontainers/image-spec/blob/v1.0.1/image-index.md). 
+/// Describes the platform which the image in the manifest runs on, as defined in the [OCI Image Index Specification](https://github.com/opencontainers/image-spec/blob/v1.0.1/image-index.md).
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 pub struct OciPlatform {
-    /// The CPU architecture, for example `amd64` or `ppc64`. 
+    /// The CPU architecture, for example `amd64` or `ppc64`.
     #[serde(rename = "architecture")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub architecture: Option<String>,
 
-    /// The operating system, for example `linux` or `windows`. 
+    /// The operating system, for example `linux` or `windows`.
     #[serde(rename = "os")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub os: Option<String>,
 
-    /// Optional field specifying the operating system version, for example on Windows `10.0.19041.1165`. 
+    /// Optional field specifying the operating system version, for example on Windows `10.0.19041.1165`.
     #[serde(rename = "os.version")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub os_version: Option<String>,
 
-    /// Optional field specifying an array of strings, each listing a required OS feature (for example on Windows `win32k`). 
+    /// Optional field specifying an array of strings, each listing a required OS feature (for example on Windows `win32k`).
     #[serde(rename = "os.features")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub os_features: Option<Vec<String>>,
 
-    /// Optional field specifying a variant of the CPU, for example `v7` to specify ARMv7 when architecture is `arm`. 
+    /// Optional field specifying a variant of the CPU, for example `v7` to specify ARMv7 when architecture is `arm`.
     #[serde(rename = "variant")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub variant: Option<String>,
-
 }
 
 /// Represents a peer-node in the swarm
@@ -4170,26 +4064,24 @@ pub struct PeerNode {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub node_id: Option<String>,
 
-    /// IP address and ports at which this node can be reached. 
+    /// IP address and ports at which this node can be reached.
     #[serde(rename = "Addr")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub addr: Option<String>,
-
 }
 
-/// Platform represents the platform (Arch/OS). 
+/// Platform represents the platform (Arch/OS).
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 pub struct Platform {
-    /// Architecture represents the hardware architecture (for example, `x86_64`). 
+    /// Architecture represents the hardware architecture (for example, `x86_64`).
     #[serde(rename = "Architecture")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub architecture: Option<String>,
 
-    /// OS represents the Operating System (for example, `linux` or `windows`). 
+    /// OS represents the Operating System (for example, `linux` or `windows`).
     #[serde(rename = "OS")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub os: Option<String>,
-
 }
 
 /// A plugin for the Engine API
@@ -4216,7 +4108,6 @@ pub struct Plugin {
 
     #[serde(rename = "Config")]
     pub config: PluginConfig,
-
 }
 
 /// The config of a plugin.
@@ -4276,7 +4167,6 @@ pub struct PluginConfig {
     #[serde(rename = "rootfs")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub rootfs: Option<PluginConfigRootfs>,
-
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
@@ -4294,7 +4184,6 @@ pub struct PluginConfigArgs {
     #[serde(rename = "Value")]
     #[serde(deserialize_with = "deserialize_nonoptional_vec")]
     pub value: Vec<String>,
-
 }
 
 /// The interface between Docker and the plugin
@@ -4311,12 +4200,11 @@ pub struct PluginConfigInterface {
     #[serde(rename = "ProtocolScheme")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub protocol_scheme: Option<PluginConfigInterfaceProtocolSchemeEnum>,
-
 }
 
 #[allow(non_camel_case_types)]
 #[derive(Debug, Clone, Copy, PartialEq, PartialOrd, Serialize, Deserialize, Eq, Ord)]
-pub enum PluginConfigInterfaceProtocolSchemeEnum { 
+pub enum PluginConfigInterfaceProtocolSchemeEnum {
     #[serde(rename = "")]
     EMPTY,
     #[serde(rename = "moby.plugins.http/v1")]
@@ -4325,10 +4213,11 @@ pub enum PluginConfigInterfaceProtocolSchemeEnum {
 
 impl ::std::fmt::Display for PluginConfigInterfaceProtocolSchemeEnum {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        match *self { 
+        match *self {
             PluginConfigInterfaceProtocolSchemeEnum::EMPTY => write!(f, "{}", ""),
-            PluginConfigInterfaceProtocolSchemeEnum::MOBY_PLUGINS_HTTP_V1 => write!(f, "{}", "moby.plugins.http/v1"),
-
+            PluginConfigInterfaceProtocolSchemeEnum::MOBY_PLUGINS_HTTP_V1 => {
+                write!(f, "{}", "moby.plugins.http/v1")
+            }
         }
     }
 }
@@ -4336,9 +4225,11 @@ impl ::std::fmt::Display for PluginConfigInterfaceProtocolSchemeEnum {
 impl ::std::str::FromStr for PluginConfigInterfaceProtocolSchemeEnum {
     type Err = String;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s { 
+        match s {
             "" => Ok(PluginConfigInterfaceProtocolSchemeEnum::EMPTY),
-            "moby.plugins.http/v1" => Ok(PluginConfigInterfaceProtocolSchemeEnum::MOBY_PLUGINS_HTTP_V1),
+            "moby.plugins.http/v1" => {
+                Ok(PluginConfigInterfaceProtocolSchemeEnum::MOBY_PLUGINS_HTTP_V1)
+            }
             x => Err(format!("Invalid enum type: {}", x)),
         }
     }
@@ -4346,7 +4237,7 @@ impl ::std::str::FromStr for PluginConfigInterfaceProtocolSchemeEnum {
 
 impl ::std::convert::AsRef<str> for PluginConfigInterfaceProtocolSchemeEnum {
     fn as_ref(&self) -> &str {
-        match self { 
+        match self {
             PluginConfigInterfaceProtocolSchemeEnum::EMPTY => "",
             PluginConfigInterfaceProtocolSchemeEnum::MOBY_PLUGINS_HTTP_V1 => "moby.plugins.http/v1",
         }
@@ -4365,14 +4256,12 @@ pub struct PluginConfigLinux {
     #[serde(rename = "Devices")]
     #[serde(deserialize_with = "deserialize_nonoptional_vec")]
     pub devices: Vec<PluginDevice>,
-
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 pub struct PluginConfigNetwork {
     #[serde(rename = "Type")]
     pub typ: String,
-
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
@@ -4384,7 +4273,6 @@ pub struct PluginConfigRootfs {
     #[serde(rename = "diff_ids")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub diff_ids: Option<Vec<String>>,
-
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
@@ -4396,7 +4284,6 @@ pub struct PluginConfigUser {
     #[serde(rename = "GID")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub gid: Option<u32>,
-
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
@@ -4413,7 +4300,6 @@ pub struct PluginDevice {
 
     #[serde(rename = "Path")]
     pub path: String,
-
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
@@ -4430,7 +4316,6 @@ pub struct PluginEnv {
 
     #[serde(rename = "Value")]
     pub value: String,
-
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
@@ -4443,7 +4328,6 @@ pub struct PluginInterfaceType {
 
     #[serde(rename = "Version")]
     pub version: String,
-
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
@@ -4470,10 +4354,9 @@ pub struct PluginMount {
     #[serde(rename = "Options")]
     #[serde(deserialize_with = "deserialize_nonoptional_vec")]
     pub options: Vec<String>,
-
 }
 
-/// Describes a permission the user has to accept upon installing the plugin. 
+/// Describes a permission the user has to accept upon installing the plugin.
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 pub struct PluginPrivilege {
     #[serde(rename = "Name")]
@@ -4487,7 +4370,6 @@ pub struct PluginPrivilege {
     #[serde(rename = "Value")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub value: Option<Vec<String>>,
-
 }
 
 /// Settings that can be modified by users.
@@ -4508,10 +4390,9 @@ pub struct PluginSettings {
     #[serde(rename = "Devices")]
     #[serde(deserialize_with = "deserialize_nonoptional_vec")]
     pub devices: Vec<PluginDevice>,
-
 }
 
-/// Available plugins per type.  <p><br /></p>  > **Note**: Only unmanaged (V1) plugins are included in this list. > V1 plugins are \"lazily\" loaded, and are not returned in this list > if there is no resource using the plugin. 
+/// Available plugins per type.  <p><br /></p>  > **Note**: Only unmanaged (V1) plugins are included in this list. > V1 plugins are \"lazily\" loaded, and are not returned in this list > if there is no resource using the plugin.
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 pub struct PluginsInfo {
     /// Names of available volume-drivers, and network-driver plugins.
@@ -4533,7 +4414,6 @@ pub struct PluginsInfo {
     #[serde(rename = "Log")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub log: Option<Vec<String>>,
-
 }
 
 /// An open port on a container
@@ -4557,12 +4437,11 @@ pub struct Port {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(with = "::serde_with::As::<::serde_with::NoneAsEmptyString>")]
     pub typ: Option<PortTypeEnum>,
-
 }
 
 #[allow(non_camel_case_types)]
 #[derive(Debug, Clone, Copy, PartialEq, PartialOrd, Serialize, Deserialize, Eq, Ord)]
-pub enum PortTypeEnum { 
+pub enum PortTypeEnum {
     #[serde(rename = "")]
     EMPTY,
     #[serde(rename = "tcp")]
@@ -4575,12 +4454,11 @@ pub enum PortTypeEnum {
 
 impl ::std::fmt::Display for PortTypeEnum {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        match *self { 
+        match *self {
             PortTypeEnum::EMPTY => write!(f, ""),
             PortTypeEnum::TCP => write!(f, "{}", "tcp"),
             PortTypeEnum::UDP => write!(f, "{}", "udp"),
             PortTypeEnum::SCTP => write!(f, "{}", "sctp"),
-
         }
     }
 }
@@ -4588,7 +4466,7 @@ impl ::std::fmt::Display for PortTypeEnum {
 impl ::std::str::FromStr for PortTypeEnum {
     type Err = String;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s { 
+        match s {
             "" => Ok(PortTypeEnum::EMPTY),
             "tcp" => Ok(PortTypeEnum::TCP),
             "udp" => Ok(PortTypeEnum::UDP),
@@ -4600,7 +4478,7 @@ impl ::std::str::FromStr for PortTypeEnum {
 
 impl ::std::convert::AsRef<str> for PortTypeEnum {
     fn as_ref(&self) -> &str {
-        match self { 
+        match self {
             PortTypeEnum::EMPTY => "",
             PortTypeEnum::TCP => "tcp",
             PortTypeEnum::UDP => "udp",
@@ -4609,7 +4487,7 @@ impl ::std::convert::AsRef<str> for PortTypeEnum {
     }
 }
 
-/// PortBinding represents a binding between a host IP address and a host port. 
+/// PortBinding represents a binding between a host IP address and a host port.
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 pub struct PortBinding {
     /// Host IP address that the container's port is mapped to.
@@ -4621,10 +4499,9 @@ pub struct PortBinding {
     #[serde(rename = "HostPort")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub host_port: Option<String>,
-
 }
 
-/// PortMap describes the mapping of container ports to host ports, using the container's port-number and protocol as key in the format `<port>/<protocol>`, for example, `80/udp`.  If a container's port is mapped for multiple protocols, separate entries are added to the mapping table. 
+/// PortMap describes the mapping of container ports to host ports, using the container's port-number and protocol as key in the format `<port>/<protocol>`, for example, `80/udp`.  If a container's port is mapped for multiple protocols, separate entries are added to the mapping table.
 // special-casing PortMap, cos swagger-codegen doesn't figure out this type
 pub type PortMap = HashMap<String, Option<Vec<PortBinding>>>;
 
@@ -4649,7 +4526,6 @@ pub struct ProcessConfig {
     #[serde(rename = "arguments")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub arguments: Option<Vec<String>>,
-
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
@@ -4661,7 +4537,6 @@ pub struct ProgressDetail {
     #[serde(rename = "total")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub total: Option<i64>,
-
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
@@ -4681,7 +4556,6 @@ pub struct PushImageInfo {
     #[serde(rename = "progressDetail")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub progress_detail: Option<ProgressDetail>,
-
 }
 
 /// Reachability represents the reachability of a node.
@@ -4691,7 +4565,7 @@ pub struct PushImageInfo {
 #[allow(non_camel_case_types)]
 #[repr(C)]
 #[derive(Debug, Clone, Copy, PartialEq, PartialOrd, Serialize, Deserialize, Eq, Ord)]
-pub enum Reachability { 
+pub enum Reachability {
     #[serde(rename = "unknown")]
     UNKNOWN,
     #[serde(rename = "unreachable")]
@@ -4702,7 +4576,7 @@ pub enum Reachability {
 
 impl ::std::fmt::Display for Reachability {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        match *self { 
+        match *self {
             Reachability::UNKNOWN => write!(f, "{}", "unknown"),
             Reachability::UNREACHABLE => write!(f, "{}", "unreachable"),
             Reachability::REACHABLE => write!(f, "{}", "reachable"),
@@ -4722,20 +4596,20 @@ impl ::std::str::FromStr for Reachability {
     }
 }
 
-/// RegistryServiceConfig stores daemon registry services configuration. 
+/// RegistryServiceConfig stores daemon registry services configuration.
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 pub struct RegistryServiceConfig {
-    /// List of IP ranges to which nondistributable artifacts can be pushed, using the CIDR syntax [RFC 4632](https://tools.ietf.org/html/4632).  Some images (for example, Windows base images) contain artifacts whose distribution is restricted by license. When these images are pushed to a registry, restricted artifacts are not included.  This configuration override this behavior, and enables the daemon to push nondistributable artifacts to all registries whose resolved IP address is within the subnet described by the CIDR syntax.  This option is useful when pushing images containing nondistributable artifacts to a registry on an air-gapped network so hosts on that network can pull the images without connecting to another server.  > **Warning**: Nondistributable artifacts typically have restrictions > on how and where they can be distributed and shared. Only use this > feature to push artifacts to private registries and ensure that you > are in compliance with any terms that cover redistributing > nondistributable artifacts. 
+    /// List of IP ranges to which nondistributable artifacts can be pushed, using the CIDR syntax [RFC 4632](https://tools.ietf.org/html/4632).  Some images (for example, Windows base images) contain artifacts whose distribution is restricted by license. When these images are pushed to a registry, restricted artifacts are not included.  This configuration override this behavior, and enables the daemon to push nondistributable artifacts to all registries whose resolved IP address is within the subnet described by the CIDR syntax.  This option is useful when pushing images containing nondistributable artifacts to a registry on an air-gapped network so hosts on that network can pull the images without connecting to another server.  > **Warning**: Nondistributable artifacts typically have restrictions > on how and where they can be distributed and shared. Only use this > feature to push artifacts to private registries and ensure that you > are in compliance with any terms that cover redistributing > nondistributable artifacts.
     #[serde(rename = "AllowNondistributableArtifactsCIDRs")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub allow_nondistributable_artifacts_cidrs: Option<Vec<String>>,
 
-    /// List of registry hostnames to which nondistributable artifacts can be pushed, using the format `<hostname>[:<port>]` or `<IP address>[:<port>]`.  Some images (for example, Windows base images) contain artifacts whose distribution is restricted by license. When these images are pushed to a registry, restricted artifacts are not included.  This configuration override this behavior for the specified registries.  This option is useful when pushing images containing nondistributable artifacts to a registry on an air-gapped network so hosts on that network can pull the images without connecting to another server.  > **Warning**: Nondistributable artifacts typically have restrictions > on how and where they can be distributed and shared. Only use this > feature to push artifacts to private registries and ensure that you > are in compliance with any terms that cover redistributing > nondistributable artifacts. 
+    /// List of registry hostnames to which nondistributable artifacts can be pushed, using the format `<hostname>[:<port>]` or `<IP address>[:<port>]`.  Some images (for example, Windows base images) contain artifacts whose distribution is restricted by license. When these images are pushed to a registry, restricted artifacts are not included.  This configuration override this behavior for the specified registries.  This option is useful when pushing images containing nondistributable artifacts to a registry on an air-gapped network so hosts on that network can pull the images without connecting to another server.  > **Warning**: Nondistributable artifacts typically have restrictions > on how and where they can be distributed and shared. Only use this > feature to push artifacts to private registries and ensure that you > are in compliance with any terms that cover redistributing > nondistributable artifacts.
     #[serde(rename = "AllowNondistributableArtifactsHostnames")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub allow_nondistributable_artifacts_hostnames: Option<Vec<String>>,
 
-    /// List of IP ranges of insecure registries, using the CIDR syntax ([RFC 4632](https://tools.ietf.org/html/4632)). Insecure registries accept un-encrypted (HTTP) and/or untrusted (HTTPS with certificates from unknown CAs) communication.  By default, local registries (`127.0.0.0/8`) are configured as insecure. All other registries are secure. Communicating with an insecure registry is not possible if the daemon assumes that registry is secure.  This configuration override this behavior, insecure communication with registries whose resolved IP address is within the subnet described by the CIDR syntax.  Registries can also be marked insecure by hostname. Those registries are listed under `IndexConfigs` and have their `Secure` field set to `false`.  > **Warning**: Using this option can be useful when running a local > registry, but introduces security vulnerabilities. This option > should therefore ONLY be used for testing purposes. For increased > security, users should add their CA to their system's list of trusted > CAs instead of enabling this option. 
+    /// List of IP ranges of insecure registries, using the CIDR syntax ([RFC 4632](https://tools.ietf.org/html/4632)). Insecure registries accept un-encrypted (HTTP) and/or untrusted (HTTPS with certificates from unknown CAs) communication.  By default, local registries (`127.0.0.0/8`) are configured as insecure. All other registries are secure. Communicating with an insecure registry is not possible if the daemon assumes that registry is secure.  This configuration override this behavior, insecure communication with registries whose resolved IP address is within the subnet described by the CIDR syntax.  Registries can also be marked insecure by hostname. Those registries are listed under `IndexConfigs` and have their `Secure` field set to `false`.  > **Warning**: Using this option can be useful when running a local > registry, but introduces security vulnerabilities. This option > should therefore ONLY be used for testing purposes. For increased > security, users should add their CA to their system's list of trusted > CAs instead of enabling this option.
     #[serde(rename = "InsecureRegistryCIDRs")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub insecure_registry_cidrs: Option<Vec<String>>,
@@ -4744,14 +4618,13 @@ pub struct RegistryServiceConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub index_configs: Option<HashMap<String, IndexInfo>>,
 
-    /// List of registry URLs that act as a mirror for the official (`docker.io`) registry. 
+    /// List of registry URLs that act as a mirror for the official (`docker.io`) registry.
     #[serde(rename = "Mirrors")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub mirrors: Option<Vec<String>>,
-
 }
 
-/// An object describing the resources which can be advertised by a node and requested by a task. 
+/// An object describing the resources which can be advertised by a node and requested by a task.
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 pub struct ResourceObject {
     #[serde(rename = "NanoCPUs")]
@@ -4765,13 +4638,12 @@ pub struct ResourceObject {
     #[serde(rename = "GenericResources")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub generic_resources: Option<GenericResources>,
-
 }
 
 /// A container's resources (cgroups config, ulimits, etc)
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 pub struct Resources {
-    /// An integer value representing this container's relative CPU weight versus other containers. 
+    /// An integer value representing this container's relative CPU weight versus other containers.
     #[serde(rename = "CpuShares")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cpu_shares: Option<i64>,
@@ -4781,7 +4653,7 @@ pub struct Resources {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub memory: Option<i64>,
 
-    /// Path to `cgroups` under which the container's `cgroup` is created. If the path is not absolute, the path is considered to be relative to the `cgroups` path of the init process. Cgroups are created if they do not already exist. 
+    /// Path to `cgroups` under which the container's `cgroup` is created. If the path is not absolute, the path is considered to be relative to the `cgroups` path of the init process. Cgroups are created if they do not already exist.
     #[serde(rename = "CgroupParent")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cgroup_parent: Option<String>,
@@ -4791,27 +4663,27 @@ pub struct Resources {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub blkio_weight: Option<u16>,
 
-    /// Block IO weight (relative device weight) in the form:  ``` [{\"Path\": \"device_path\", \"Weight\": weight}] ``` 
+    /// Block IO weight (relative device weight) in the form:  ``` [{\"Path\": \"device_path\", \"Weight\": weight}] ```
     #[serde(rename = "BlkioWeightDevice")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub blkio_weight_device: Option<Vec<ResourcesBlkioWeightDevice>>,
 
-    /// Limit read rate (bytes per second) from a device, in the form:  ``` [{\"Path\": \"device_path\", \"Rate\": rate}] ``` 
+    /// Limit read rate (bytes per second) from a device, in the form:  ``` [{\"Path\": \"device_path\", \"Rate\": rate}] ```
     #[serde(rename = "BlkioDeviceReadBps")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub blkio_device_read_bps: Option<Vec<ThrottleDevice>>,
 
-    /// Limit write rate (bytes per second) to a device, in the form:  ``` [{\"Path\": \"device_path\", \"Rate\": rate}] ``` 
+    /// Limit write rate (bytes per second) to a device, in the form:  ``` [{\"Path\": \"device_path\", \"Rate\": rate}] ```
     #[serde(rename = "BlkioDeviceWriteBps")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub blkio_device_write_bps: Option<Vec<ThrottleDevice>>,
 
-    /// Limit read rate (IO per second) from a device, in the form:  ``` [{\"Path\": \"device_path\", \"Rate\": rate}] ``` 
+    /// Limit read rate (IO per second) from a device, in the form:  ``` [{\"Path\": \"device_path\", \"Rate\": rate}] ```
     #[serde(rename = "BlkioDeviceReadIOps")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub blkio_device_read_iops: Option<Vec<ThrottleDevice>>,
 
-    /// Limit write rate (IO per second) to a device, in the form:  ``` [{\"Path\": \"device_path\", \"Rate\": rate}] ``` 
+    /// Limit write rate (IO per second) to a device, in the form:  ``` [{\"Path\": \"device_path\", \"Rate\": rate}] ```
     #[serde(rename = "BlkioDeviceWriteIOps")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub blkio_device_write_iops: Option<Vec<ThrottleDevice>>,
@@ -4821,27 +4693,27 @@ pub struct Resources {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cpu_period: Option<i64>,
 
-    /// Microseconds of CPU time that the container can get in a CPU period. 
+    /// Microseconds of CPU time that the container can get in a CPU period.
     #[serde(rename = "CpuQuota")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cpu_quota: Option<i64>,
 
-    /// The length of a CPU real-time period in microseconds. Set to 0 to allocate no time allocated to real-time tasks. 
+    /// The length of a CPU real-time period in microseconds. Set to 0 to allocate no time allocated to real-time tasks.
     #[serde(rename = "CpuRealtimePeriod")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cpu_realtime_period: Option<i64>,
 
-    /// The length of a CPU real-time runtime in microseconds. Set to 0 to allocate no time allocated to real-time tasks. 
+    /// The length of a CPU real-time runtime in microseconds. Set to 0 to allocate no time allocated to real-time tasks.
     #[serde(rename = "CpuRealtimeRuntime")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cpu_realtime_runtime: Option<i64>,
 
-    /// CPUs in which to allow execution (e.g., `0-3`, `0,1`). 
+    /// CPUs in which to allow execution (e.g., `0-3`, `0,1`).
     #[serde(rename = "CpusetCpus")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cpuset_cpus: Option<String>,
 
-    /// Memory nodes (MEMs) in which to allow execution (0-3, 0,1). Only effective on NUMA systems. 
+    /// Memory nodes (MEMs) in which to allow execution (0-3, 0,1). Only effective on NUMA systems.
     #[serde(rename = "CpusetMems")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cpuset_mems: Option<String>,
@@ -4856,12 +4728,12 @@ pub struct Resources {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub device_cgroup_rules: Option<Vec<String>>,
 
-    /// A list of requests for devices to be sent to device drivers. 
+    /// A list of requests for devices to be sent to device drivers.
     #[serde(rename = "DeviceRequests")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub device_requests: Option<Vec<DeviceRequest>>,
 
-    /// Hard limit for kernel TCP buffer memory (in bytes). Depending on the OCI runtime in use, this option may be ignored. It is no longer supported by the default (runc) runtime.  This field is omitted when empty. 
+    /// Hard limit for kernel TCP buffer memory (in bytes). Depending on the OCI runtime in use, this option may be ignored. It is no longer supported by the default (runc) runtime.  This field is omitted when empty.
     #[serde(rename = "KernelMemoryTCP")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub kernel_memory_tcp: Option<i64>,
@@ -4871,12 +4743,12 @@ pub struct Resources {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub memory_reservation: Option<i64>,
 
-    /// Total memory limit (memory + swap). Set as `-1` to enable unlimited swap. 
+    /// Total memory limit (memory + swap). Set as `-1` to enable unlimited swap.
     #[serde(rename = "MemorySwap")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub memory_swap: Option<i64>,
 
-    /// Tune a container's memory swappiness behavior. Accepts an integer between 0 and 100. 
+    /// Tune a container's memory swappiness behavior. Accepts an integer between 0 and 100.
     #[serde(rename = "MemorySwappiness")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub memory_swappiness: Option<i64>,
@@ -4891,27 +4763,27 @@ pub struct Resources {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub oom_kill_disable: Option<bool>,
 
-    /// Run an init inside the container that forwards signals and reaps processes. This field is omitted if empty, and the default (as configured on the daemon) is used. 
+    /// Run an init inside the container that forwards signals and reaps processes. This field is omitted if empty, and the default (as configured on the daemon) is used.
     #[serde(rename = "Init")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub init: Option<bool>,
 
-    /// Tune a container's PIDs limit. Set `0` or `-1` for unlimited, or `null` to not change. 
+    /// Tune a container's PIDs limit. Set `0` or `-1` for unlimited, or `null` to not change.
     #[serde(rename = "PidsLimit")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub pids_limit: Option<i64>,
 
-    /// A list of resource limits to set in the container. For example:  ``` {\"Name\": \"nofile\", \"Soft\": 1024, \"Hard\": 2048} ``` 
+    /// A list of resource limits to set in the container. For example:  ``` {\"Name\": \"nofile\", \"Soft\": 1024, \"Hard\": 2048} ```
     #[serde(rename = "Ulimits")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub ulimits: Option<Vec<ResourcesUlimits>>,
 
-    /// The number of usable CPUs (Windows only).  On Windows Server containers, the processor resource controls are mutually exclusive. The order of precedence is `CPUCount` first, then `CPUShares`, and `CPUPercent` last. 
+    /// The number of usable CPUs (Windows only).  On Windows Server containers, the processor resource controls are mutually exclusive. The order of precedence is `CPUCount` first, then `CPUShares`, and `CPUPercent` last.
     #[serde(rename = "CpuCount")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cpu_count: Option<i64>,
 
-    /// The usable percentage of the available CPUs (Windows only).  On Windows Server containers, the processor resource controls are mutually exclusive. The order of precedence is `CPUCount` first, then `CPUShares`, and `CPUPercent` last. 
+    /// The usable percentage of the available CPUs (Windows only).  On Windows Server containers, the processor resource controls are mutually exclusive. The order of precedence is `CPUCount` first, then `CPUShares`, and `CPUPercent` last.
     #[serde(rename = "CpuPercent")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cpu_percent: Option<i64>,
@@ -4921,11 +4793,10 @@ pub struct Resources {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub io_maximum_iops: Option<i64>,
 
-    /// Maximum IO in bytes per second for the container system drive (Windows only). 
+    /// Maximum IO in bytes per second for the container system drive (Windows only).
     #[serde(rename = "IOMaximumBandwidth")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub io_maximum_bandwidth: Option<i64>,
-
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
@@ -4937,7 +4808,6 @@ pub struct ResourcesBlkioWeightDevice {
     #[serde(rename = "Weight")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub weight: Option<usize>,
-
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
@@ -4956,27 +4826,25 @@ pub struct ResourcesUlimits {
     #[serde(rename = "Hard")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub hard: Option<i64>,
-
 }
 
-/// The behavior to apply when the container exits. The default is not to restart.  An ever increasing delay (double the previous delay, starting at 100ms) is added before each restart to prevent flooding the server. 
+/// The behavior to apply when the container exits. The default is not to restart.  An ever increasing delay (double the previous delay, starting at 100ms) is added before each restart to prevent flooding the server.
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 pub struct RestartPolicy {
-    /// - Empty string means not to restart - `no` Do not automatically restart - `always` Always restart - `unless-stopped` Restart always except when the user has manually stopped the container - `on-failure` Restart only when the container exit code is non-zero 
+    /// - Empty string means not to restart - `no` Do not automatically restart - `always` Always restart - `unless-stopped` Restart always except when the user has manually stopped the container - `on-failure` Restart only when the container exit code is non-zero
     #[serde(rename = "Name")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<RestartPolicyNameEnum>,
 
-    /// If `on-failure` is used, the number of times to retry before giving up. 
+    /// If `on-failure` is used, the number of times to retry before giving up.
     #[serde(rename = "MaximumRetryCount")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub maximum_retry_count: Option<i64>,
-
 }
 
 #[allow(non_camel_case_types)]
 #[derive(Debug, Clone, Copy, PartialEq, PartialOrd, Serialize, Deserialize, Eq, Ord)]
-pub enum RestartPolicyNameEnum { 
+pub enum RestartPolicyNameEnum {
     #[serde(rename = "")]
     EMPTY,
     #[serde(rename = "no")]
@@ -4991,13 +4859,12 @@ pub enum RestartPolicyNameEnum {
 
 impl ::std::fmt::Display for RestartPolicyNameEnum {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        match *self { 
+        match *self {
             RestartPolicyNameEnum::EMPTY => write!(f, "{}", ""),
             RestartPolicyNameEnum::NO => write!(f, "{}", "no"),
             RestartPolicyNameEnum::ALWAYS => write!(f, "{}", "always"),
             RestartPolicyNameEnum::UNLESS_STOPPED => write!(f, "{}", "unless-stopped"),
             RestartPolicyNameEnum::ON_FAILURE => write!(f, "{}", "on-failure"),
-
         }
     }
 }
@@ -5005,7 +4872,7 @@ impl ::std::fmt::Display for RestartPolicyNameEnum {
 impl ::std::str::FromStr for RestartPolicyNameEnum {
     type Err = String;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s { 
+        match s {
             "" => Ok(RestartPolicyNameEnum::EMPTY),
             "no" => Ok(RestartPolicyNameEnum::NO),
             "always" => Ok(RestartPolicyNameEnum::ALWAYS),
@@ -5018,7 +4885,7 @@ impl ::std::str::FromStr for RestartPolicyNameEnum {
 
 impl ::std::convert::AsRef<str> for RestartPolicyNameEnum {
     fn as_ref(&self) -> &str {
-        match self { 
+        match self {
             RestartPolicyNameEnum::EMPTY => "",
             RestartPolicyNameEnum::NO => "no",
             RestartPolicyNameEnum::ALWAYS => "always",
@@ -5028,19 +4895,18 @@ impl ::std::convert::AsRef<str> for RestartPolicyNameEnum {
     }
 }
 
-/// Runtime describes an [OCI compliant](https://github.com/opencontainers/runtime-spec) runtime.  The runtime is invoked by the daemon via the `containerd` daemon. OCI runtimes act as an interface to the Linux kernel namespaces, cgroups, and SELinux. 
+/// Runtime describes an [OCI compliant](https://github.com/opencontainers/runtime-spec) runtime.  The runtime is invoked by the daemon via the `containerd` daemon. OCI runtimes act as an interface to the Linux kernel namespaces, cgroups, and SELinux.
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 pub struct Runtime {
-    /// Name and, optional, path, of the OCI executable binary.  If the path is omitted, the daemon searches the host's `$PATH` for the binary and uses the first result. 
+    /// Name and, optional, path, of the OCI executable binary.  If the path is omitted, the daemon searches the host's `$PATH` for the binary and uses the first result.
     #[serde(rename = "path")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub path: Option<String>,
 
-    /// List of command-line arguments to pass to the runtime when invoked. 
+    /// List of command-line arguments to pass to the runtime when invoked.
     #[serde(rename = "runtimeArgs")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub runtime_args: Option<Vec<String>>,
-
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
@@ -5074,7 +4940,6 @@ pub struct Secret {
     #[serde(rename = "Spec")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub spec: Option<SecretSpec>,
-
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
@@ -5089,21 +4954,20 @@ pub struct SecretSpec {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub labels: Option<HashMap<String, String>>,
 
-    /// Base64-url-safe-encoded ([RFC 4648](https://tools.ietf.org/html/rfc4648#section-5)) data to store as secret.  This field is only used to _create_ a secret, and is not returned by other endpoints. 
+    /// Base64-url-safe-encoded ([RFC 4648](https://tools.ietf.org/html/rfc4648#section-5)) data to store as secret.  This field is only used to _create_ a secret, and is not returned by other endpoints.
     #[serde(rename = "Data")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub data: Option<String>,
 
-    /// Name of the secrets driver used to fetch the secret's value from an external secret store. 
+    /// Name of the secrets driver used to fetch the secret's value from an external secret store.
     #[serde(rename = "Driver")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub driver: Option<Driver>,
 
-    /// Templating driver, if applicable  Templating controls whether and how to evaluate the config payload as a template. If no driver is set, no templating is used. 
+    /// Templating driver, if applicable  Templating controls whether and how to evaluate the config payload as a template. If no driver is set, no templating is used.
     #[serde(rename = "Templating")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub templating: Option<Driver>,
-
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
@@ -5153,7 +5017,6 @@ pub struct Service {
     #[serde(rename = "JobStatus")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub job_status: Option<ServiceJobStatus>,
-
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
@@ -5167,7 +5030,6 @@ pub struct ServiceCreateResponse {
     #[serde(rename = "Warning")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub warning: Option<String>,
-
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
@@ -5183,7 +5045,6 @@ pub struct ServiceEndpoint {
     #[serde(rename = "VirtualIPs")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub virtual_ips: Option<Vec<ServiceEndpointVirtualIps>>,
-
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
@@ -5195,18 +5056,17 @@ pub struct ServiceEndpointVirtualIps {
     #[serde(rename = "Addr")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub addr: Option<String>,
-
 }
 
-/// The status of the service when it is in one of ReplicatedJob or GlobalJob modes. Absent on Replicated and Global mode services. The JobIteration is an ObjectVersion, but unlike the Service's version, does not need to be sent with an update request. 
+/// The status of the service when it is in one of ReplicatedJob or GlobalJob modes. Absent on Replicated and Global mode services. The JobIteration is an ObjectVersion, but unlike the Service's version, does not need to be sent with an update request.
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 pub struct ServiceJobStatus {
-    /// JobIteration is a value increased each time a Job is executed, successfully or otherwise. \"Executed\", in this case, means the job as a whole has been started, not that an individual Task has been launched. A job is \"Executed\" when its ServiceSpec is updated. JobIteration can be used to disambiguate Tasks belonging to different executions of a job.  Though JobIteration will increase with each subsequent execution, it may not necessarily increase by 1, and so JobIteration should not be used to 
+    /// JobIteration is a value increased each time a Job is executed, successfully or otherwise. \"Executed\", in this case, means the job as a whole has been started, not that an individual Task has been launched. A job is \"Executed\" when its ServiceSpec is updated. JobIteration can be used to disambiguate Tasks belonging to different executions of a job.  Though JobIteration will increase with each subsequent execution, it may not necessarily increase by 1, and so JobIteration should not be used to
     #[serde(rename = "JobIteration")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub job_iteration: Option<ObjectVersion>,
 
-    /// The last time, as observed by the server, that this job was started. 
+    /// The last time, as observed by the server, that this job was started.
     #[serde(rename = "LastExecution")]
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(
@@ -5215,27 +5075,25 @@ pub struct ServiceJobStatus {
         serialize_with = "serialize_timestamp"
     )]
     pub last_execution: Option<BollardDate>,
-
 }
 
-/// The status of the service's tasks. Provided only when requested as part of a ServiceList operation. 
+/// The status of the service's tasks. Provided only when requested as part of a ServiceList operation.
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 pub struct ServiceServiceStatus {
-    /// The number of tasks for the service currently in the Running state. 
+    /// The number of tasks for the service currently in the Running state.
     #[serde(rename = "RunningTasks")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub running_tasks: Option<u64>,
 
-    /// The number of tasks for the service desired to be running. For replicated services, this is the replica count from the service spec. For global services, this is computed by taking count of all tasks for the service with a Desired State other than Shutdown. 
+    /// The number of tasks for the service desired to be running. For replicated services, this is the replica count from the service spec. For global services, this is computed by taking count of all tasks for the service with a Desired State other than Shutdown.
     #[serde(rename = "DesiredTasks")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub desired_tasks: Option<u64>,
 
-    /// The number of tasks for a job that are in the Completed state. This field must be cross-referenced with the service type, as the value of 0 may mean the service is not in a job mode, or it may mean the job-mode service has no tasks yet Completed. 
+    /// The number of tasks for a job that are in the Completed state. This field must be cross-referenced with the service type, as the value of 0 may mean the service is not in a job mode, or it may mean the job-mode service has no tasks yet Completed.
     #[serde(rename = "CompletedTasks")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub completed_tasks: Option<u64>,
-
 }
 
 /// User modifiable configuration for a service.
@@ -5275,7 +5133,6 @@ pub struct ServiceSpec {
     #[serde(rename = "EndpointSpec")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub endpoint_spec: Option<EndpointSpec>,
-
 }
 
 /// Scheduling mode for the service.
@@ -5293,11 +5150,10 @@ pub struct ServiceSpecMode {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub replicated_job: Option<ServiceSpecModeReplicatedJob>,
 
-    /// The mode used for services which run a task to the completed state on each valid node. 
+    /// The mode used for services which run a task to the completed state on each valid node.
     #[serde(rename = "GlobalJob")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub global_job: Option<HashMap<(), ()>>,
-
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
@@ -5305,62 +5161,59 @@ pub struct ServiceSpecModeReplicated {
     #[serde(rename = "Replicas")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub replicas: Option<i64>,
-
 }
 
-/// The mode used for services with a finite number of tasks that run to a completed state. 
+/// The mode used for services with a finite number of tasks that run to a completed state.
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 pub struct ServiceSpecModeReplicatedJob {
-    /// The maximum number of replicas to run simultaneously. 
+    /// The maximum number of replicas to run simultaneously.
     #[serde(rename = "MaxConcurrent")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub max_concurrent: Option<i64>,
 
-    /// The total number of replicas desired to reach the Completed state. If unset, will default to the value of `MaxConcurrent` 
+    /// The total number of replicas desired to reach the Completed state. If unset, will default to the value of `MaxConcurrent`
     #[serde(rename = "TotalCompletions")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub total_completions: Option<i64>,
-
 }
 
 /// Specification for the rollback strategy of the service.
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 pub struct ServiceSpecRollbackConfig {
-    /// Maximum number of tasks to be rolled back in one iteration (0 means unlimited parallelism). 
+    /// Maximum number of tasks to be rolled back in one iteration (0 means unlimited parallelism).
     #[serde(rename = "Parallelism")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub parallelism: Option<i64>,
 
-    /// Amount of time between rollback iterations, in nanoseconds. 
+    /// Amount of time between rollback iterations, in nanoseconds.
     #[serde(rename = "Delay")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub delay: Option<i64>,
 
-    /// Action to take if an rolled back task fails to run, or stops running during the rollback. 
+    /// Action to take if an rolled back task fails to run, or stops running during the rollback.
     #[serde(rename = "FailureAction")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub failure_action: Option<ServiceSpecRollbackConfigFailureActionEnum>,
 
-    /// Amount of time to monitor each rolled back task for failures, in nanoseconds. 
+    /// Amount of time to monitor each rolled back task for failures, in nanoseconds.
     #[serde(rename = "Monitor")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub monitor: Option<i64>,
 
-    /// The fraction of tasks that may fail during a rollback before the failure action is invoked, specified as a floating point number between 0 and 1. 
+    /// The fraction of tasks that may fail during a rollback before the failure action is invoked, specified as a floating point number between 0 and 1.
     #[serde(rename = "MaxFailureRatio")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub max_failure_ratio: Option<f64>,
 
-    /// The order of operations when rolling back a task. Either the old task is shut down before the new task is started, or the new task is started before the old task is shut down. 
+    /// The order of operations when rolling back a task. Either the old task is shut down before the new task is started, or the new task is started before the old task is shut down.
     #[serde(rename = "Order")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub order: Option<ServiceSpecRollbackConfigOrderEnum>,
-
 }
 
 #[allow(non_camel_case_types)]
 #[derive(Debug, Clone, Copy, PartialEq, PartialOrd, Serialize, Deserialize, Eq, Ord)]
-pub enum ServiceSpecRollbackConfigFailureActionEnum { 
+pub enum ServiceSpecRollbackConfigFailureActionEnum {
     #[serde(rename = "")]
     EMPTY,
     #[serde(rename = "continue")]
@@ -5371,11 +5224,10 @@ pub enum ServiceSpecRollbackConfigFailureActionEnum {
 
 impl ::std::fmt::Display for ServiceSpecRollbackConfigFailureActionEnum {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        match *self { 
+        match *self {
             ServiceSpecRollbackConfigFailureActionEnum::EMPTY => write!(f, ""),
             ServiceSpecRollbackConfigFailureActionEnum::CONTINUE => write!(f, "{}", "continue"),
             ServiceSpecRollbackConfigFailureActionEnum::PAUSE => write!(f, "{}", "pause"),
-
         }
     }
 }
@@ -5383,7 +5235,7 @@ impl ::std::fmt::Display for ServiceSpecRollbackConfigFailureActionEnum {
 impl ::std::str::FromStr for ServiceSpecRollbackConfigFailureActionEnum {
     type Err = String;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s { 
+        match s {
             "" => Ok(ServiceSpecRollbackConfigFailureActionEnum::EMPTY),
             "continue" => Ok(ServiceSpecRollbackConfigFailureActionEnum::CONTINUE),
             "pause" => Ok(ServiceSpecRollbackConfigFailureActionEnum::PAUSE),
@@ -5394,7 +5246,7 @@ impl ::std::str::FromStr for ServiceSpecRollbackConfigFailureActionEnum {
 
 impl ::std::convert::AsRef<str> for ServiceSpecRollbackConfigFailureActionEnum {
     fn as_ref(&self) -> &str {
-        match self { 
+        match self {
             ServiceSpecRollbackConfigFailureActionEnum::EMPTY => "",
             ServiceSpecRollbackConfigFailureActionEnum::CONTINUE => "continue",
             ServiceSpecRollbackConfigFailureActionEnum::PAUSE => "pause",
@@ -5404,7 +5256,7 @@ impl ::std::convert::AsRef<str> for ServiceSpecRollbackConfigFailureActionEnum {
 
 #[allow(non_camel_case_types)]
 #[derive(Debug, Clone, Copy, PartialEq, PartialOrd, Serialize, Deserialize, Eq, Ord)]
-pub enum ServiceSpecRollbackConfigOrderEnum { 
+pub enum ServiceSpecRollbackConfigOrderEnum {
     #[serde(rename = "")]
     EMPTY,
     #[serde(rename = "stop-first")]
@@ -5415,11 +5267,10 @@ pub enum ServiceSpecRollbackConfigOrderEnum {
 
 impl ::std::fmt::Display for ServiceSpecRollbackConfigOrderEnum {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        match *self { 
+        match *self {
             ServiceSpecRollbackConfigOrderEnum::EMPTY => write!(f, ""),
             ServiceSpecRollbackConfigOrderEnum::STOP_FIRST => write!(f, "{}", "stop-first"),
             ServiceSpecRollbackConfigOrderEnum::START_FIRST => write!(f, "{}", "start-first"),
-
         }
     }
 }
@@ -5427,7 +5278,7 @@ impl ::std::fmt::Display for ServiceSpecRollbackConfigOrderEnum {
 impl ::std::str::FromStr for ServiceSpecRollbackConfigOrderEnum {
     type Err = String;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s { 
+        match s {
             "" => Ok(ServiceSpecRollbackConfigOrderEnum::EMPTY),
             "stop-first" => Ok(ServiceSpecRollbackConfigOrderEnum::STOP_FIRST),
             "start-first" => Ok(ServiceSpecRollbackConfigOrderEnum::START_FIRST),
@@ -5438,7 +5289,7 @@ impl ::std::str::FromStr for ServiceSpecRollbackConfigOrderEnum {
 
 impl ::std::convert::AsRef<str> for ServiceSpecRollbackConfigOrderEnum {
     fn as_ref(&self) -> &str {
-        match self { 
+        match self {
             ServiceSpecRollbackConfigOrderEnum::EMPTY => "",
             ServiceSpecRollbackConfigOrderEnum::STOP_FIRST => "stop-first",
             ServiceSpecRollbackConfigOrderEnum::START_FIRST => "start-first",
@@ -5449,7 +5300,7 @@ impl ::std::convert::AsRef<str> for ServiceSpecRollbackConfigOrderEnum {
 /// Specification for the update strategy of the service.
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 pub struct ServiceSpecUpdateConfig {
-    /// Maximum number of tasks to be updated in one iteration (0 means unlimited parallelism). 
+    /// Maximum number of tasks to be updated in one iteration (0 means unlimited parallelism).
     #[serde(rename = "Parallelism")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub parallelism: Option<i64>,
@@ -5459,31 +5310,30 @@ pub struct ServiceSpecUpdateConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub delay: Option<i64>,
 
-    /// Action to take if an updated task fails to run, or stops running during the update. 
+    /// Action to take if an updated task fails to run, or stops running during the update.
     #[serde(rename = "FailureAction")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub failure_action: Option<ServiceSpecUpdateConfigFailureActionEnum>,
 
-    /// Amount of time to monitor each updated task for failures, in nanoseconds. 
+    /// Amount of time to monitor each updated task for failures, in nanoseconds.
     #[serde(rename = "Monitor")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub monitor: Option<i64>,
 
-    /// The fraction of tasks that may fail during an update before the failure action is invoked, specified as a floating point number between 0 and 1. 
+    /// The fraction of tasks that may fail during an update before the failure action is invoked, specified as a floating point number between 0 and 1.
     #[serde(rename = "MaxFailureRatio")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub max_failure_ratio: Option<f64>,
 
-    /// The order of operations when rolling out an updated task. Either the old task is shut down before the new task is started, or the new task is started before the old task is shut down. 
+    /// The order of operations when rolling out an updated task. Either the old task is shut down before the new task is started, or the new task is started before the old task is shut down.
     #[serde(rename = "Order")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub order: Option<ServiceSpecUpdateConfigOrderEnum>,
-
 }
 
 #[allow(non_camel_case_types)]
 #[derive(Debug, Clone, Copy, PartialEq, PartialOrd, Serialize, Deserialize, Eq, Ord)]
-pub enum ServiceSpecUpdateConfigFailureActionEnum { 
+pub enum ServiceSpecUpdateConfigFailureActionEnum {
     #[serde(rename = "")]
     EMPTY,
     #[serde(rename = "continue")]
@@ -5496,12 +5346,11 @@ pub enum ServiceSpecUpdateConfigFailureActionEnum {
 
 impl ::std::fmt::Display for ServiceSpecUpdateConfigFailureActionEnum {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        match *self { 
+        match *self {
             ServiceSpecUpdateConfigFailureActionEnum::EMPTY => write!(f, ""),
             ServiceSpecUpdateConfigFailureActionEnum::CONTINUE => write!(f, "{}", "continue"),
             ServiceSpecUpdateConfigFailureActionEnum::PAUSE => write!(f, "{}", "pause"),
             ServiceSpecUpdateConfigFailureActionEnum::ROLLBACK => write!(f, "{}", "rollback"),
-
         }
     }
 }
@@ -5509,7 +5358,7 @@ impl ::std::fmt::Display for ServiceSpecUpdateConfigFailureActionEnum {
 impl ::std::str::FromStr for ServiceSpecUpdateConfigFailureActionEnum {
     type Err = String;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s { 
+        match s {
             "" => Ok(ServiceSpecUpdateConfigFailureActionEnum::EMPTY),
             "continue" => Ok(ServiceSpecUpdateConfigFailureActionEnum::CONTINUE),
             "pause" => Ok(ServiceSpecUpdateConfigFailureActionEnum::PAUSE),
@@ -5521,7 +5370,7 @@ impl ::std::str::FromStr for ServiceSpecUpdateConfigFailureActionEnum {
 
 impl ::std::convert::AsRef<str> for ServiceSpecUpdateConfigFailureActionEnum {
     fn as_ref(&self) -> &str {
-        match self { 
+        match self {
             ServiceSpecUpdateConfigFailureActionEnum::EMPTY => "",
             ServiceSpecUpdateConfigFailureActionEnum::CONTINUE => "continue",
             ServiceSpecUpdateConfigFailureActionEnum::PAUSE => "pause",
@@ -5532,7 +5381,7 @@ impl ::std::convert::AsRef<str> for ServiceSpecUpdateConfigFailureActionEnum {
 
 #[allow(non_camel_case_types)]
 #[derive(Debug, Clone, Copy, PartialEq, PartialOrd, Serialize, Deserialize, Eq, Ord)]
-pub enum ServiceSpecUpdateConfigOrderEnum { 
+pub enum ServiceSpecUpdateConfigOrderEnum {
     #[serde(rename = "")]
     EMPTY,
     #[serde(rename = "stop-first")]
@@ -5543,11 +5392,10 @@ pub enum ServiceSpecUpdateConfigOrderEnum {
 
 impl ::std::fmt::Display for ServiceSpecUpdateConfigOrderEnum {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        match *self { 
+        match *self {
             ServiceSpecUpdateConfigOrderEnum::EMPTY => write!(f, ""),
             ServiceSpecUpdateConfigOrderEnum::STOP_FIRST => write!(f, "{}", "stop-first"),
             ServiceSpecUpdateConfigOrderEnum::START_FIRST => write!(f, "{}", "start-first"),
-
         }
     }
 }
@@ -5555,7 +5403,7 @@ impl ::std::fmt::Display for ServiceSpecUpdateConfigOrderEnum {
 impl ::std::str::FromStr for ServiceSpecUpdateConfigOrderEnum {
     type Err = String;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s { 
+        match s {
             "" => Ok(ServiceSpecUpdateConfigOrderEnum::EMPTY),
             "stop-first" => Ok(ServiceSpecUpdateConfigOrderEnum::STOP_FIRST),
             "start-first" => Ok(ServiceSpecUpdateConfigOrderEnum::START_FIRST),
@@ -5566,7 +5414,7 @@ impl ::std::str::FromStr for ServiceSpecUpdateConfigOrderEnum {
 
 impl ::std::convert::AsRef<str> for ServiceSpecUpdateConfigOrderEnum {
     fn as_ref(&self) -> &str {
-        match self { 
+        match self {
             ServiceSpecUpdateConfigOrderEnum::EMPTY => "",
             ServiceSpecUpdateConfigOrderEnum::STOP_FIRST => "stop-first",
             ServiceSpecUpdateConfigOrderEnum::START_FIRST => "start-first",
@@ -5580,7 +5428,6 @@ pub struct ServiceUpdateResponse {
     #[serde(rename = "Warnings")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub warnings: Option<Vec<String>>,
-
 }
 
 /// The status of a service update.
@@ -5611,12 +5458,11 @@ pub struct ServiceUpdateStatus {
     #[serde(rename = "Message")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub message: Option<String>,
-
 }
 
 #[allow(non_camel_case_types)]
 #[derive(Debug, Clone, Copy, PartialEq, PartialOrd, Serialize, Deserialize, Eq, Ord)]
-pub enum ServiceUpdateStatusStateEnum { 
+pub enum ServiceUpdateStatusStateEnum {
     #[serde(rename = "")]
     EMPTY,
     #[serde(rename = "updating")]
@@ -5635,15 +5481,16 @@ pub enum ServiceUpdateStatusStateEnum {
 
 impl ::std::fmt::Display for ServiceUpdateStatusStateEnum {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        match *self { 
+        match *self {
             ServiceUpdateStatusStateEnum::EMPTY => write!(f, ""),
             ServiceUpdateStatusStateEnum::UPDATING => write!(f, "{}", "updating"),
             ServiceUpdateStatusStateEnum::PAUSED => write!(f, "{}", "paused"),
             ServiceUpdateStatusStateEnum::COMPLETED => write!(f, "{}", "completed"),
             ServiceUpdateStatusStateEnum::ROLLBACK_STARTED => write!(f, "{}", "rollback_started"),
             ServiceUpdateStatusStateEnum::ROLLBACK_PAUSED => write!(f, "{}", "rollback_paused"),
-            ServiceUpdateStatusStateEnum::ROLLBACK_COMPLETED => write!(f, "{}", "rollback_completed"),
-
+            ServiceUpdateStatusStateEnum::ROLLBACK_COMPLETED => {
+                write!(f, "{}", "rollback_completed")
+            }
         }
     }
 }
@@ -5651,7 +5498,7 @@ impl ::std::fmt::Display for ServiceUpdateStatusStateEnum {
 impl ::std::str::FromStr for ServiceUpdateStatusStateEnum {
     type Err = String;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s { 
+        match s {
             "" => Ok(ServiceUpdateStatusStateEnum::EMPTY),
             "updating" => Ok(ServiceUpdateStatusStateEnum::UPDATING),
             "paused" => Ok(ServiceUpdateStatusStateEnum::PAUSED),
@@ -5666,7 +5513,7 @@ impl ::std::str::FromStr for ServiceUpdateStatusStateEnum {
 
 impl ::std::convert::AsRef<str> for ServiceUpdateStatusStateEnum {
     fn as_ref(&self) -> &str {
-        match self { 
+        match self {
             ServiceUpdateStatusStateEnum::EMPTY => "",
             ServiceUpdateStatusStateEnum::UPDATING => "updating",
             ServiceUpdateStatusStateEnum::PAUSED => "paused",
@@ -5689,7 +5536,7 @@ pub struct Swarm {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub version: Option<ObjectVersion>,
 
-    /// Date and time at which the swarm was initialised in [RFC 3339](https://www.ietf.org/rfc/rfc3339.txt) format with nano-seconds. 
+    /// Date and time at which the swarm was initialised in [RFC 3339](https://www.ietf.org/rfc/rfc3339.txt) format with nano-seconds.
     #[serde(rename = "CreatedAt")]
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(
@@ -5699,7 +5546,7 @@ pub struct Swarm {
     )]
     pub created_at: Option<BollardDate>,
 
-    /// Date and time at which the swarm was last updated in [RFC 3339](https://www.ietf.org/rfc/rfc3339.txt) format with nano-seconds. 
+    /// Date and time at which the swarm was last updated in [RFC 3339](https://www.ietf.org/rfc/rfc3339.txt) format with nano-seconds.
     #[serde(rename = "UpdatedAt")]
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(
@@ -5717,22 +5564,22 @@ pub struct Swarm {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub tls_info: Option<TlsInfo>,
 
-    /// Whether there is currently a root CA rotation in progress for the swarm 
+    /// Whether there is currently a root CA rotation in progress for the swarm
     #[serde(rename = "RootRotationInProgress")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub root_rotation_in_progress: Option<bool>,
 
-    /// DataPathPort specifies the data path port number for data traffic. Acceptable port range is 1024 to 49151. If no port is set or is set to 0, the default port (4789) is used. 
+    /// DataPathPort specifies the data path port number for data traffic. Acceptable port range is 1024 to 49151. If no port is set or is set to 0, the default port (4789) is used.
     #[serde(rename = "DataPathPort")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub data_path_port: Option<u32>,
 
-    /// Default Address Pool specifies default subnet pools for global scope networks. 
+    /// Default Address Pool specifies default subnet pools for global scope networks.
     #[serde(rename = "DefaultAddrPool")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub default_addr_pool: Option<Vec<String>>,
 
-    /// SubnetSize specifies the subnet size of the networks created from the default subnet pool. 
+    /// SubnetSize specifies the subnet size of the networks created from the default subnet pool.
     #[serde(rename = "SubnetSize")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub subnet_size: Option<u32>,
@@ -5740,10 +5587,9 @@ pub struct Swarm {
     #[serde(rename = "JoinTokens")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub join_tokens: Option<JoinTokens>,
-
 }
 
-/// Represents generic information about swarm. 
+/// Represents generic information about swarm.
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 pub struct SwarmInfo {
     /// Unique identifier of for this node in the swarm.
@@ -5751,7 +5597,7 @@ pub struct SwarmInfo {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub node_id: Option<String>,
 
-    /// IP address at which this node can be reached by other nodes in the swarm. 
+    /// IP address at which this node can be reached by other nodes in the swarm.
     #[serde(rename = "NodeAddr")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub node_addr: Option<String>,
@@ -5768,7 +5614,7 @@ pub struct SwarmInfo {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub error: Option<String>,
 
-    /// List of ID's and addresses of other managers in the swarm. 
+    /// List of ID's and addresses of other managers in the swarm.
     #[serde(rename = "RemoteManagers")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub remote_managers: Option<Vec<PeerNode>>,
@@ -5786,32 +5632,31 @@ pub struct SwarmInfo {
     #[serde(rename = "Cluster")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cluster: Option<ClusterInfo>,
-
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 pub struct SwarmInitRequest {
-    /// Listen address used for inter-manager communication, as well as determining the networking interface used for the VXLAN Tunnel Endpoint (VTEP). This can either be an address/port combination in the form `192.168.1.1:4567`, or an interface followed by a port number, like `eth0:4567`. If the port number is omitted, the default swarm listening port is used. 
+    /// Listen address used for inter-manager communication, as well as determining the networking interface used for the VXLAN Tunnel Endpoint (VTEP). This can either be an address/port combination in the form `192.168.1.1:4567`, or an interface followed by a port number, like `eth0:4567`. If the port number is omitted, the default swarm listening port is used.
     #[serde(rename = "ListenAddr")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub listen_addr: Option<String>,
 
-    /// Externally reachable address advertised to other nodes. This can either be an address/port combination in the form `192.168.1.1:4567`, or an interface followed by a port number, like `eth0:4567`. If the port number is omitted, the port number from the listen address is used. If `AdvertiseAddr` is not specified, it will be automatically detected when possible. 
+    /// Externally reachable address advertised to other nodes. This can either be an address/port combination in the form `192.168.1.1:4567`, or an interface followed by a port number, like `eth0:4567`. If the port number is omitted, the port number from the listen address is used. If `AdvertiseAddr` is not specified, it will be automatically detected when possible.
     #[serde(rename = "AdvertiseAddr")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub advertise_addr: Option<String>,
 
-    /// Address or interface to use for data path traffic (format: `<ip|interface>`), for example,  `192.168.1.1`, or an interface, like `eth0`. If `DataPathAddr` is unspecified, the same address as `AdvertiseAddr` is used.  The `DataPathAddr` specifies the address that global scope network drivers will publish towards other  nodes in order to reach the containers running on this node. Using this parameter it is possible to separate the container data traffic from the management traffic of the cluster. 
+    /// Address or interface to use for data path traffic (format: `<ip|interface>`), for example,  `192.168.1.1`, or an interface, like `eth0`. If `DataPathAddr` is unspecified, the same address as `AdvertiseAddr` is used.  The `DataPathAddr` specifies the address that global scope network drivers will publish towards other  nodes in order to reach the containers running on this node. Using this parameter it is possible to separate the container data traffic from the management traffic of the cluster.
     #[serde(rename = "DataPathAddr")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub data_path_addr: Option<String>,
 
-    /// DataPathPort specifies the data path port number for data traffic. Acceptable port range is 1024 to 49151. if no port is set or is set to 0, default port 4789 will be used. 
+    /// DataPathPort specifies the data path port number for data traffic. Acceptable port range is 1024 to 49151. if no port is set or is set to 0, default port 4789 will be used.
     #[serde(rename = "DataPathPort")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub data_path_port: Option<u32>,
 
-    /// Default Address Pool specifies default subnet pools for global scope networks. 
+    /// Default Address Pool specifies default subnet pools for global scope networks.
     #[serde(rename = "DefaultAddrPool")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub default_addr_pool: Option<Vec<String>>,
@@ -5821,7 +5666,7 @@ pub struct SwarmInitRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub force_new_cluster: Option<bool>,
 
-    /// SubnetSize specifies the subnet size of the networks created from the default subnet pool. 
+    /// SubnetSize specifies the subnet size of the networks created from the default subnet pool.
     #[serde(rename = "SubnetSize")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub subnet_size: Option<u32>,
@@ -5829,27 +5674,26 @@ pub struct SwarmInitRequest {
     #[serde(rename = "Spec")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub spec: Option<SwarmSpec>,
-
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 pub struct SwarmJoinRequest {
-    /// Listen address used for inter-manager communication if the node gets promoted to manager, as well as determining the networking interface used for the VXLAN Tunnel Endpoint (VTEP). 
+    /// Listen address used for inter-manager communication if the node gets promoted to manager, as well as determining the networking interface used for the VXLAN Tunnel Endpoint (VTEP).
     #[serde(rename = "ListenAddr")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub listen_addr: Option<String>,
 
-    /// Externally reachable address advertised to other nodes. This can either be an address/port combination in the form `192.168.1.1:4567`, or an interface followed by a port number, like `eth0:4567`. If the port number is omitted, the port number from the listen address is used. If `AdvertiseAddr` is not specified, it will be automatically detected when possible. 
+    /// Externally reachable address advertised to other nodes. This can either be an address/port combination in the form `192.168.1.1:4567`, or an interface followed by a port number, like `eth0:4567`. If the port number is omitted, the port number from the listen address is used. If `AdvertiseAddr` is not specified, it will be automatically detected when possible.
     #[serde(rename = "AdvertiseAddr")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub advertise_addr: Option<String>,
 
-    /// Address or interface to use for data path traffic (format: `<ip|interface>`), for example,  `192.168.1.1`, or an interface, like `eth0`. If `DataPathAddr` is unspecified, the same address as `AdvertiseAddr` is used.  The `DataPathAddr` specifies the address that global scope network drivers will publish towards other nodes in order to reach the containers running on this node. Using this parameter it is possible to separate the container data traffic from the management traffic of the cluster. 
+    /// Address or interface to use for data path traffic (format: `<ip|interface>`), for example,  `192.168.1.1`, or an interface, like `eth0`. If `DataPathAddr` is unspecified, the same address as `AdvertiseAddr` is used.  The `DataPathAddr` specifies the address that global scope network drivers will publish towards other nodes in order to reach the containers running on this node. Using this parameter it is possible to separate the container data traffic from the management traffic of the cluster.
     #[serde(rename = "DataPathAddr")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub data_path_addr: Option<String>,
 
-    /// Addresses of manager nodes already participating in the swarm. 
+    /// Addresses of manager nodes already participating in the swarm.
     #[serde(rename = "RemoteAddrs")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub remote_addrs: Option<Vec<String>>,
@@ -5858,7 +5702,6 @@ pub struct SwarmJoinRequest {
     #[serde(rename = "JoinToken")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub join_token: Option<String>,
-
 }
 
 /// User modifiable swarm configuration.
@@ -5897,7 +5740,6 @@ pub struct SwarmSpec {
     #[serde(rename = "TaskDefaults")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub task_defaults: Option<SwarmSpecTaskDefaults>,
-
 }
 
 /// CA configuration.
@@ -5908,55 +5750,53 @@ pub struct SwarmSpecCaConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub node_cert_expiry: Option<i64>,
 
-    /// Configuration for forwarding signing requests to an external certificate authority. 
+    /// Configuration for forwarding signing requests to an external certificate authority.
     #[serde(rename = "ExternalCAs")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub external_cas: Option<Vec<SwarmSpecCaConfigExternalCas>>,
 
-    /// The desired signing CA certificate for all swarm node TLS leaf certificates, in PEM format. 
+    /// The desired signing CA certificate for all swarm node TLS leaf certificates, in PEM format.
     #[serde(rename = "SigningCACert")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub signing_ca_cert: Option<String>,
 
-    /// The desired signing CA key for all swarm node TLS leaf certificates, in PEM format. 
+    /// The desired signing CA key for all swarm node TLS leaf certificates, in PEM format.
     #[serde(rename = "SigningCAKey")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub signing_ca_key: Option<String>,
 
-    /// An integer whose purpose is to force swarm to generate a new signing CA certificate and key, if none have been specified in `SigningCACert` and `SigningCAKey` 
+    /// An integer whose purpose is to force swarm to generate a new signing CA certificate and key, if none have been specified in `SigningCACert` and `SigningCAKey`
     #[serde(rename = "ForceRotate")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub force_rotate: Option<u64>,
-
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 pub struct SwarmSpecCaConfigExternalCas {
-    /// Protocol for communication with the external CA (currently only `cfssl` is supported). 
+    /// Protocol for communication with the external CA (currently only `cfssl` is supported).
     #[serde(rename = "Protocol")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub protocol: Option<SwarmSpecCaConfigExternalCasProtocolEnum>,
 
-    /// URL where certificate signing requests should be sent. 
+    /// URL where certificate signing requests should be sent.
     #[serde(rename = "URL")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub url: Option<String>,
 
-    /// An object with key/value pairs that are interpreted as protocol-specific options for the external CA driver. 
+    /// An object with key/value pairs that are interpreted as protocol-specific options for the external CA driver.
     #[serde(rename = "Options")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub options: Option<HashMap<String, String>>,
 
-    /// The root CA certificate (in PEM format) this external CA uses to issue TLS certificates (assumed to be to the current swarm root CA certificate if not provided). 
+    /// The root CA certificate (in PEM format) this external CA uses to issue TLS certificates (assumed to be to the current swarm root CA certificate if not provided).
     #[serde(rename = "CACert")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub ca_cert: Option<String>,
-
 }
 
 #[allow(non_camel_case_types)]
 #[derive(Debug, Clone, Copy, PartialEq, PartialOrd, Serialize, Deserialize, Eq, Ord)]
-pub enum SwarmSpecCaConfigExternalCasProtocolEnum { 
+pub enum SwarmSpecCaConfigExternalCasProtocolEnum {
     #[serde(rename = "")]
     EMPTY,
     #[serde(rename = "cfssl")]
@@ -5965,10 +5805,9 @@ pub enum SwarmSpecCaConfigExternalCasProtocolEnum {
 
 impl ::std::fmt::Display for SwarmSpecCaConfigExternalCasProtocolEnum {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        match *self { 
+        match *self {
             SwarmSpecCaConfigExternalCasProtocolEnum::EMPTY => write!(f, ""),
             SwarmSpecCaConfigExternalCasProtocolEnum::CFSSL => write!(f, "{}", "cfssl"),
-
         }
     }
 }
@@ -5976,7 +5815,7 @@ impl ::std::fmt::Display for SwarmSpecCaConfigExternalCasProtocolEnum {
 impl ::std::str::FromStr for SwarmSpecCaConfigExternalCasProtocolEnum {
     type Err = String;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s { 
+        match s {
             "" => Ok(SwarmSpecCaConfigExternalCasProtocolEnum::EMPTY),
             "cfssl" => Ok(SwarmSpecCaConfigExternalCasProtocolEnum::CFSSL),
             x => Err(format!("Invalid enum type: {}", x)),
@@ -5986,7 +5825,7 @@ impl ::std::str::FromStr for SwarmSpecCaConfigExternalCasProtocolEnum {
 
 impl ::std::convert::AsRef<str> for SwarmSpecCaConfigExternalCasProtocolEnum {
     fn as_ref(&self) -> &str {
-        match self { 
+        match self {
             SwarmSpecCaConfigExternalCasProtocolEnum::EMPTY => "",
             SwarmSpecCaConfigExternalCasProtocolEnum::CFSSL => "cfssl",
         }
@@ -5996,31 +5835,28 @@ impl ::std::convert::AsRef<str> for SwarmSpecCaConfigExternalCasProtocolEnum {
 /// Dispatcher configuration.
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 pub struct SwarmSpecDispatcher {
-    /// The delay for an agent to send a heartbeat to the dispatcher. 
+    /// The delay for an agent to send a heartbeat to the dispatcher.
     #[serde(rename = "HeartbeatPeriod")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub heartbeat_period: Option<i64>,
-
 }
 
 /// Parameters related to encryption-at-rest.
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 pub struct SwarmSpecEncryptionConfig {
-    /// If set, generate a key and use it to lock data stored on the managers. 
+    /// If set, generate a key and use it to lock data stored on the managers.
     #[serde(rename = "AutoLockManagers")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub auto_lock_managers: Option<bool>,
-
 }
 
 /// Orchestration configuration.
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 pub struct SwarmSpecOrchestration {
-    /// The number of historic tasks to keep per instance or node. If negative, never remove completed or failed tasks. 
+    /// The number of historic tasks to keep per instance or node. If negative, never remove completed or failed tasks.
     #[serde(rename = "TaskHistoryRetentionLimit")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub task_history_retention_limit: Option<i64>,
-
 }
 
 /// Raft configuration.
@@ -6031,26 +5867,25 @@ pub struct SwarmSpecRaft {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub snapshot_interval: Option<u64>,
 
-    /// The number of snapshots to keep beyond the current snapshot. 
+    /// The number of snapshots to keep beyond the current snapshot.
     #[serde(rename = "KeepOldSnapshots")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub keep_old_snapshots: Option<u64>,
 
-    /// The number of log entries to keep around to sync up slow followers after a snapshot is created. 
+    /// The number of log entries to keep around to sync up slow followers after a snapshot is created.
     #[serde(rename = "LogEntriesForSlowFollowers")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub log_entries_for_slow_followers: Option<u64>,
 
-    /// The number of ticks that a follower will wait for a message from the leader before becoming a candidate and starting an election. `ElectionTick` must be greater than `HeartbeatTick`.  A tick currently defaults to one second, so these translate directly to seconds currently, but this is NOT guaranteed. 
+    /// The number of ticks that a follower will wait for a message from the leader before becoming a candidate and starting an election. `ElectionTick` must be greater than `HeartbeatTick`.  A tick currently defaults to one second, so these translate directly to seconds currently, but this is NOT guaranteed.
     #[serde(rename = "ElectionTick")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub election_tick: Option<i64>,
 
-    /// The number of ticks between heartbeats. Every HeartbeatTick ticks, the leader will send a heartbeat to the followers.  A tick currently defaults to one second, so these translate directly to seconds currently, but this is NOT guaranteed. 
+    /// The number of ticks between heartbeats. Every HeartbeatTick ticks, the leader will send a heartbeat to the followers.  A tick currently defaults to one second, so these translate directly to seconds currently, but this is NOT guaranteed.
     #[serde(rename = "HeartbeatTick")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub heartbeat_tick: Option<i64>,
-
 }
 
 /// Defaults for creating tasks in this cluster.
@@ -6059,22 +5894,20 @@ pub struct SwarmSpecTaskDefaults {
     #[serde(rename = "LogDriver")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub log_driver: Option<SwarmSpecTaskDefaultsLogDriver>,
-
 }
 
-/// The log driver to use for tasks created in the orchestrator if unspecified by a service.  Updating this value only affects new tasks. Existing tasks continue to use their previously configured log driver until recreated. 
+/// The log driver to use for tasks created in the orchestrator if unspecified by a service.  Updating this value only affects new tasks. Existing tasks continue to use their previously configured log driver until recreated.
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 pub struct SwarmSpecTaskDefaultsLogDriver {
-    /// The log driver to use as a default for new tasks. 
+    /// The log driver to use as a default for new tasks.
     #[serde(rename = "Name")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
 
-    /// Driver-specific options for the selectd log driver, specified as key/value pairs. 
+    /// Driver-specific options for the selectd log driver, specified as key/value pairs.
     #[serde(rename = "Options")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub options: Option<HashMap<String, String>>,
-
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
@@ -6083,7 +5916,6 @@ pub struct SwarmUnlockRequest {
     #[serde(rename = "UnlockKey")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub unlock_key: Option<String>,
-
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
@@ -6096,7 +5928,6 @@ pub struct SystemAuthResponse {
     #[serde(rename = "IdentityToken")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub identity_token: Option<String>,
-
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
@@ -6120,12 +5951,11 @@ pub struct SystemDataUsageResponse {
     #[serde(rename = "BuildCache")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub build_cache: Option<Vec<BuildCache>>,
-
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 pub struct SystemInfo {
-    /// Unique identifier of the daemon.  <p><br /></p>  > **Note**: The format of the ID itself is not part of the API, and > should not be considered stable. 
+    /// Unique identifier of the daemon.  <p><br /></p>  > **Note**: The format of the ID itself is not part of the API, and > should not be considered stable.
     #[serde(rename = "ID")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub id: Option<String>,
@@ -6135,22 +5965,22 @@ pub struct SystemInfo {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub containers: Option<i64>,
 
-    /// Number of containers with status `\"running\"`. 
+    /// Number of containers with status `\"running\"`.
     #[serde(rename = "ContainersRunning")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub containers_running: Option<i64>,
 
-    /// Number of containers with status `\"paused\"`. 
+    /// Number of containers with status `\"paused\"`.
     #[serde(rename = "ContainersPaused")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub containers_paused: Option<i64>,
 
-    /// Number of containers with status `\"stopped\"`. 
+    /// Number of containers with status `\"stopped\"`.
     #[serde(rename = "ContainersStopped")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub containers_stopped: Option<i64>,
 
-    /// Total number of images on the host.  Both _tagged_ and _untagged_ (dangling) images are counted. 
+    /// Total number of images on the host.  Both _tagged_ and _untagged_ (dangling) images are counted.
     #[serde(rename = "Images")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub images: Option<i64>,
@@ -6160,12 +5990,12 @@ pub struct SystemInfo {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub driver: Option<String>,
 
-    /// Information specific to the storage driver, provided as \"label\" / \"value\" pairs.  This information is provided by the storage driver, and formatted in a way consistent with the output of `docker info` on the command line.  <p><br /></p>  > **Note**: The information returned in this field, including the > formatting of values and labels, should not be considered stable, > and may change without notice. 
+    /// Information specific to the storage driver, provided as \"label\" / \"value\" pairs.  This information is provided by the storage driver, and formatted in a way consistent with the output of `docker info` on the command line.  <p><br /></p>  > **Note**: The information returned in this field, including the > formatting of values and labels, should not be considered stable, > and may change without notice.
     #[serde(rename = "DriverStatus")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub driver_status: Option<Vec<Vec<String>>>,
 
-    /// Root directory of persistent Docker state.  Defaults to `/var/lib/docker` on Linux, and `C:\\ProgramData\\docker` on Windows. 
+    /// Root directory of persistent Docker state.  Defaults to `/var/lib/docker` on Linux, and `C:\\ProgramData\\docker` on Windows.
     #[serde(rename = "DockerRootDir")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub docker_root_dir: Option<String>,
@@ -6184,27 +6014,27 @@ pub struct SystemInfo {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub swap_limit: Option<bool>,
 
-    /// Indicates if the host has kernel memory TCP limit support enabled. This field is omitted if not supported.  Kernel memory TCP limits are not supported when using cgroups v2, which does not support the corresponding `memory.kmem.tcp.limit_in_bytes` cgroup. 
+    /// Indicates if the host has kernel memory TCP limit support enabled. This field is omitted if not supported.  Kernel memory TCP limits are not supported when using cgroups v2, which does not support the corresponding `memory.kmem.tcp.limit_in_bytes` cgroup.
     #[serde(rename = "KernelMemoryTCP")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub kernel_memory_tcp: Option<bool>,
 
-    /// Indicates if CPU CFS(Completely Fair Scheduler) period is supported by the host. 
+    /// Indicates if CPU CFS(Completely Fair Scheduler) period is supported by the host.
     #[serde(rename = "CpuCfsPeriod")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cpu_cfs_period: Option<bool>,
 
-    /// Indicates if CPU CFS(Completely Fair Scheduler) quota is supported by the host. 
+    /// Indicates if CPU CFS(Completely Fair Scheduler) quota is supported by the host.
     #[serde(rename = "CpuCfsQuota")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cpu_cfs_quota: Option<bool>,
 
-    /// Indicates if CPU Shares limiting is supported by the host. 
+    /// Indicates if CPU Shares limiting is supported by the host.
     #[serde(rename = "CPUShares")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cpu_shares: Option<bool>,
 
-    /// Indicates if CPUsets (cpuset.cpus, cpuset.mems) are supported by the host.  See [cpuset(7)](https://www.kernel.org/doc/Documentation/cgroup-v1/cpusets.txt) 
+    /// Indicates if CPUsets (cpuset.cpus, cpuset.mems) are supported by the host.  See [cpuset(7)](https://www.kernel.org/doc/Documentation/cgroup-v1/cpusets.txt)
     #[serde(rename = "CPUSet")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cpu_set: Option<bool>,
@@ -6234,37 +6064,37 @@ pub struct SystemInfo {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub bridge_nf_ip6tables: Option<bool>,
 
-    /// Indicates if the daemon is running in debug-mode / with debug-level logging enabled. 
+    /// Indicates if the daemon is running in debug-mode / with debug-level logging enabled.
     #[serde(rename = "Debug")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub debug: Option<bool>,
 
-    /// The total number of file Descriptors in use by the daemon process.  This information is only returned if debug-mode is enabled. 
+    /// The total number of file Descriptors in use by the daemon process.  This information is only returned if debug-mode is enabled.
     #[serde(rename = "NFd")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub nfd: Option<i64>,
 
-    /// The  number of goroutines that currently exist.  This information is only returned if debug-mode is enabled. 
+    /// The  number of goroutines that currently exist.  This information is only returned if debug-mode is enabled.
     #[serde(rename = "NGoroutines")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub n_goroutines: Option<i64>,
 
-    /// Current system-time in [RFC 3339](https://www.ietf.org/rfc/rfc3339.txt) format with nano-seconds. 
+    /// Current system-time in [RFC 3339](https://www.ietf.org/rfc/rfc3339.txt) format with nano-seconds.
     #[serde(rename = "SystemTime")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub system_time: Option<String>,
 
-    /// The logging driver to use as a default for new containers. 
+    /// The logging driver to use as a default for new containers.
     #[serde(rename = "LoggingDriver")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub logging_driver: Option<String>,
 
-    /// The driver to use for managing cgroups. 
+    /// The driver to use for managing cgroups.
     #[serde(rename = "CgroupDriver")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cgroup_driver: Option<SystemInfoCgroupDriverEnum>,
 
-    /// The version of the cgroup. 
+    /// The version of the cgroup.
     #[serde(rename = "CgroupVersion")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cgroup_version: Option<SystemInfoCgroupVersionEnum>,
@@ -6274,42 +6104,42 @@ pub struct SystemInfo {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub n_events_listener: Option<i64>,
 
-    /// Kernel version of the host.  On Linux, this information obtained from `uname`. On Windows this information is queried from the <kbd>HKEY_LOCAL_MACHINE\\\\SOFTWARE\\\\Microsoft\\\\Windows NT\\\\CurrentVersion\\\\</kbd> registry value, for example _\"10.0 14393 (14393.1198.amd64fre.rs1_release_sec.170427-1353)\"_. 
+    /// Kernel version of the host.  On Linux, this information obtained from `uname`. On Windows this information is queried from the <kbd>HKEY_LOCAL_MACHINE\\\\SOFTWARE\\\\Microsoft\\\\Windows NT\\\\CurrentVersion\\\\</kbd> registry value, for example _\"10.0 14393 (14393.1198.amd64fre.rs1_release_sec.170427-1353)\"_.
     #[serde(rename = "KernelVersion")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub kernel_version: Option<String>,
 
-    /// Name of the host's operating system, for example: \"Ubuntu 16.04.2 LTS\" or \"Windows Server 2016 Datacenter\" 
+    /// Name of the host's operating system, for example: \"Ubuntu 16.04.2 LTS\" or \"Windows Server 2016 Datacenter\"
     #[serde(rename = "OperatingSystem")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub operating_system: Option<String>,
 
-    /// Version of the host's operating system  <p><br /></p>  > **Note**: The information returned in this field, including its > very existence, and the formatting of values, should not be considered > stable, and may change without notice. 
+    /// Version of the host's operating system  <p><br /></p>  > **Note**: The information returned in this field, including its > very existence, and the formatting of values, should not be considered > stable, and may change without notice.
     #[serde(rename = "OSVersion")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub os_version: Option<String>,
 
-    /// Generic type of the operating system of the host, as returned by the Go runtime (`GOOS`).  Currently returned values are \"linux\" and \"windows\". A full list of possible values can be found in the [Go documentation](https://golang.org/doc/install/source#environment). 
+    /// Generic type of the operating system of the host, as returned by the Go runtime (`GOOS`).  Currently returned values are \"linux\" and \"windows\". A full list of possible values can be found in the [Go documentation](https://golang.org/doc/install/source#environment).
     #[serde(rename = "OSType")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub os_type: Option<String>,
 
-    /// Hardware architecture of the host, as returned by the Go runtime (`GOARCH`).  A full list of possible values can be found in the [Go documentation](https://golang.org/doc/install/source#environment). 
+    /// Hardware architecture of the host, as returned by the Go runtime (`GOARCH`).  A full list of possible values can be found in the [Go documentation](https://golang.org/doc/install/source#environment).
     #[serde(rename = "Architecture")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub architecture: Option<String>,
 
-    /// The number of logical CPUs usable by the daemon.  The number of available CPUs is checked by querying the operating system when the daemon starts. Changes to operating system CPU allocation after the daemon is started are not reflected. 
+    /// The number of logical CPUs usable by the daemon.  The number of available CPUs is checked by querying the operating system when the daemon starts. Changes to operating system CPU allocation after the daemon is started are not reflected.
     #[serde(rename = "NCPU")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub ncpu: Option<i64>,
 
-    /// Total amount of physical memory available on the host, in bytes. 
+    /// Total amount of physical memory available on the host, in bytes.
     #[serde(rename = "MemTotal")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub mem_total: Option<i64>,
 
-    /// Address / URL of the index server that is used for image search, and as a default for user authentication for Docker Hub and Docker Cloud. 
+    /// Address / URL of the index server that is used for image search, and as a default for user authentication for Docker Hub and Docker Cloud.
     #[serde(rename = "IndexServerAddress")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub index_server_address: Option<String>,
@@ -6322,17 +6152,17 @@ pub struct SystemInfo {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub generic_resources: Option<GenericResources>,
 
-    /// HTTP-proxy configured for the daemon. This value is obtained from the [`HTTP_PROXY`](https://www.gnu.org/software/wget/manual/html_node/Proxies.html) environment variable. Credentials ([user info component](https://tools.ietf.org/html/rfc3986#section-3.2.1)) in the proxy URL are masked in the API response.  Containers do not automatically inherit this configuration. 
+    /// HTTP-proxy configured for the daemon. This value is obtained from the [`HTTP_PROXY`](https://www.gnu.org/software/wget/manual/html_node/Proxies.html) environment variable. Credentials ([user info component](https://tools.ietf.org/html/rfc3986#section-3.2.1)) in the proxy URL are masked in the API response.  Containers do not automatically inherit this configuration.
     #[serde(rename = "HttpProxy")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub http_proxy: Option<String>,
 
-    /// HTTPS-proxy configured for the daemon. This value is obtained from the [`HTTPS_PROXY`](https://www.gnu.org/software/wget/manual/html_node/Proxies.html) environment variable. Credentials ([user info component](https://tools.ietf.org/html/rfc3986#section-3.2.1)) in the proxy URL are masked in the API response.  Containers do not automatically inherit this configuration. 
+    /// HTTPS-proxy configured for the daemon. This value is obtained from the [`HTTPS_PROXY`](https://www.gnu.org/software/wget/manual/html_node/Proxies.html) environment variable. Credentials ([user info component](https://tools.ietf.org/html/rfc3986#section-3.2.1)) in the proxy URL are masked in the API response.  Containers do not automatically inherit this configuration.
     #[serde(rename = "HttpsProxy")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub https_proxy: Option<String>,
 
-    /// Comma-separated list of domain extensions for which no proxy should be used. This value is obtained from the [`NO_PROXY`](https://www.gnu.org/software/wget/manual/html_node/Proxies.html) environment variable.  Containers do not automatically inherit this configuration. 
+    /// Comma-separated list of domain extensions for which no proxy should be used. This value is obtained from the [`NO_PROXY`](https://www.gnu.org/software/wget/manual/html_node/Proxies.html) environment variable.  Containers do not automatically inherit this configuration.
     #[serde(rename = "NoProxy")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_proxy: Option<String>,
@@ -6342,37 +6172,37 @@ pub struct SystemInfo {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
 
-    /// User-defined labels (key/value metadata) as set on the daemon.  <p><br /></p>  > **Note**: When part of a Swarm, nodes can both have _daemon_ labels, > set through the daemon configuration, and _node_ labels, set from a > manager node in the Swarm. Node labels are not included in this > field. Node labels can be retrieved using the `/nodes/(id)` endpoint > on a manager node in the Swarm. 
+    /// User-defined labels (key/value metadata) as set on the daemon.  <p><br /></p>  > **Note**: When part of a Swarm, nodes can both have _daemon_ labels, > set through the daemon configuration, and _node_ labels, set from a > manager node in the Swarm. Node labels are not included in this > field. Node labels can be retrieved using the `/nodes/(id)` endpoint > on a manager node in the Swarm.
     #[serde(rename = "Labels")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub labels: Option<Vec<String>>,
 
-    /// Indicates if experimental features are enabled on the daemon. 
+    /// Indicates if experimental features are enabled on the daemon.
     #[serde(rename = "ExperimentalBuild")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub experimental_build: Option<bool>,
 
-    /// Version string of the daemon.  > **Note**: the [standalone Swarm API](https://docs.docker.com/swarm/swarm-api/) > returns the Swarm version instead of the daemon  version, for example > `swarm/1.2.8`. 
+    /// Version string of the daemon.  > **Note**: the [standalone Swarm API](https://docs.docker.com/swarm/swarm-api/) > returns the Swarm version instead of the daemon  version, for example > `swarm/1.2.8`.
     #[serde(rename = "ServerVersion")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub server_version: Option<String>,
 
-    /// URL of the distributed storage backend.   The storage backend is used for multihost networking (to store network and endpoint information) and by the node discovery mechanism.  <p><br /></p>  > **Deprecated**: This field is only propagated when using standalone Swarm > mode, and overlay networking using an external k/v store. Overlay > networks with Swarm mode enabled use the built-in raft store, and > this field will be empty. 
+    /// URL of the distributed storage backend.   The storage backend is used for multihost networking (to store network and endpoint information) and by the node discovery mechanism.  <p><br /></p>  > **Deprecated**: This field is only propagated when using standalone Swarm > mode, and overlay networking using an external k/v store. Overlay > networks with Swarm mode enabled use the built-in raft store, and > this field will be empty.
     #[serde(rename = "ClusterStore")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cluster_store: Option<String>,
 
-    /// The network endpoint that the Engine advertises for the purpose of node discovery. ClusterAdvertise is a `host:port` combination on which the daemon is reachable by other hosts.  <p><br /></p>  > **Deprecated**: This field is only propagated when using standalone Swarm > mode, and overlay networking using an external k/v store. Overlay > networks with Swarm mode enabled use the built-in raft store, and > this field will be empty. 
+    /// The network endpoint that the Engine advertises for the purpose of node discovery. ClusterAdvertise is a `host:port` combination on which the daemon is reachable by other hosts.  <p><br /></p>  > **Deprecated**: This field is only propagated when using standalone Swarm > mode, and overlay networking using an external k/v store. Overlay > networks with Swarm mode enabled use the built-in raft store, and > this field will be empty.
     #[serde(rename = "ClusterAdvertise")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cluster_advertise: Option<String>,
 
-    /// List of [OCI compliant](https://github.com/opencontainers/runtime-spec) runtimes configured on the daemon. Keys hold the \"name\" used to reference the runtime.  The Docker daemon relies on an OCI compliant runtime (invoked via the `containerd` daemon) as its interface to the Linux kernel namespaces, cgroups, and SELinux.  The default runtime is `runc`, and automatically configured. Additional runtimes can be configured by the user and will be listed here. 
+    /// List of [OCI compliant](https://github.com/opencontainers/runtime-spec) runtimes configured on the daemon. Keys hold the \"name\" used to reference the runtime.  The Docker daemon relies on an OCI compliant runtime (invoked via the `containerd` daemon) as its interface to the Linux kernel namespaces, cgroups, and SELinux.  The default runtime is `runc`, and automatically configured. Additional runtimes can be configured by the user and will be listed here.
     #[serde(rename = "Runtimes")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub runtimes: Option<HashMap<String, Runtime>>,
 
-    /// Name of the default OCI runtime that is used when starting containers.  The default can be overridden per-container at create time. 
+    /// Name of the default OCI runtime that is used when starting containers.  The default can be overridden per-container at create time.
     #[serde(rename = "DefaultRuntime")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub default_runtime: Option<String>,
@@ -6381,17 +6211,17 @@ pub struct SystemInfo {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub swarm: Option<SwarmInfo>,
 
-    /// Indicates if live restore is enabled.  If enabled, containers are kept running when the daemon is shutdown or upon daemon start if running containers are detected. 
+    /// Indicates if live restore is enabled.  If enabled, containers are kept running when the daemon is shutdown or upon daemon start if running containers are detected.
     #[serde(rename = "LiveRestoreEnabled")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub live_restore_enabled: Option<bool>,
 
-    /// Represents the isolation technology to use as a default for containers. The supported values are platform-specific.  If no isolation value is specified on daemon start, on Windows client, the default is `hyperv`, and on Windows server, the default is `process`.  This option is currently not used on other platforms. 
+    /// Represents the isolation technology to use as a default for containers. The supported values are platform-specific.  If no isolation value is specified on daemon start, on Windows client, the default is `hyperv`, and on Windows server, the default is `process`.  This option is currently not used on other platforms.
     #[serde(rename = "Isolation")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub isolation: Option<SystemInfoIsolationEnum>,
 
-    /// Name and, optional, path of the `docker-init` binary.  If the path is omitted, the daemon searches the host's `$PATH` for the binary and uses the first result. 
+    /// Name and, optional, path of the `docker-init` binary.  If the path is omitted, the daemon searches the host's `$PATH` for the binary and uses the first result.
     #[serde(rename = "InitBinary")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub init_binary: Option<String>,
@@ -6408,31 +6238,30 @@ pub struct SystemInfo {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub init_commit: Option<Commit>,
 
-    /// List of security features that are enabled on the daemon, such as apparmor, seccomp, SELinux, user-namespaces (userns), and rootless.  Additional configuration options for each security feature may be present, and are included as a comma-separated list of key/value pairs. 
+    /// List of security features that are enabled on the daemon, such as apparmor, seccomp, SELinux, user-namespaces (userns), and rootless.  Additional configuration options for each security feature may be present, and are included as a comma-separated list of key/value pairs.
     #[serde(rename = "SecurityOptions")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub security_options: Option<Vec<String>>,
 
-    /// Reports a summary of the product license on the daemon.  If a commercial license has been applied to the daemon, information such as number of nodes, and expiration are included. 
+    /// Reports a summary of the product license on the daemon.  If a commercial license has been applied to the daemon, information such as number of nodes, and expiration are included.
     #[serde(rename = "ProductLicense")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub product_license: Option<String>,
 
-    /// List of custom default address pools for local networks, which can be specified in the daemon.json file or dockerd option.  Example: a Base \"10.10.0.0/16\" with Size 24 will define the set of 256 10.10.[0-255].0/24 address pools. 
+    /// List of custom default address pools for local networks, which can be specified in the daemon.json file or dockerd option.  Example: a Base \"10.10.0.0/16\" with Size 24 will define the set of 256 10.10.[0-255].0/24 address pools.
     #[serde(rename = "DefaultAddressPools")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub default_address_pools: Option<Vec<SystemInfoDefaultAddressPools>>,
 
-    /// List of warnings / informational messages about missing features, or issues related to the daemon configuration.  These messages can be printed by the client as information to the user. 
+    /// List of warnings / informational messages about missing features, or issues related to the daemon configuration.  These messages can be printed by the client as information to the user.
     #[serde(rename = "Warnings")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub warnings: Option<Vec<String>>,
-
 }
 
 #[allow(non_camel_case_types)]
 #[derive(Debug, Clone, Copy, PartialEq, PartialOrd, Serialize, Deserialize, Eq, Ord)]
-pub enum SystemInfoCgroupDriverEnum { 
+pub enum SystemInfoCgroupDriverEnum {
     #[serde(rename = "")]
     EMPTY,
     #[serde(rename = "cgroupfs")]
@@ -6445,12 +6274,11 @@ pub enum SystemInfoCgroupDriverEnum {
 
 impl ::std::fmt::Display for SystemInfoCgroupDriverEnum {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        match *self { 
+        match *self {
             SystemInfoCgroupDriverEnum::EMPTY => write!(f, ""),
             SystemInfoCgroupDriverEnum::CGROUPFS => write!(f, "{}", "cgroupfs"),
             SystemInfoCgroupDriverEnum::SYSTEMD => write!(f, "{}", "systemd"),
             SystemInfoCgroupDriverEnum::NONE => write!(f, "{}", "none"),
-
         }
     }
 }
@@ -6458,7 +6286,7 @@ impl ::std::fmt::Display for SystemInfoCgroupDriverEnum {
 impl ::std::str::FromStr for SystemInfoCgroupDriverEnum {
     type Err = String;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s { 
+        match s {
             "" => Ok(SystemInfoCgroupDriverEnum::EMPTY),
             "cgroupfs" => Ok(SystemInfoCgroupDriverEnum::CGROUPFS),
             "systemd" => Ok(SystemInfoCgroupDriverEnum::SYSTEMD),
@@ -6470,7 +6298,7 @@ impl ::std::str::FromStr for SystemInfoCgroupDriverEnum {
 
 impl ::std::convert::AsRef<str> for SystemInfoCgroupDriverEnum {
     fn as_ref(&self) -> &str {
-        match self { 
+        match self {
             SystemInfoCgroupDriverEnum::EMPTY => "",
             SystemInfoCgroupDriverEnum::CGROUPFS => "cgroupfs",
             SystemInfoCgroupDriverEnum::SYSTEMD => "systemd",
@@ -6481,7 +6309,7 @@ impl ::std::convert::AsRef<str> for SystemInfoCgroupDriverEnum {
 
 #[allow(non_camel_case_types)]
 #[derive(Debug, Clone, Copy, PartialEq, PartialOrd, Serialize, Deserialize, Eq, Ord)]
-pub enum SystemInfoCgroupVersionEnum { 
+pub enum SystemInfoCgroupVersionEnum {
     #[serde(rename = "")]
     EMPTY,
     #[serde(rename = "1")]
@@ -6492,11 +6320,10 @@ pub enum SystemInfoCgroupVersionEnum {
 
 impl ::std::fmt::Display for SystemInfoCgroupVersionEnum {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        match *self { 
+        match *self {
             SystemInfoCgroupVersionEnum::EMPTY => write!(f, ""),
             SystemInfoCgroupVersionEnum::_1 => write!(f, "{}", "1"),
             SystemInfoCgroupVersionEnum::_2 => write!(f, "{}", "2"),
-
         }
     }
 }
@@ -6504,7 +6331,7 @@ impl ::std::fmt::Display for SystemInfoCgroupVersionEnum {
 impl ::std::str::FromStr for SystemInfoCgroupVersionEnum {
     type Err = String;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s { 
+        match s {
             "" => Ok(SystemInfoCgroupVersionEnum::EMPTY),
             "1" => Ok(SystemInfoCgroupVersionEnum::_1),
             "2" => Ok(SystemInfoCgroupVersionEnum::_2),
@@ -6515,7 +6342,7 @@ impl ::std::str::FromStr for SystemInfoCgroupVersionEnum {
 
 impl ::std::convert::AsRef<str> for SystemInfoCgroupVersionEnum {
     fn as_ref(&self) -> &str {
-        match self { 
+        match self {
             SystemInfoCgroupVersionEnum::EMPTY => "",
             SystemInfoCgroupVersionEnum::_1 => "1",
             SystemInfoCgroupVersionEnum::_2 => "2",
@@ -6525,7 +6352,7 @@ impl ::std::convert::AsRef<str> for SystemInfoCgroupVersionEnum {
 
 #[allow(non_camel_case_types)]
 #[derive(Debug, Clone, Copy, PartialEq, PartialOrd, Serialize, Deserialize, Eq, Ord)]
-pub enum SystemInfoIsolationEnum { 
+pub enum SystemInfoIsolationEnum {
     #[serde(rename = "")]
     EMPTY,
     #[serde(rename = "default")]
@@ -6538,12 +6365,11 @@ pub enum SystemInfoIsolationEnum {
 
 impl ::std::fmt::Display for SystemInfoIsolationEnum {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        match *self { 
+        match *self {
             SystemInfoIsolationEnum::EMPTY => write!(f, ""),
             SystemInfoIsolationEnum::DEFAULT => write!(f, "{}", "default"),
             SystemInfoIsolationEnum::HYPERV => write!(f, "{}", "hyperv"),
             SystemInfoIsolationEnum::PROCESS => write!(f, "{}", "process"),
-
         }
     }
 }
@@ -6551,7 +6377,7 @@ impl ::std::fmt::Display for SystemInfoIsolationEnum {
 impl ::std::str::FromStr for SystemInfoIsolationEnum {
     type Err = String;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s { 
+        match s {
             "" => Ok(SystemInfoIsolationEnum::EMPTY),
             "default" => Ok(SystemInfoIsolationEnum::DEFAULT),
             "hyperv" => Ok(SystemInfoIsolationEnum::HYPERV),
@@ -6563,7 +6389,7 @@ impl ::std::str::FromStr for SystemInfoIsolationEnum {
 
 impl ::std::convert::AsRef<str> for SystemInfoIsolationEnum {
     fn as_ref(&self) -> &str {
-        match self { 
+        match self {
             SystemInfoIsolationEnum::EMPTY => "",
             SystemInfoIsolationEnum::DEFAULT => "default",
             SystemInfoIsolationEnum::HYPERV => "hyperv",
@@ -6583,17 +6409,16 @@ pub struct SystemInfoDefaultAddressPools {
     #[serde(rename = "Size")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub size: Option<i64>,
-
 }
 
-/// Response of Engine API: GET \"/version\" 
+/// Response of Engine API: GET \"/version\"
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 pub struct SystemVersion {
     #[serde(rename = "Platform")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub platform: Option<SystemVersionPlatform>,
 
-    /// Information about system components 
+    /// Information about system components
     #[serde(rename = "Components")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub components: Option<Vec<SystemVersionComponents>>,
@@ -6603,75 +6428,72 @@ pub struct SystemVersion {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub version: Option<String>,
 
-    /// The default (and highest) API version that is supported by the daemon 
+    /// The default (and highest) API version that is supported by the daemon
     #[serde(rename = "ApiVersion")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub api_version: Option<String>,
 
-    /// The minimum API version that is supported by the daemon 
+    /// The minimum API version that is supported by the daemon
     #[serde(rename = "MinAPIVersion")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub min_api_version: Option<String>,
 
-    /// The Git commit of the source code that was used to build the daemon 
+    /// The Git commit of the source code that was used to build the daemon
     #[serde(rename = "GitCommit")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub git_commit: Option<String>,
 
-    /// The version Go used to compile the daemon, and the version of the Go runtime in use. 
+    /// The version Go used to compile the daemon, and the version of the Go runtime in use.
     #[serde(rename = "GoVersion")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub go_version: Option<String>,
 
-    /// The operating system that the daemon is running on (\"linux\" or \"windows\") 
+    /// The operating system that the daemon is running on (\"linux\" or \"windows\")
     #[serde(rename = "Os")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub os: Option<String>,
 
-    /// The architecture that the daemon is running on 
+    /// The architecture that the daemon is running on
     #[serde(rename = "Arch")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub arch: Option<String>,
 
-    /// The kernel version (`uname -r`) that the daemon is running on.  This field is omitted when empty. 
+    /// The kernel version (`uname -r`) that the daemon is running on.  This field is omitted when empty.
     #[serde(rename = "KernelVersion")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub kernel_version: Option<String>,
 
-    /// Indicates if the daemon is started with experimental features enabled.  This field is omitted when empty / false. 
+    /// Indicates if the daemon is started with experimental features enabled.  This field is omitted when empty / false.
     #[serde(rename = "Experimental")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub experimental: Option<bool>,
 
-    /// The date and time that the daemon was compiled. 
+    /// The date and time that the daemon was compiled.
     #[serde(rename = "BuildTime")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub build_time: Option<String>,
-
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 pub struct SystemVersionComponents {
-    /// Name of the component 
+    /// Name of the component
     #[serde(rename = "Name")]
     pub name: String,
 
-    /// Version of the component 
+    /// Version of the component
     #[serde(rename = "Version")]
     pub version: String,
 
-    /// Key/value pairs of strings with additional information about the component. These values are intended for informational purposes only, and their content is not defined, and not part of the API specification.  These messages can be printed by the client as information to the user. 
+    /// Key/value pairs of strings with additional information about the component. These values are intended for informational purposes only, and their content is not defined, and not part of the API specification.  These messages can be printed by the client as information to the user.
     #[serde(rename = "Details")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub details: Option<HashMap<(), ()>>,
-
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 pub struct SystemVersionPlatform {
     #[serde(rename = "Name")]
     pub name: String,
-
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
@@ -6743,11 +6565,10 @@ pub struct Task {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub desired_state: Option<TaskState>,
 
-    /// If the Service this Task belongs to is a job-mode service, contains the JobIteration of the Service this Task was created for. Absent if the Task was created for a Replicated or Global Service. 
+    /// If the Service this Task belongs to is a job-mode service, contains the JobIteration of the Service this Task was created for. Absent if the Task was created for a Replicated or Global Service.
     #[serde(rename = "JobIteration")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub job_iteration: Option<ObjectVersion>,
-
 }
 
 /// User modifiable task configuration.
@@ -6777,12 +6598,12 @@ pub struct TaskSpec {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub placement: Option<TaskSpecPlacement>,
 
-    /// A counter that triggers an update even if no relevant parameters have been changed. 
+    /// A counter that triggers an update even if no relevant parameters have been changed.
     #[serde(rename = "ForceUpdate")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub force_update: Option<i64>,
 
-    /// Runtime is the type of runtime specified for the task executor. 
+    /// Runtime is the type of runtime specified for the task executor.
     #[serde(rename = "Runtime")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub runtime: Option<String>,
@@ -6795,10 +6616,9 @@ pub struct TaskSpec {
     #[serde(rename = "LogDriver")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub log_driver: Option<TaskSpecLogDriver>,
-
 }
 
-/// Container spec for the service.  <p><br /></p>  > **Note**: ContainerSpec, NetworkAttachmentSpec, and PluginSpec are > mutually exclusive. PluginSpec is only used when the Runtime field > is set to `plugin`. NetworkAttachmentSpec is used when the Runtime > field is set to `attachment`. 
+/// Container spec for the service.  <p><br /></p>  > **Note**: ContainerSpec, NetworkAttachmentSpec, and PluginSpec are > mutually exclusive. PluginSpec is only used when the Runtime field > is set to `plugin`. NetworkAttachmentSpec is used when the Runtime > field is set to `attachment`.
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 pub struct TaskSpecContainerSpec {
     /// The image name to use for the container
@@ -6821,12 +6641,12 @@ pub struct TaskSpecContainerSpec {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub args: Option<Vec<String>>,
 
-    /// The hostname to use for the container, as a valid [RFC 1123](https://tools.ietf.org/html/rfc1123) hostname. 
+    /// The hostname to use for the container, as a valid [RFC 1123](https://tools.ietf.org/html/rfc1123) hostname.
     #[serde(rename = "Hostname")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub hostname: Option<String>,
 
-    /// A list of environment variables in the form `VAR=value`. 
+    /// A list of environment variables in the form `VAR=value`.
     #[serde(rename = "Env")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub env: Option<Vec<String>>,
@@ -6841,7 +6661,7 @@ pub struct TaskSpecContainerSpec {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub user: Option<String>,
 
-    /// A list of additional groups that the container process will run as. 
+    /// A list of additional groups that the container process will run as.
     #[serde(rename = "Groups")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub groups: Option<Vec<String>>,
@@ -6865,7 +6685,7 @@ pub struct TaskSpecContainerSpec {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub read_only: Option<bool>,
 
-    /// Specification for mounts to be added to containers created as part of the service. 
+    /// Specification for mounts to be added to containers created as part of the service.
     #[serde(rename = "Mounts")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub mounts: Option<Vec<Mount>>,
@@ -6875,7 +6695,7 @@ pub struct TaskSpecContainerSpec {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub stop_signal: Option<String>,
 
-    /// Amount of time to wait for the container to terminate before forcefully killing it. 
+    /// Amount of time to wait for the container to terminate before forcefully killing it.
     #[serde(rename = "StopGracePeriod")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub stop_grace_period: Option<i64>,
@@ -6884,7 +6704,7 @@ pub struct TaskSpecContainerSpec {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub health_check: Option<HealthConfig>,
 
-    /// A list of hostname/IP mappings to add to the container's `hosts` file. The format of extra hosts is specified in the [hosts(5)](http://man7.org/linux/man-pages/man5/hosts.5.html) man page:      IP_address canonical_hostname [aliases...] 
+    /// A list of hostname/IP mappings to add to the container's `hosts` file. The format of extra hosts is specified in the [hosts(5)](http://man7.org/linux/man-pages/man5/hosts.5.html) man page:      IP_address canonical_hostname [aliases...]
     #[serde(rename = "Hosts")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub hosts: Option<Vec<String>>,
@@ -6893,51 +6713,50 @@ pub struct TaskSpecContainerSpec {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub dns_config: Option<TaskSpecContainerSpecDnsConfig>,
 
-    /// Secrets contains references to zero or more secrets that will be exposed to the service. 
+    /// Secrets contains references to zero or more secrets that will be exposed to the service.
     #[serde(rename = "Secrets")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub secrets: Option<Vec<TaskSpecContainerSpecSecrets>>,
 
-    /// Configs contains references to zero or more configs that will be exposed to the service. 
+    /// Configs contains references to zero or more configs that will be exposed to the service.
     #[serde(rename = "Configs")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub configs: Option<Vec<TaskSpecContainerSpecConfigs>>,
 
-    /// Isolation technology of the containers running the service. (Windows only) 
+    /// Isolation technology of the containers running the service. (Windows only)
     #[serde(rename = "Isolation")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub isolation: Option<TaskSpecContainerSpecIsolationEnum>,
 
-    /// Run an init inside the container that forwards signals and reaps processes. This field is omitted if empty, and the default (as configured on the daemon) is used. 
+    /// Run an init inside the container that forwards signals and reaps processes. This field is omitted if empty, and the default (as configured on the daemon) is used.
     #[serde(rename = "Init")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub init: Option<bool>,
 
-    /// Set kernel namedspaced parameters (sysctls) in the container. The Sysctls option on services accepts the same sysctls as the are supported on containers. Note that while the same sysctls are supported, no guarantees or checks are made about their suitability for a clustered environment, and it's up to the user to determine whether a given sysctl will work properly in a Service. 
+    /// Set kernel namedspaced parameters (sysctls) in the container. The Sysctls option on services accepts the same sysctls as the are supported on containers. Note that while the same sysctls are supported, no guarantees or checks are made about their suitability for a clustered environment, and it's up to the user to determine whether a given sysctl will work properly in a Service.
     #[serde(rename = "Sysctls")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub sysctls: Option<HashMap<String, String>>,
 
-    /// A list of kernel capabilities to add to the default set for the container. 
+    /// A list of kernel capabilities to add to the default set for the container.
     #[serde(rename = "CapabilityAdd")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub capability_add: Option<Vec<String>>,
 
-    /// A list of kernel capabilities to drop from the default set for the container. 
+    /// A list of kernel capabilities to drop from the default set for the container.
     #[serde(rename = "CapabilityDrop")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub capability_drop: Option<Vec<String>>,
 
-    /// A list of resource limits to set in the container. For example: `{\"Name\": \"nofile\", \"Soft\": 1024, \"Hard\": 2048}`\" 
+    /// A list of resource limits to set in the container. For example: `{\"Name\": \"nofile\", \"Soft\": 1024, \"Hard\": 2048}`\"
     #[serde(rename = "Ulimits")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub ulimits: Option<Vec<ResourcesUlimits>>,
-
 }
 
 #[allow(non_camel_case_types)]
 #[derive(Debug, Clone, Copy, PartialEq, PartialOrd, Serialize, Deserialize, Eq, Ord)]
-pub enum TaskSpecContainerSpecIsolationEnum { 
+pub enum TaskSpecContainerSpecIsolationEnum {
     #[serde(rename = "")]
     EMPTY,
     #[serde(rename = "default")]
@@ -6950,12 +6769,11 @@ pub enum TaskSpecContainerSpecIsolationEnum {
 
 impl ::std::fmt::Display for TaskSpecContainerSpecIsolationEnum {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        match *self { 
+        match *self {
             TaskSpecContainerSpecIsolationEnum::EMPTY => write!(f, ""),
             TaskSpecContainerSpecIsolationEnum::DEFAULT => write!(f, "{}", "default"),
             TaskSpecContainerSpecIsolationEnum::PROCESS => write!(f, "{}", "process"),
             TaskSpecContainerSpecIsolationEnum::HYPERV => write!(f, "{}", "hyperv"),
-
         }
     }
 }
@@ -6963,7 +6781,7 @@ impl ::std::fmt::Display for TaskSpecContainerSpecIsolationEnum {
 impl ::std::str::FromStr for TaskSpecContainerSpecIsolationEnum {
     type Err = String;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s { 
+        match s {
             "" => Ok(TaskSpecContainerSpecIsolationEnum::EMPTY),
             "default" => Ok(TaskSpecContainerSpecIsolationEnum::DEFAULT),
             "process" => Ok(TaskSpecContainerSpecIsolationEnum::PROCESS),
@@ -6975,7 +6793,7 @@ impl ::std::str::FromStr for TaskSpecContainerSpecIsolationEnum {
 
 impl ::std::convert::AsRef<str> for TaskSpecContainerSpecIsolationEnum {
     fn as_ref(&self) -> &str {
-        match self { 
+        match self {
             TaskSpecContainerSpecIsolationEnum::EMPTY => "",
             TaskSpecContainerSpecIsolationEnum::DEFAULT => "default",
             TaskSpecContainerSpecIsolationEnum::PROCESS => "process",
@@ -6990,24 +6808,23 @@ pub struct TaskSpecContainerSpecConfigs {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub file: Option<TaskSpecContainerSpecFile1>,
 
-    /// Runtime represents a target that is not mounted into the container but is used by the task  <p><br /><p>  > **Note**: `Configs.File` and `Configs.Runtime` are mutually > exclusive 
+    /// Runtime represents a target that is not mounted into the container but is used by the task  <p><br /><p>  > **Note**: `Configs.File` and `Configs.Runtime` are mutually > exclusive
     #[serde(rename = "Runtime")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub runtime: Option<HashMap<(), ()>>,
 
-    /// ConfigID represents the ID of the specific config that we're referencing. 
+    /// ConfigID represents the ID of the specific config that we're referencing.
     #[serde(rename = "ConfigID")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub config_id: Option<String>,
 
-    /// ConfigName is the name of the config that this references, but this is just provided for lookup/display purposes. The config in the reference will be identified by its ID. 
+    /// ConfigName is the name of the config that this references, but this is just provided for lookup/display purposes. The config in the reference will be identified by its ID.
     #[serde(rename = "ConfigName")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub config_name: Option<String>,
-
 }
 
-/// Specification for DNS related configurations in resolver configuration file (`resolv.conf`). 
+/// Specification for DNS related configurations in resolver configuration file (`resolv.conf`).
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 pub struct TaskSpecContainerSpecDnsConfig {
     /// The IP addresses of the name servers.
@@ -7020,17 +6837,16 @@ pub struct TaskSpecContainerSpecDnsConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub search: Option<Vec<String>>,
 
-    /// A list of internal resolver variables to be modified (e.g., `debug`, `ndots:3`, etc.). 
+    /// A list of internal resolver variables to be modified (e.g., `debug`, `ndots:3`, etc.).
     #[serde(rename = "Options")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub options: Option<Vec<String>>,
-
 }
 
-/// File represents a specific target that is backed by a file. 
+/// File represents a specific target that is backed by a file.
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 pub struct TaskSpecContainerSpecFile {
-    /// Name represents the final filename in the filesystem. 
+    /// Name represents the final filename in the filesystem.
     #[serde(rename = "Name")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
@@ -7049,13 +6865,12 @@ pub struct TaskSpecContainerSpecFile {
     #[serde(rename = "Mode")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub mode: Option<u32>,
-
 }
 
-/// File represents a specific target that is backed by a file.  <p><br /><p>  > **Note**: `Configs.File` and `Configs.Runtime` are mutually exclusive 
+/// File represents a specific target that is backed by a file.  <p><br /><p>  > **Note**: `Configs.File` and `Configs.Runtime` are mutually exclusive
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 pub struct TaskSpecContainerSpecFile1 {
-    /// Name represents the final filename in the filesystem. 
+    /// Name represents the final filename in the filesystem.
     #[serde(rename = "Name")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
@@ -7074,7 +6889,6 @@ pub struct TaskSpecContainerSpecFile1 {
     #[serde(rename = "Mode")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub mode: Option<u32>,
-
 }
 
 /// Security options for the container
@@ -7087,27 +6901,25 @@ pub struct TaskSpecContainerSpecPrivileges {
     #[serde(rename = "SELinuxContext")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub se_linux_context: Option<TaskSpecContainerSpecPrivilegesSeLinuxContext>,
-
 }
 
 /// CredentialSpec for managed service account (Windows only)
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 pub struct TaskSpecContainerSpecPrivilegesCredentialSpec {
-    /// Load credential spec from a Swarm Config with the given ID. The specified config must also be present in the Configs field with the Runtime property set.  <p><br /></p>   > **Note**: `CredentialSpec.File`, `CredentialSpec.Registry`, > and `CredentialSpec.Config` are mutually exclusive. 
+    /// Load credential spec from a Swarm Config with the given ID. The specified config must also be present in the Configs field with the Runtime property set.  <p><br /></p>   > **Note**: `CredentialSpec.File`, `CredentialSpec.Registry`, > and `CredentialSpec.Config` are mutually exclusive.
     #[serde(rename = "Config")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub config: Option<String>,
 
-    /// Load credential spec from this file. The file is read by the daemon, and must be present in the `CredentialSpecs` subdirectory in the docker data directory, which defaults to `C:\\ProgramData\\Docker\\` on Windows.  For example, specifying `spec.json` loads `C:\\ProgramData\\Docker\\CredentialSpecs\\spec.json`.  <p><br /></p>  > **Note**: `CredentialSpec.File`, `CredentialSpec.Registry`, > and `CredentialSpec.Config` are mutually exclusive. 
+    /// Load credential spec from this file. The file is read by the daemon, and must be present in the `CredentialSpecs` subdirectory in the docker data directory, which defaults to `C:\\ProgramData\\Docker\\` on Windows.  For example, specifying `spec.json` loads `C:\\ProgramData\\Docker\\CredentialSpecs\\spec.json`.  <p><br /></p>  > **Note**: `CredentialSpec.File`, `CredentialSpec.Registry`, > and `CredentialSpec.Config` are mutually exclusive.
     #[serde(rename = "File")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub file: Option<String>,
 
-    /// Load credential spec from this value in the Windows registry. The specified registry value must be located in:  `HKLM\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Virtualization\\Containers\\CredentialSpecs`  <p><br /></p>   > **Note**: `CredentialSpec.File`, `CredentialSpec.Registry`, > and `CredentialSpec.Config` are mutually exclusive. 
+    /// Load credential spec from this value in the Windows registry. The specified registry value must be located in:  `HKLM\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Virtualization\\Containers\\CredentialSpecs`  <p><br /></p>   > **Note**: `CredentialSpec.File`, `CredentialSpec.Registry`, > and `CredentialSpec.Config` are mutually exclusive.
     #[serde(rename = "Registry")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub registry: Option<String>,
-
 }
 
 /// SELinux labels of the container
@@ -7137,7 +6949,6 @@ pub struct TaskSpecContainerSpecPrivilegesSeLinuxContext {
     #[serde(rename = "Level")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub level: Option<String>,
-
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
@@ -7146,19 +6957,18 @@ pub struct TaskSpecContainerSpecSecrets {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub file: Option<TaskSpecContainerSpecFile>,
 
-    /// SecretID represents the ID of the specific secret that we're referencing. 
+    /// SecretID represents the ID of the specific secret that we're referencing.
     #[serde(rename = "SecretID")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub secret_id: Option<String>,
 
-    /// SecretName is the name of the secret that this references, but this is just provided for lookup/display purposes. The secret in the reference will be identified by its ID. 
+    /// SecretName is the name of the secret that this references, but this is just provided for lookup/display purposes. The secret in the reference will be identified by its ID.
     #[serde(rename = "SecretName")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub secret_name: Option<String>,
-
 }
 
-/// Specifies the log driver to use for tasks created from this spec. If not present, the default one for the swarm will be used, finally falling back to the engine default if not specified. 
+/// Specifies the log driver to use for tasks created from this spec. If not present, the default one for the swarm will be used, finally falling back to the engine default if not specified.
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 pub struct TaskSpecLogDriver {
     #[serde(rename = "Name")]
@@ -7168,41 +6978,38 @@ pub struct TaskSpecLogDriver {
     #[serde(rename = "Options")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub options: Option<HashMap<String, String>>,
-
 }
 
-/// Read-only spec type for non-swarm containers attached to swarm overlay networks.  <p><br /></p>  > **Note**: ContainerSpec, NetworkAttachmentSpec, and PluginSpec are > mutually exclusive. PluginSpec is only used when the Runtime field > is set to `plugin`. NetworkAttachmentSpec is used when the Runtime > field is set to `attachment`. 
+/// Read-only spec type for non-swarm containers attached to swarm overlay networks.  <p><br /></p>  > **Note**: ContainerSpec, NetworkAttachmentSpec, and PluginSpec are > mutually exclusive. PluginSpec is only used when the Runtime field > is set to `plugin`. NetworkAttachmentSpec is used when the Runtime > field is set to `attachment`.
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 pub struct TaskSpecNetworkAttachmentSpec {
     /// ID of the container represented by this task
     #[serde(rename = "ContainerID")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub container_id: Option<String>,
-
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 pub struct TaskSpecPlacement {
-    /// An array of constraint expressions to limit the set of nodes where a task can be scheduled. Constraint expressions can either use a _match_ (`==`) or _exclude_ (`!=`) rule. Multiple constraints find nodes that satisfy every expression (AND match). Constraints can match node or Docker Engine labels as follows:  node attribute       | matches                        | example ---------------------|--------------------------------|----------------------------------------------- `node.id`            | Node ID                        | `node.id==2ivku8v2gvtg4` `node.hostname`      | Node hostname                  | `node.hostname!=node-2` `node.role`          | Node role (`manager`/`worker`) | `node.role==manager` `node.platform.os`   | Node operating system          | `node.platform.os==windows` `node.platform.arch` | Node architecture              | `node.platform.arch==x86_64` `node.labels`        | User-defined node labels       | `node.labels.security==high` `engine.labels`      | Docker Engine's labels         | `engine.labels.operatingsystem==ubuntu-14.04`  `engine.labels` apply to Docker Engine labels like operating system, drivers, etc. Swarm administrators add `node.labels` for operational purposes by using the [`node update endpoint`](#operation/NodeUpdate). 
+    /// An array of constraint expressions to limit the set of nodes where a task can be scheduled. Constraint expressions can either use a _match_ (`==`) or _exclude_ (`!=`) rule. Multiple constraints find nodes that satisfy every expression (AND match). Constraints can match node or Docker Engine labels as follows:  node attribute       | matches                        | example ---------------------|--------------------------------|----------------------------------------------- `node.id`            | Node ID                        | `node.id==2ivku8v2gvtg4` `node.hostname`      | Node hostname                  | `node.hostname!=node-2` `node.role`          | Node role (`manager`/`worker`) | `node.role==manager` `node.platform.os`   | Node operating system          | `node.platform.os==windows` `node.platform.arch` | Node architecture              | `node.platform.arch==x86_64` `node.labels`        | User-defined node labels       | `node.labels.security==high` `engine.labels`      | Docker Engine's labels         | `engine.labels.operatingsystem==ubuntu-14.04`  `engine.labels` apply to Docker Engine labels like operating system, drivers, etc. Swarm administrators add `node.labels` for operational purposes by using the [`node update endpoint`](#operation/NodeUpdate).
     #[serde(rename = "Constraints")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub constraints: Option<Vec<String>>,
 
-    /// Preferences provide a way to make the scheduler aware of factors such as topology. They are provided in order from highest to lowest precedence. 
+    /// Preferences provide a way to make the scheduler aware of factors such as topology. They are provided in order from highest to lowest precedence.
     #[serde(rename = "Preferences")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub preferences: Option<Vec<TaskSpecPlacementPreferences>>,
 
-    /// Maximum number of replicas for per node (default value is 0, which is unlimited) 
+    /// Maximum number of replicas for per node (default value is 0, which is unlimited)
     #[serde(rename = "MaxReplicas")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub max_replicas: Option<i64>,
 
-    /// Platforms stores all the platforms that the service's image can run on. This field is used in the platform filter for scheduling. If empty, then the platform filter is off, meaning there are no scheduling restrictions. 
+    /// Platforms stores all the platforms that the service's image can run on. This field is used in the platform filter for scheduling. If empty, then the platform filter is off, meaning there are no scheduling restrictions.
     #[serde(rename = "Platforms")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub platforms: Option<Vec<Platform>>,
-
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
@@ -7210,19 +7017,17 @@ pub struct TaskSpecPlacementPreferences {
     #[serde(rename = "Spread")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub spread: Option<TaskSpecPlacementSpread>,
-
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 pub struct TaskSpecPlacementSpread {
-    /// label descriptor, such as `engine.labels.az`. 
+    /// label descriptor, such as `engine.labels.az`.
     #[serde(rename = "SpreadDescriptor")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub spread_descriptor: Option<String>,
-
 }
 
-/// Plugin spec for the service.  *(Experimental release only.)*  <p><br /></p>  > **Note**: ContainerSpec, NetworkAttachmentSpec, and PluginSpec are > mutually exclusive. PluginSpec is only used when the Runtime field > is set to `plugin`. NetworkAttachmentSpec is used when the Runtime > field is set to `attachment`. 
+/// Plugin spec for the service.  *(Experimental release only.)*  <p><br /></p>  > **Note**: ContainerSpec, NetworkAttachmentSpec, and PluginSpec are > mutually exclusive. PluginSpec is only used when the Runtime field > is set to `plugin`. NetworkAttachmentSpec is used when the Runtime > field is set to `attachment`.
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 pub struct TaskSpecPluginSpec {
     /// The name or 'alias' to use for the plugin.
@@ -7243,10 +7048,9 @@ pub struct TaskSpecPluginSpec {
     #[serde(rename = "PluginPrivilege")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub plugin_privilege: Option<Vec<PluginPrivilege>>,
-
 }
 
-/// Resource requirements which apply to each individual container created as part of the service. 
+/// Resource requirements which apply to each individual container created as part of the service.
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 pub struct TaskSpecResources {
     /// Define resources limits.
@@ -7258,10 +7062,9 @@ pub struct TaskSpecResources {
     #[serde(rename = "Reservations")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub reservations: Option<ResourceObject>,
-
 }
 
-/// Specification for the restart policy which applies to containers created as part of this service. 
+/// Specification for the restart policy which applies to containers created as part of this service.
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 pub struct TaskSpecRestartPolicy {
     /// Condition for restart.
@@ -7274,21 +7077,20 @@ pub struct TaskSpecRestartPolicy {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub delay: Option<i64>,
 
-    /// Maximum attempts to restart a given container before giving up (default value is 0, which is ignored). 
+    /// Maximum attempts to restart a given container before giving up (default value is 0, which is ignored).
     #[serde(rename = "MaxAttempts")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub max_attempts: Option<i64>,
 
-    /// Windows is the time window used to evaluate the restart policy (default value is 0, which is unbounded). 
+    /// Windows is the time window used to evaluate the restart policy (default value is 0, which is unbounded).
     #[serde(rename = "Window")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub window: Option<i64>,
-
 }
 
 #[allow(non_camel_case_types)]
 #[derive(Debug, Clone, Copy, PartialEq, PartialOrd, Serialize, Deserialize, Eq, Ord)]
-pub enum TaskSpecRestartPolicyConditionEnum { 
+pub enum TaskSpecRestartPolicyConditionEnum {
     #[serde(rename = "")]
     EMPTY,
     #[serde(rename = "none")]
@@ -7301,12 +7103,11 @@ pub enum TaskSpecRestartPolicyConditionEnum {
 
 impl ::std::fmt::Display for TaskSpecRestartPolicyConditionEnum {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        match *self { 
+        match *self {
             TaskSpecRestartPolicyConditionEnum::EMPTY => write!(f, ""),
             TaskSpecRestartPolicyConditionEnum::NONE => write!(f, "{}", "none"),
             TaskSpecRestartPolicyConditionEnum::ON_FAILURE => write!(f, "{}", "on-failure"),
             TaskSpecRestartPolicyConditionEnum::ANY => write!(f, "{}", "any"),
-
         }
     }
 }
@@ -7314,7 +7115,7 @@ impl ::std::fmt::Display for TaskSpecRestartPolicyConditionEnum {
 impl ::std::str::FromStr for TaskSpecRestartPolicyConditionEnum {
     type Err = String;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s { 
+        match s {
             "" => Ok(TaskSpecRestartPolicyConditionEnum::EMPTY),
             "none" => Ok(TaskSpecRestartPolicyConditionEnum::NONE),
             "on-failure" => Ok(TaskSpecRestartPolicyConditionEnum::ON_FAILURE),
@@ -7326,7 +7127,7 @@ impl ::std::str::FromStr for TaskSpecRestartPolicyConditionEnum {
 
 impl ::std::convert::AsRef<str> for TaskSpecRestartPolicyConditionEnum {
     fn as_ref(&self) -> &str {
-        match self { 
+        match self {
             TaskSpecRestartPolicyConditionEnum::EMPTY => "",
             TaskSpecRestartPolicyConditionEnum::NONE => "none",
             TaskSpecRestartPolicyConditionEnum::ON_FAILURE => "on-failure",
@@ -7341,7 +7142,7 @@ impl ::std::convert::AsRef<str> for TaskSpecRestartPolicyConditionEnum {
 #[allow(non_camel_case_types)]
 #[repr(C)]
 #[derive(Debug, Clone, Copy, PartialEq, PartialOrd, Serialize, Deserialize, Eq, Ord)]
-pub enum TaskState { 
+pub enum TaskState {
     #[serde(rename = "new")]
     NEW,
     #[serde(rename = "allocated")]
@@ -7376,7 +7177,7 @@ pub enum TaskState {
 
 impl ::std::fmt::Display for TaskState {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        match *self { 
+        match *self {
             TaskState::NEW => write!(f, "{}", "new"),
             TaskState::ALLOCATED => write!(f, "{}", "allocated"),
             TaskState::PENDING => write!(f, "{}", "pending"),
@@ -7446,7 +7247,6 @@ pub struct TaskStatus {
     #[serde(rename = "ContainerStatus")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub container_status: Option<TaskStatusContainerStatus>,
-
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
@@ -7462,7 +7262,6 @@ pub struct TaskStatusContainerStatus {
     #[serde(rename = "ExitCode")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub exit_code: Option<i64>,
-
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
@@ -7476,13 +7275,12 @@ pub struct ThrottleDevice {
     #[serde(rename = "Rate")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub rate: Option<i64>,
-
 }
 
-/// Information about the issuer of leaf TLS certificates and the trusted root CA certificate. 
+/// Information about the issuer of leaf TLS certificates and the trusted root CA certificate.
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 pub struct TlsInfo {
-    /// The root CA certificate(s) that are used to validate leaf TLS certificates. 
+    /// The root CA certificate(s) that are used to validate leaf TLS certificates.
     #[serde(rename = "TrustRoot")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub trust_root: Option<String>,
@@ -7492,14 +7290,13 @@ pub struct TlsInfo {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cert_issuer_subject: Option<String>,
 
-    /// The base64-url-safe-encoded raw public key bytes of the issuer. 
+    /// The base64-url-safe-encoded raw public key bytes of the issuer.
     #[serde(rename = "CertIssuerPublicKey")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cert_issuer_public_key: Option<String>,
-
 }
 
-/// A map of topological domains to topological segments. For in depth details, see documentation for the Topology object in the CSI specification. 
+/// A map of topological domains to topological segments. For in depth details, see documentation for the Topology object in the CSI specification.
 // special-casing PortMap, cos swagger-codegen doesn't figure out this type
 pub type Topology = HashMap<String, Option<Vec<PortBinding>>>;
 
@@ -7509,7 +7306,6 @@ pub struct UnlockKeyResponse {
     #[serde(rename = "UnlockKey")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub unlock_key: Option<String>,
-
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
@@ -7536,7 +7332,7 @@ pub struct Volume {
     )]
     pub created_at: Option<BollardDate>,
 
-    /// Low-level details about the volume, provided by the volume driver. Details are returned as a map with key/value pairs: `{\"key\":\"value\",\"key2\":\"value2\"}`.  The `Status` field is optional, and is omitted if the volume driver does not support this feature. 
+    /// Low-level details about the volume, provided by the volume driver. Details are returned as a map with key/value pairs: `{\"key\":\"value\",\"key2\":\"value2\"}`.  The `Status` field is optional, and is omitted if the volume driver does not support this feature.
     #[serde(rename = "Status")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub status: Option<HashMap<String, HashMap<(), ()>>>,
@@ -7546,7 +7342,7 @@ pub struct Volume {
     #[serde(deserialize_with = "deserialize_nonoptional_map")]
     pub labels: HashMap<String, String>,
 
-    /// The level at which the volume exists. Either `global` for cluster-wide, or `local` for machine level. 
+    /// The level at which the volume exists. Either `global` for cluster-wide, or `local` for machine level.
     #[serde(rename = "Scope")]
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(with = "::serde_with::As::<::serde_with::NoneAsEmptyString>")]
@@ -7556,7 +7352,7 @@ pub struct Volume {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cluster_volume: Option<ClusterVolume>,
 
-    /// The driver specific options used when creating the volume. 
+    /// The driver specific options used when creating the volume.
     #[serde(rename = "Options")]
     #[serde(deserialize_with = "deserialize_nonoptional_map")]
     pub options: HashMap<String, String>,
@@ -7564,12 +7360,11 @@ pub struct Volume {
     #[serde(rename = "UsageData")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub usage_data: Option<VolumeUsageData>,
-
 }
 
 #[allow(non_camel_case_types)]
 #[derive(Debug, Clone, Copy, PartialEq, PartialOrd, Serialize, Deserialize, Eq, Ord)]
-pub enum VolumeScopeEnum { 
+pub enum VolumeScopeEnum {
     #[serde(rename = "")]
     EMPTY,
     #[serde(rename = "local")]
@@ -7580,11 +7375,10 @@ pub enum VolumeScopeEnum {
 
 impl ::std::fmt::Display for VolumeScopeEnum {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        match *self { 
+        match *self {
             VolumeScopeEnum::EMPTY => write!(f, ""),
             VolumeScopeEnum::LOCAL => write!(f, "{}", "local"),
             VolumeScopeEnum::GLOBAL => write!(f, "{}", "global"),
-
         }
     }
 }
@@ -7592,7 +7386,7 @@ impl ::std::fmt::Display for VolumeScopeEnum {
 impl ::std::str::FromStr for VolumeScopeEnum {
     type Err = String;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s { 
+        match s {
             "" => Ok(VolumeScopeEnum::EMPTY),
             "local" => Ok(VolumeScopeEnum::LOCAL),
             "global" => Ok(VolumeScopeEnum::GLOBAL),
@@ -7603,7 +7397,7 @@ impl ::std::str::FromStr for VolumeScopeEnum {
 
 impl ::std::convert::AsRef<str> for VolumeScopeEnum {
     fn as_ref(&self) -> &str {
-        match self { 
+        match self {
             VolumeScopeEnum::EMPTY => "",
             VolumeScopeEnum::LOCAL => "local",
             VolumeScopeEnum::GLOBAL => "global",
@@ -7614,7 +7408,7 @@ impl ::std::convert::AsRef<str> for VolumeScopeEnum {
 /// Volume configuration
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 pub struct VolumeCreateOptions {
-    /// The new volume's name. If not specified, Docker generates a name. 
+    /// The new volume's name. If not specified, Docker generates a name.
     #[serde(rename = "Name")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
@@ -7624,7 +7418,7 @@ pub struct VolumeCreateOptions {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub driver: Option<String>,
 
-    /// A mapping of driver options and values. These options are passed directly to the driver and are driver specific. 
+    /// A mapping of driver options and values. These options are passed directly to the driver and are driver specific.
     #[serde(rename = "DriverOpts")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub driver_opts: Option<HashMap<String, String>>,
@@ -7637,7 +7431,6 @@ pub struct VolumeCreateOptions {
     #[serde(rename = "ClusterVolumeSpec")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cluster_volume_spec: Option<ClusterVolumeSpec>,
-
 }
 
 /// Volume list response
@@ -7648,11 +7441,10 @@ pub struct VolumeListResponse {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub volumes: Option<Vec<Volume>>,
 
-    /// Warnings that occurred when fetching the list of volumes. 
+    /// Warnings that occurred when fetching the list of volumes.
     #[serde(rename = "Warnings")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub warnings: Option<Vec<String>>,
-
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
@@ -7666,18 +7458,16 @@ pub struct VolumePruneResponse {
     #[serde(rename = "SpaceReclaimed")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub space_reclaimed: Option<i64>,
-
 }
 
-/// Usage details about the volume. This information is used by the `GET /system/df` endpoint, and omitted in other endpoints. 
+/// Usage details about the volume. This information is used by the `GET /system/df` endpoint, and omitted in other endpoints.
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 pub struct VolumeUsageData {
-    /// Amount of disk space used by the volume (in bytes). This information is only available for volumes created with the `\"local\"` volume driver. For volumes created with other volume drivers, this field is set to `-1` (\"not available\") 
+    /// Amount of disk space used by the volume (in bytes). This information is only available for volumes created with the `\"local\"` volume driver. For volumes created with other volume drivers, this field is set to `-1` (\"not available\")
     #[serde(rename = "Size")]
     pub size: i64,
 
-    /// The number of containers referencing this volume. This field is set to `-1` if the reference-count is not available. 
+    /// The number of containers referencing this volume. This field is set to `-1` if the reference-count is not available.
     #[serde(rename = "RefCount")]
     pub ref_count: i64,
-
 }


### PR DESCRIPTION
I found that I wasn't getting the commit hash when calling the `commit_container` function like expected, but the commit hash was still present in the the payload returned to bollard. The field was named `Id` rather than the expected `ID`.

To fix this I added an alias for `Id`. I used an alias rather than changing the name because I assumed that `ID` had worked for someone at some point and did not want to break it.

For the curious, I'm using docker version 23.0.6, build ef23cbc