### PR TITLE
added rustls dangerous_configuration feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ log = "0.4"
 pin-project-lite = "0.2.8"
 num = { version = "0.4", optional = true }
 rand = { version = "0.8", optional = true }
-rustls = { version = "0.21", optional = true }
+rustls = { version = "0.21", optional = true, features = ["dangerous_configuration"] }
 rustls-native-certs = { version = "0.6.0", optional = true }
 rustls-pemfile = { version = "1.0", optional = true }
 serde = "1.0"


### PR DESCRIPTION
Hi, I was having trouble connecting to docker running in minikube and figured that it's because rustls cannot handle ip addresses as hostnames without this feature. This worked as a pretty quick and easy fix. Thanks. 