### PR TITLE
Expose OCI export endpoint as part of grpc buildkit API

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 jobs:
   test_ssl:
     docker:
-      - image: docker:20.10.16
+      - image: docker:24.0.5
     steps:
       - checkout
       - setup_remote_docker
@@ -15,7 +15,7 @@ jobs:
       - run: docker run -ti -e DOCKER_CERT_PATH=/certs -e DOCKER_HOST='tcp://test.example.com:2376' --volumes-from certs --rm --link test-docker-daemon:docker bollard cargo test --features test_ssl,ct_logs -- --test test_version_ssl
   test_http:
     docker:
-      - image: docker:20.10.16
+      - image: docker:24.0.5
     steps:
       - checkout
       - setup_remote_docker
@@ -24,7 +24,7 @@ jobs:
       - run: docker run -ti -e DOCKER_HOST='tcp://test.example.com:2375' --rm --link test-docker-daemon:docker bollard cargo test --features test_http -- --test test_version_http
   test_unix:
     docker:
-      - image: docker:20.10.16
+      - image: docker:24.0.5
     steps:
       - checkout
       - setup_remote_docker
@@ -32,7 +32,7 @@ jobs:
       - run: resources/dockerfiles/bin/run_integration_tests.sh --features buildkit --tests
   test_chrono:
     docker:
-      - image: docker:20.10.16
+      - image: docker:24.0.5
     steps:
       - checkout
       - setup_remote_docker
@@ -40,7 +40,7 @@ jobs:
       - run: resources/dockerfiles/bin/run_integration_tests.sh --features chrono --tests
   test_time:
     docker:
-      - image: docker:20.10.16
+      - image: docker:24.0.5
     steps:
       - checkout
       - setup_remote_docker
@@ -48,7 +48,7 @@ jobs:
       - run: resources/dockerfiles/bin/run_integration_tests.sh --features time --tests
   test_doc:
     docker:
-      - image: docker:20.10.16
+      - image: docker:24.0.5
     steps:
       - checkout
       - setup_remote_docker
@@ -56,7 +56,7 @@ jobs:
       - run: docker run -ti --rm bollard cargo test --all-features --target x86_64-unknown-linux-gnu --doc
   test_clippy:
     docker:
-      - image: docker:20.10.16
+      - image: docker:24.0.5
     steps:
       - checkout
       - setup_remote_docker
@@ -64,7 +64,7 @@ jobs:
       - run: docker run -ti --rm bollard bash -c "rustup component add clippy && cargo clippy --all-targets -- -Dwarnings"
   test_audit:
     docker:
-      - image: docker:20.10.16
+      - image: docker:24.0.5
     steps:
       - checkout
       - setup_remote_docker
@@ -73,7 +73,7 @@ jobs:
       - run: docker run -ti --rm bollard bash -c "cargo install cargo-audit && cargo audit --deny warnings --ignore=RUSTSEC-2020-0071"
   test_fmt:
     docker:
-      - image: docker:20.10.16
+      - image: docker:24.0.5
     steps:
       - checkout
       - setup_remote_docker

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,7 +67,7 @@ tower = { version = "0.4", optional = true }
 thiserror = "1.0"
 time = { version = "0.3", features = ["formatting", "parsing"], optional = true }
 tokio-stream = { version = "0.1", optional = true }
-tokio-util = { version = "0.7", features = ["codec"] }
+tokio-util = { version = "0.7", features = ["codec", "io"] }
 tower-service = { version = "0.3", optional = true }
 url = "2.2"
 webpki-roots = { version = "0.25.2", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ members = [
 
 [features]
 # Enable Buildkit-enabled docker image building
-buildkit = ["num", "rand", "tower", "tonic", "tower-service", "bollard-stubs/buildkit", "bollard-buildkit-proto"]
+buildkit = ["num", "rand", "tokio-stream", "tower", "tonic", "tower-service", "bollard-stubs/buildkit", "bollard-buildkit-proto"]
 # Enable tests specifically for the http connector
 test_http = []
 # Enable tests specifically for rustls
@@ -66,6 +66,7 @@ tonic = { version = "0.9", optional = true }
 tower = { version = "0.4", optional = true }
 thiserror = "1.0"
 time = { version = "0.3", features = ["formatting", "parsing"], optional = true }
+tokio-stream = { version = "0.1", optional = true }
 tokio-util = { version = "0.7", features = ["codec"] }
 tower-service = { version = "0.3", optional = true }
 url = "2.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,6 +77,7 @@ flate2 = "1.0"
 tar = "0.4"
 tokio = { version = "1.7", features = ["fs", "rt-multi-thread", "macros"] }
 yup-hyper-mock = "6.0.0"
+env_logger = "*"
 
 [target.'cfg(unix)'.dependencies]
 hyperlocal =  { version = "0.8.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,7 +62,7 @@ serde_json = "1.0"
 serde_repr = "0.1.6"
 serde_urlencoded = "0.7"
 tokio = { version = "1.7", features = ["time", "net", "io-util"] }
-tonic = { version = "0.9", optional = true }
+tonic = { version = "0.10", optional = true }
 tower = { version = "0.4", optional = true }
 thiserror = "1.0"
 time = { version = "0.3", features = ["formatting", "parsing"], optional = true }

--- a/codegen/proto/Cargo.toml
+++ b/codegen/proto/Cargo.toml
@@ -14,9 +14,9 @@ name = "gen"
 required-features = ["build"]
 
 [dependencies]
-tonic = { version = "0.9" }
-prost = { version = "0.11" }
-prost-types = "0.11"
-tonic-build = { version = "0.9", optional = true }
+tonic = { version = "0.10" }
+prost = { version = "0.12" }
+prost-types = "0.12"
+tonic-build = { version = "0.10", optional = true }
 # bug: https://github.com/bluss/indexmap/issues/151#issuecomment-716691744
 indexmap = { version = "2.0.0", features = ["std"], optional = true }

--- a/codegen/proto/resources/fsutil/types/stat.proto
+++ b/codegen/proto/resources/fsutil/types/stat.proto
@@ -1,0 +1,19 @@
+syntax = "proto3";
+
+package fsutil.types;
+
+option go_package = "types";
+
+message Stat {
+  string path = 1;
+  uint32 mode = 2;
+  uint32 uid = 3;
+  uint32 gid = 4;
+  int64 size = 5;
+  int64 modTime = 6;
+  // int32 typeflag = 7;
+  string linkname = 7;
+  int64 devmajor = 8;
+  int64 devminor = 9;
+  map<string, bytes> xattrs = 10;
+}

--- a/codegen/proto/resources/fsutil/types/wire.proto
+++ b/codegen/proto/resources/fsutil/types/wire.proto
@@ -1,0 +1,21 @@
+syntax = "proto3";
+
+package fsutil.types;
+
+option go_package = "types";
+
+import "fsutil/types/stat.proto";
+
+message Packet {
+  enum PacketType {
+      PACKET_STAT = 0;
+      PACKET_REQ = 1;
+      PACKET_DATA = 2;
+      PACKET_FIN = 3;
+      PACKET_ERR = 4;
+    }
+  PacketType type = 1;
+  Stat stat = 2;
+  uint32 ID = 3;
+  bytes data = 4;
+}

--- a/codegen/proto/resources/moby/filesync/v1/filesync.proto
+++ b/codegen/proto/resources/moby/filesync/v1/filesync.proto
@@ -1,0 +1,22 @@
+syntax = "proto3";
+
+package moby.filesync.v1;
+
+option go_package = "filesync";
+
+import "fsutil/types/wire.proto";
+
+service FileSync{
+  rpc DiffCopy(stream fsutil.types.Packet) returns (stream fsutil.types.Packet);
+  rpc TarStream(stream fsutil.types.Packet) returns (stream fsutil.types.Packet);
+}
+
+service FileSend{
+  rpc DiffCopy(stream BytesMessage) returns (stream BytesMessage);
+}
+
+
+// BytesMessage contains a chunk of byte data
+message BytesMessage{
+	bytes data = 1;
+}

--- a/codegen/proto/resources/moby/upload/v1/upload.proto
+++ b/codegen/proto/resources/moby/upload/v1/upload.proto
@@ -1,0 +1,14 @@
+syntax = "proto3";
+
+package moby.upload.v1;
+
+option go_package = "upload";
+
+service Upload {
+	rpc Pull(stream BytesMessage) returns (stream BytesMessage);
+}
+
+// BytesMessage contains a chunk of byte data
+message BytesMessage{
+	bytes data = 1;
+}

--- a/codegen/proto/src/bin/gen.rs
+++ b/codegen/proto/src/bin/gen.rs
@@ -2,13 +2,16 @@ use tonic_build;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     tonic_build::configure()
-        .build_client(false)
         .out_dir("src/generated")
         .compile_well_known_types(true)
         .compile(
             &[
+                "resources/fsutil/types/stat.proto",
+                "resources/fsutil/types/wire.proto",
                 "resources/moby/buildkit/v1/control.proto",
                 "resources/moby/buildkit/v1/types/worker.proto",
+                "resources/moby/filesync/v1/filesync.proto",
+                "resources/moby/upload/v1/upload.proto",
                 "resources/grpc/health/v1/health.proto",
             ],
             &["resources"],

--- a/codegen/proto/src/generated/fsutil.types.rs
+++ b/codegen/proto/src/generated/fsutil.types.rs
@@ -1,0 +1,88 @@
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Stat {
+    #[prost(string, tag = "1")]
+    pub path: ::prost::alloc::string::String,
+    #[prost(uint32, tag = "2")]
+    pub mode: u32,
+    #[prost(uint32, tag = "3")]
+    pub uid: u32,
+    #[prost(uint32, tag = "4")]
+    pub gid: u32,
+    #[prost(int64, tag = "5")]
+    pub size: i64,
+    #[prost(int64, tag = "6")]
+    pub mod_time: i64,
+    /// int32 typeflag = 7;
+    #[prost(string, tag = "7")]
+    pub linkname: ::prost::alloc::string::String,
+    #[prost(int64, tag = "8")]
+    pub devmajor: i64,
+    #[prost(int64, tag = "9")]
+    pub devminor: i64,
+    #[prost(map = "string, bytes", tag = "10")]
+    pub xattrs: ::std::collections::HashMap<
+        ::prost::alloc::string::String,
+        ::prost::alloc::vec::Vec<u8>,
+    >,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Packet {
+    #[prost(enumeration = "packet::PacketType", tag = "1")]
+    pub r#type: i32,
+    #[prost(message, optional, tag = "2")]
+    pub stat: ::core::option::Option<Stat>,
+    #[prost(uint32, tag = "3")]
+    pub id: u32,
+    #[prost(bytes = "vec", tag = "4")]
+    pub data: ::prost::alloc::vec::Vec<u8>,
+}
+/// Nested message and enum types in `Packet`.
+pub mod packet {
+    #[derive(
+        Clone,
+        Copy,
+        Debug,
+        PartialEq,
+        Eq,
+        Hash,
+        PartialOrd,
+        Ord,
+        ::prost::Enumeration
+    )]
+    #[repr(i32)]
+    pub enum PacketType {
+        PacketStat = 0,
+        PacketReq = 1,
+        PacketData = 2,
+        PacketFin = 3,
+        PacketErr = 4,
+    }
+    impl PacketType {
+        /// String value of the enum field names used in the ProtoBuf definition.
+        ///
+        /// The values are not transformed in any way and thus are considered stable
+        /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+        pub fn as_str_name(&self) -> &'static str {
+            match self {
+                PacketType::PacketStat => "PACKET_STAT",
+                PacketType::PacketReq => "PACKET_REQ",
+                PacketType::PacketData => "PACKET_DATA",
+                PacketType::PacketFin => "PACKET_FIN",
+                PacketType::PacketErr => "PACKET_ERR",
+            }
+        }
+        /// Creates an enum from field names used in the ProtoBuf definition.
+        pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+            match value {
+                "PACKET_STAT" => Some(Self::PacketStat),
+                "PACKET_REQ" => Some(Self::PacketReq),
+                "PACKET_DATA" => Some(Self::PacketData),
+                "PACKET_FIN" => Some(Self::PacketFin),
+                "PACKET_ERR" => Some(Self::PacketErr),
+                _ => None,
+            }
+        }
+    }
+}

--- a/codegen/proto/src/generated/google.protobuf.rs
+++ b/codegen/proto/src/generated/google.protobuf.rs
@@ -928,7 +928,7 @@ pub mod uninterpreted_option {
     /// The name of the uninterpreted option.  Each string represents a segment in
     /// a dot-separated name.  is_extension is true iff a segment represents an
     /// extension (denoted with parentheses in options specs in .proto files).
-    /// E.g.,{ ["foo", false], ["bar.baz", true], ["qux", false] } represents
+    /// E.g.,{ \["foo", false\], \["bar.baz", true\], \["qux", false\] } represents
     /// "foo.(bar.baz).qux".
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
@@ -959,11 +959,11 @@ pub struct SourceCodeInfo {
     ///    a       bc     de  f  ghi
     /// We have the following locations:
     ///    span   path               represents
-    ///    [a,i)  [ 4, 0, 2, 0 ]     The whole field definition.
-    ///    [a,b)  [ 4, 0, 2, 0, 4 ]  The label (optional).
-    ///    [c,d)  [ 4, 0, 2, 0, 5 ]  The type (string).
-    ///    [e,f)  [ 4, 0, 2, 0, 1 ]  The name (foo).
-    ///    [g,h)  [ 4, 0, 2, 0, 3 ]  The number (1).
+    ///    \[a,i)  [ 4, 0, 2, 0 \]     The whole field definition.
+    ///    \[a,b)  [ 4, 0, 2, 0, 4 \]  The label (optional).
+    ///    \[c,d)  [ 4, 0, 2, 0, 5 \]  The type (string).
+    ///    \[e,f)  [ 4, 0, 2, 0, 1 \]  The name (foo).
+    ///    \[g,h)  [ 4, 0, 2, 0, 3 \]  The number (1).
     ///
     /// Notes:
     /// - A location may refer to a repeated field itself (i.e. not to any
@@ -1001,7 +1001,7 @@ pub mod source_code_info {
         /// Each element is a field number or an index.  They form a path from
         /// the root FileDescriptorProto to the place where the definition.  For
         /// example, this path:
-        ///    [ 4, 3, 2, 7, 1 ]
+        ///    \[ 4, 3, 2, 7, 1 \]
         /// refers to:
         ///    file.message_type(3)  // 4, 3
         ///        .field(7)         // 2, 7
@@ -1015,7 +1015,7 @@ pub mod source_code_info {
         ///
         /// Thus, the above path gives the location of a field name.  If we removed
         /// the last element:
-        ///    [ 4, 3, 2, 7 ]
+        ///    \[ 4, 3, 2, 7 \]
         /// this path refers to the whole field declaration (from the beginning
         /// of the label to the terminating semicolon).
         #[prost(int32, repeated, tag = "1")]
@@ -1199,12 +1199,12 @@ pub mod generated_code_info {
 ///
 /// In JavaScript, one can convert a Date object to this format using the
 /// standard
-/// \[toISOString()\](<https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toISOString>)
+/// [toISOString()](<https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toISOString>)
 /// method. In Python, a standard `datetime.datetime` object can be converted
 /// to this format using
-/// \[`strftime`\](<https://docs.python.org/2/library/time.html#time.strftime>) with
+/// [`strftime`](<https://docs.python.org/2/library/time.html#time.strftime>) with
 /// the time format spec '%Y-%m-%dT%H:%M:%S.%fZ'. Likewise, in Java, one can use
-/// the Joda Time's \[`ISODateTimeFormat.dateTime()`\](
+/// the Joda Time's [`ISODateTimeFormat.dateTime()`](
 /// <http://joda-time.sourceforge.net/apidocs/org/joda/time/format/ISODateTimeFormat.html#dateTime(>)
 /// ) to obtain a formatter capable of generating timestamps in this format.
 ///

--- a/codegen/proto/src/generated/google.protobuf.rs
+++ b/codegen/proto/src/generated/google.protobuf.rs
@@ -1,11 +1,13 @@
 /// The protocol compiler can output a FileDescriptorSet containing the .proto
 /// files it parses.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct FileDescriptorSet {
     #[prost(message, repeated, tag = "1")]
     pub file: ::prost::alloc::vec::Vec<FileDescriptorProto>,
 }
 /// Describes a complete .proto file.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct FileDescriptorProto {
     /// file name, relative to root of source tree
@@ -47,6 +49,7 @@ pub struct FileDescriptorProto {
     pub syntax: ::core::option::Option<::prost::alloc::string::String>,
 }
 /// Describes a message type.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct DescriptorProto {
     #[prost(string, optional, tag = "1")]
@@ -74,6 +77,7 @@ pub struct DescriptorProto {
 }
 /// Nested message and enum types in `DescriptorProto`.
 pub mod descriptor_proto {
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct ExtensionRange {
         /// Inclusive.
@@ -88,6 +92,7 @@ pub mod descriptor_proto {
     /// Range of reserved tag numbers. Reserved tag numbers may not be used by
     /// fields or extension ranges in the same message. Reserved ranges may
     /// not overlap.
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct ReservedRange {
         /// Inclusive.
@@ -98,6 +103,7 @@ pub mod descriptor_proto {
         pub end: ::core::option::Option<i32>,
     }
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ExtensionRangeOptions {
     /// The parser stores options it doesn't recognize here. See above.
@@ -105,6 +111,7 @@ pub struct ExtensionRangeOptions {
     pub uninterpreted_option: ::prost::alloc::vec::Vec<UninterpretedOption>,
 }
 /// Describes a field within a message.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct FieldDescriptorProto {
     #[prost(string, optional, tag = "1")]
@@ -223,6 +230,30 @@ pub mod field_descriptor_proto {
                 Type::Sint64 => "TYPE_SINT64",
             }
         }
+        /// Creates an enum from field names used in the ProtoBuf definition.
+        pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+            match value {
+                "TYPE_DOUBLE" => Some(Self::Double),
+                "TYPE_FLOAT" => Some(Self::Float),
+                "TYPE_INT64" => Some(Self::Int64),
+                "TYPE_UINT64" => Some(Self::Uint64),
+                "TYPE_INT32" => Some(Self::Int32),
+                "TYPE_FIXED64" => Some(Self::Fixed64),
+                "TYPE_FIXED32" => Some(Self::Fixed32),
+                "TYPE_BOOL" => Some(Self::Bool),
+                "TYPE_STRING" => Some(Self::String),
+                "TYPE_GROUP" => Some(Self::Group),
+                "TYPE_MESSAGE" => Some(Self::Message),
+                "TYPE_BYTES" => Some(Self::Bytes),
+                "TYPE_UINT32" => Some(Self::Uint32),
+                "TYPE_ENUM" => Some(Self::Enum),
+                "TYPE_SFIXED32" => Some(Self::Sfixed32),
+                "TYPE_SFIXED64" => Some(Self::Sfixed64),
+                "TYPE_SINT32" => Some(Self::Sint32),
+                "TYPE_SINT64" => Some(Self::Sint64),
+                _ => None,
+            }
+        }
     }
     #[derive(
         Clone,
@@ -254,9 +285,19 @@ pub mod field_descriptor_proto {
                 Label::Repeated => "LABEL_REPEATED",
             }
         }
+        /// Creates an enum from field names used in the ProtoBuf definition.
+        pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+            match value {
+                "LABEL_OPTIONAL" => Some(Self::Optional),
+                "LABEL_REQUIRED" => Some(Self::Required),
+                "LABEL_REPEATED" => Some(Self::Repeated),
+                _ => None,
+            }
+        }
     }
 }
 /// Describes a oneof.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct OneofDescriptorProto {
     #[prost(string, optional, tag = "1")]
@@ -265,6 +306,7 @@ pub struct OneofDescriptorProto {
     pub options: ::core::option::Option<OneofOptions>,
 }
 /// Describes an enum type.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct EnumDescriptorProto {
     #[prost(string, optional, tag = "1")]
@@ -293,6 +335,7 @@ pub mod enum_descriptor_proto {
     /// Note that this is distinct from DescriptorProto.ReservedRange in that it
     /// is inclusive such that it can appropriately represent the entire int32
     /// domain.
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct EnumReservedRange {
         /// Inclusive.
@@ -304,6 +347,7 @@ pub mod enum_descriptor_proto {
     }
 }
 /// Describes a value within an enum.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct EnumValueDescriptorProto {
     #[prost(string, optional, tag = "1")]
@@ -314,6 +358,7 @@ pub struct EnumValueDescriptorProto {
     pub options: ::core::option::Option<EnumValueOptions>,
 }
 /// Describes a service.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ServiceDescriptorProto {
     #[prost(string, optional, tag = "1")]
@@ -324,6 +369,7 @@ pub struct ServiceDescriptorProto {
     pub options: ::core::option::Option<ServiceOptions>,
 }
 /// Describes a method of a service.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct MethodDescriptorProto {
     #[prost(string, optional, tag = "1")]
@@ -343,6 +389,7 @@ pub struct MethodDescriptorProto {
     #[prost(bool, optional, tag = "6", default = "false")]
     pub server_streaming: ::core::option::Option<bool>,
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct FileOptions {
     /// Sets the Java package where classes generated from this .proto will be
@@ -494,8 +541,18 @@ pub mod file_options {
                 OptimizeMode::LiteRuntime => "LITE_RUNTIME",
             }
         }
+        /// Creates an enum from field names used in the ProtoBuf definition.
+        pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+            match value {
+                "SPEED" => Some(Self::Speed),
+                "CODE_SIZE" => Some(Self::CodeSize),
+                "LITE_RUNTIME" => Some(Self::LiteRuntime),
+                _ => None,
+            }
+        }
     }
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct MessageOptions {
     /// Set true to use the old proto1 MessageSet wire format for extensions.
@@ -556,6 +613,7 @@ pub struct MessageOptions {
     #[prost(message, repeated, tag = "999")]
     pub uninterpreted_option: ::prost::alloc::vec::Vec<UninterpretedOption>,
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct FieldOptions {
     /// The ctype option instructs the C++ code generator to use a different
@@ -669,6 +727,15 @@ pub mod field_options {
                 CType::StringPiece => "STRING_PIECE",
             }
         }
+        /// Creates an enum from field names used in the ProtoBuf definition.
+        pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+            match value {
+                "STRING" => Some(Self::String),
+                "CORD" => Some(Self::Cord),
+                "STRING_PIECE" => Some(Self::StringPiece),
+                _ => None,
+            }
+        }
     }
     #[derive(
         Clone,
@@ -702,14 +769,25 @@ pub mod field_options {
                 JsType::JsNumber => "JS_NUMBER",
             }
         }
+        /// Creates an enum from field names used in the ProtoBuf definition.
+        pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+            match value {
+                "JS_NORMAL" => Some(Self::JsNormal),
+                "JS_STRING" => Some(Self::JsString),
+                "JS_NUMBER" => Some(Self::JsNumber),
+                _ => None,
+            }
+        }
     }
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct OneofOptions {
     /// The parser stores options it doesn't recognize here. See above.
     #[prost(message, repeated, tag = "999")]
     pub uninterpreted_option: ::prost::alloc::vec::Vec<UninterpretedOption>,
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct EnumOptions {
     /// Set this option to true to allow mapping different tag names to the same
@@ -726,6 +804,7 @@ pub struct EnumOptions {
     #[prost(message, repeated, tag = "999")]
     pub uninterpreted_option: ::prost::alloc::vec::Vec<UninterpretedOption>,
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct EnumValueOptions {
     /// Is this enum value deprecated?
@@ -738,6 +817,7 @@ pub struct EnumValueOptions {
     #[prost(message, repeated, tag = "999")]
     pub uninterpreted_option: ::prost::alloc::vec::Vec<UninterpretedOption>,
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ServiceOptions {
     /// Is this service deprecated?
@@ -750,6 +830,7 @@ pub struct ServiceOptions {
     #[prost(message, repeated, tag = "999")]
     pub uninterpreted_option: ::prost::alloc::vec::Vec<UninterpretedOption>,
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct MethodOptions {
     /// Is this method deprecated?
@@ -805,6 +886,15 @@ pub mod method_options {
                 IdempotencyLevel::Idempotent => "IDEMPOTENT",
             }
         }
+        /// Creates an enum from field names used in the ProtoBuf definition.
+        pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+            match value {
+                "IDEMPOTENCY_UNKNOWN" => Some(Self::IdempotencyUnknown),
+                "NO_SIDE_EFFECTS" => Some(Self::NoSideEffects),
+                "IDEMPOTENT" => Some(Self::Idempotent),
+                _ => None,
+            }
+        }
     }
 }
 /// A message representing a option the parser does not recognize. This only
@@ -813,6 +903,7 @@ pub mod method_options {
 /// options protos in descriptor objects (e.g. returned by Descriptor::options(),
 /// or produced by Descriptor::CopyTo()) will never have UninterpretedOptions
 /// in them.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct UninterpretedOption {
     #[prost(message, repeated, tag = "2")]
@@ -839,6 +930,7 @@ pub mod uninterpreted_option {
     /// extension (denoted with parentheses in options specs in .proto files).
     /// E.g.,{ ["foo", false], ["bar.baz", true], ["qux", false] } represents
     /// "foo.(bar.baz).qux".
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct NamePart {
         #[prost(string, required, tag = "1")]
@@ -849,6 +941,7 @@ pub mod uninterpreted_option {
 }
 /// Encapsulates information about the original source file from which a
 /// FileDescriptorProto was generated.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SourceCodeInfo {
     /// A Location identifies a piece of source code in a .proto file which
@@ -899,6 +992,7 @@ pub struct SourceCodeInfo {
 }
 /// Nested message and enum types in `SourceCodeInfo`.
 pub mod source_code_info {
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct Location {
         /// Identifies which part of the FileDescriptorProto was defined at this
@@ -993,6 +1087,7 @@ pub mod source_code_info {
 /// Describes the relationship between generated code and its original source
 /// file. A GeneratedCodeInfo message is associated with only one generated
 /// source file, but may contain references to different source .proto files.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GeneratedCodeInfo {
     /// An Annotation connects some span of text in generated code to an element
@@ -1002,6 +1097,7 @@ pub struct GeneratedCodeInfo {
 }
 /// Nested message and enum types in `GeneratedCodeInfo`.
 pub mod generated_code_info {
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct Annotation {
         /// Identifies the element in the original source .proto file. This field
@@ -1072,7 +1168,6 @@ pub mod generated_code_info {
 ///      Timestamp timestamp = Timestamp.newBuilder().setSeconds(millis / 1000)
 ///          .setNanos((int) ((millis % 1000) * 1000000)).build();
 ///
-///
 /// Example 5: Compute Timestamp from Java `Instant.now()`.
 ///
 ///      Instant now = Instant.now();
@@ -1080,7 +1175,6 @@ pub mod generated_code_info {
 ///      Timestamp timestamp =
 ///          Timestamp.newBuilder().setSeconds(now.getEpochSecond())
 ///              .setNanos(now.getNano()).build();
-///
 ///
 /// Example 6: Compute Timestamp from current time in Python.
 ///
@@ -1111,10 +1205,10 @@ pub mod generated_code_info {
 /// \[`strftime`\](<https://docs.python.org/2/library/time.html#time.strftime>) with
 /// the time format spec '%Y-%m-%dT%H:%M:%S.%fZ'. Likewise, in Java, one can use
 /// the Joda Time's \[`ISODateTimeFormat.dateTime()`\](
-/// <http://www.joda.org/joda-time/apidocs/org/joda/time/format/ISODateTimeFormat.html#dateTime%2D%2D>
+/// <http://joda-time.sourceforge.net/apidocs/org/joda/time/format/ISODateTimeFormat.html#dateTime(>)
 /// ) to obtain a formatter capable of generating timestamps in this format.
 ///
-///
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Timestamp {
     /// Represents seconds of UTC time since Unix epoch

--- a/codegen/proto/src/generated/grpc.health.v1.rs
+++ b/codegen/proto/src/generated/grpc.health.v1.rs
@@ -1,8 +1,10 @@
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct HealthCheckRequest {
     #[prost(string, tag = "1")]
     pub service: ::prost::alloc::string::String,
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct HealthCheckResponse {
     #[prost(enumeration = "health_check_response::ServingStatus", tag = "1")]
@@ -42,13 +44,177 @@ pub mod health_check_response {
                 ServingStatus::ServiceUnknown => "SERVICE_UNKNOWN",
             }
         }
+        /// Creates an enum from field names used in the ProtoBuf definition.
+        pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+            match value {
+                "UNKNOWN" => Some(Self::Unknown),
+                "SERVING" => Some(Self::Serving),
+                "NOT_SERVING" => Some(Self::NotServing),
+                "SERVICE_UNKNOWN" => Some(Self::ServiceUnknown),
+                _ => None,
+            }
+        }
+    }
+}
+/// Generated client implementations.
+pub mod health_client {
+    #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
+    use tonic::codegen::*;
+    use tonic::codegen::http::Uri;
+    #[derive(Debug, Clone)]
+    pub struct HealthClient<T> {
+        inner: tonic::client::Grpc<T>,
+    }
+    impl HealthClient<tonic::transport::Channel> {
+        /// Attempt to create a new client by connecting to a given endpoint.
+        pub async fn connect<D>(dst: D) -> Result<Self, tonic::transport::Error>
+        where
+            D: TryInto<tonic::transport::Endpoint>,
+            D::Error: Into<StdError>,
+        {
+            let conn = tonic::transport::Endpoint::new(dst)?.connect().await?;
+            Ok(Self::new(conn))
+        }
+    }
+    impl<T> HealthClient<T>
+    where
+        T: tonic::client::GrpcService<tonic::body::BoxBody>,
+        T::Error: Into<StdError>,
+        T::ResponseBody: Body<Data = Bytes> + Send + 'static,
+        <T::ResponseBody as Body>::Error: Into<StdError> + Send,
+    {
+        pub fn new(inner: T) -> Self {
+            let inner = tonic::client::Grpc::new(inner);
+            Self { inner }
+        }
+        pub fn with_origin(inner: T, origin: Uri) -> Self {
+            let inner = tonic::client::Grpc::with_origin(inner, origin);
+            Self { inner }
+        }
+        pub fn with_interceptor<F>(
+            inner: T,
+            interceptor: F,
+        ) -> HealthClient<InterceptedService<T, F>>
+        where
+            F: tonic::service::Interceptor,
+            T::ResponseBody: Default,
+            T: tonic::codegen::Service<
+                http::Request<tonic::body::BoxBody>,
+                Response = http::Response<
+                    <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
+                >,
+            >,
+            <T as tonic::codegen::Service<
+                http::Request<tonic::body::BoxBody>,
+            >>::Error: Into<StdError> + Send + Sync,
+        {
+            HealthClient::new(InterceptedService::new(inner, interceptor))
+        }
+        /// Compress requests with the given encoding.
+        ///
+        /// This requires the server to support it otherwise it might respond with an
+        /// error.
+        #[must_use]
+        pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.send_compressed(encoding);
+            self
+        }
+        /// Enable decompressing responses.
+        #[must_use]
+        pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.accept_compressed(encoding);
+            self
+        }
+        /// Limits the maximum size of a decoded message.
+        ///
+        /// Default: `4MB`
+        #[must_use]
+        pub fn max_decoding_message_size(mut self, limit: usize) -> Self {
+            self.inner = self.inner.max_decoding_message_size(limit);
+            self
+        }
+        /// Limits the maximum size of an encoded message.
+        ///
+        /// Default: `usize::MAX`
+        #[must_use]
+        pub fn max_encoding_message_size(mut self, limit: usize) -> Self {
+            self.inner = self.inner.max_encoding_message_size(limit);
+            self
+        }
+        /// If the requested service is unknown, the call will fail with status
+        /// NOT_FOUND.
+        pub async fn check(
+            &mut self,
+            request: impl tonic::IntoRequest<super::HealthCheckRequest>,
+        ) -> std::result::Result<
+            tonic::Response<super::HealthCheckResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/grpc.health.v1.Health/Check",
+            );
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("grpc.health.v1.Health", "Check"));
+            self.inner.unary(req, path, codec).await
+        }
+        /// Performs a watch for the serving status of the requested service.
+        /// The server will immediately send back a message indicating the current
+        /// serving status.  It will then subsequently send a new message whenever
+        /// the service's serving status changes.
+        ///
+        /// If the requested service is unknown when the call is received, the
+        /// server will send a message setting the serving status to
+        /// SERVICE_UNKNOWN but will *not* terminate the call.  If at some
+        /// future point, the serving status of the service becomes known, the
+        /// server will send a new message with the service's serving status.
+        ///
+        /// If the call terminates with status UNIMPLEMENTED, then clients
+        /// should assume this method is not supported and should not retry the
+        /// call.  If the call terminates with any other status (including OK),
+        /// clients should retry the call with appropriate exponential backoff.
+        pub async fn watch(
+            &mut self,
+            request: impl tonic::IntoRequest<super::HealthCheckRequest>,
+        ) -> std::result::Result<
+            tonic::Response<tonic::codec::Streaming<super::HealthCheckResponse>>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/grpc.health.v1.Health/Watch",
+            );
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("grpc.health.v1.Health", "Watch"));
+            self.inner.server_streaming(req, path, codec).await
+        }
     }
 }
 /// Generated server implementations.
 pub mod health_server {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
     use tonic::codegen::*;
-    ///Generated trait containing gRPC methods that should be implemented for use with HealthServer.
+    /// Generated trait containing gRPC methods that should be implemented for use with HealthServer.
     #[async_trait]
     pub trait Health: Send + Sync + 'static {
         /// If the requested service is unknown, the call will fail with status
@@ -56,10 +222,13 @@ pub mod health_server {
         async fn check(
             &self,
             request: tonic::Request<super::HealthCheckRequest>,
-        ) -> Result<tonic::Response<super::HealthCheckResponse>, tonic::Status>;
-        ///Server streaming response type for the Watch method.
+        ) -> std::result::Result<
+            tonic::Response<super::HealthCheckResponse>,
+            tonic::Status,
+        >;
+        /// Server streaming response type for the Watch method.
         type WatchStream: futures_core::Stream<
-                Item = Result<super::HealthCheckResponse, tonic::Status>,
+                Item = std::result::Result<super::HealthCheckResponse, tonic::Status>,
             >
             + Send
             + 'static;
@@ -81,13 +250,15 @@ pub mod health_server {
         async fn watch(
             &self,
             request: tonic::Request<super::HealthCheckRequest>,
-        ) -> Result<tonic::Response<Self::WatchStream>, tonic::Status>;
+        ) -> std::result::Result<tonic::Response<Self::WatchStream>, tonic::Status>;
     }
     #[derive(Debug)]
     pub struct HealthServer<T: Health> {
         inner: _Inner<T>,
         accept_compression_encodings: EnabledCompressionEncodings,
         send_compression_encodings: EnabledCompressionEncodings,
+        max_decoding_message_size: Option<usize>,
+        max_encoding_message_size: Option<usize>,
     }
     struct _Inner<T>(Arc<T>);
     impl<T: Health> HealthServer<T> {
@@ -100,6 +271,8 @@ pub mod health_server {
                 inner,
                 accept_compression_encodings: Default::default(),
                 send_compression_encodings: Default::default(),
+                max_decoding_message_size: None,
+                max_encoding_message_size: None,
             }
         }
         pub fn with_interceptor<F>(
@@ -123,6 +296,22 @@ pub mod health_server {
             self.send_compression_encodings.enable(encoding);
             self
         }
+        /// Limits the maximum size of a decoded message.
+        ///
+        /// Default: `4MB`
+        #[must_use]
+        pub fn max_decoding_message_size(mut self, limit: usize) -> Self {
+            self.max_decoding_message_size = Some(limit);
+            self
+        }
+        /// Limits the maximum size of an encoded message.
+        ///
+        /// Default: `usize::MAX`
+        #[must_use]
+        pub fn max_encoding_message_size(mut self, limit: usize) -> Self {
+            self.max_encoding_message_size = Some(limit);
+            self
+        }
     }
     impl<T, B> tonic::codegen::Service<http::Request<B>> for HealthServer<T>
     where
@@ -136,7 +325,7 @@ pub mod health_server {
         fn poll_ready(
             &mut self,
             _cx: &mut Context<'_>,
-        ) -> Poll<Result<(), Self::Error>> {
+        ) -> Poll<std::result::Result<(), Self::Error>> {
             Poll::Ready(Ok(()))
         }
         fn call(&mut self, req: http::Request<B>) -> Self::Future {
@@ -158,13 +347,15 @@ pub mod health_server {
                             &mut self,
                             request: tonic::Request<super::HealthCheckRequest>,
                         ) -> Self::Future {
-                            let inner = self.0.clone();
+                            let inner = Arc::clone(&self.0);
                             let fut = async move { (*inner).check(request).await };
                             Box::pin(fut)
                         }
                     }
                     let accept_compression_encodings = self.accept_compression_encodings;
                     let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
                     let inner = self.inner.clone();
                     let fut = async move {
                         let inner = inner.0;
@@ -174,6 +365,10 @@ pub mod health_server {
                             .apply_compression_config(
                                 accept_compression_encodings,
                                 send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
                             );
                         let res = grpc.unary(method, req).await;
                         Ok(res)
@@ -197,13 +392,15 @@ pub mod health_server {
                             &mut self,
                             request: tonic::Request<super::HealthCheckRequest>,
                         ) -> Self::Future {
-                            let inner = self.0.clone();
+                            let inner = Arc::clone(&self.0);
                             let fut = async move { (*inner).watch(request).await };
                             Box::pin(fut)
                         }
                     }
                     let accept_compression_encodings = self.accept_compression_encodings;
                     let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
                     let inner = self.inner.clone();
                     let fut = async move {
                         let inner = inner.0;
@@ -213,6 +410,10 @@ pub mod health_server {
                             .apply_compression_config(
                                 accept_compression_encodings,
                                 send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
                             );
                         let res = grpc.server_streaming(method, req).await;
                         Ok(res)
@@ -241,12 +442,14 @@ pub mod health_server {
                 inner,
                 accept_compression_encodings: self.accept_compression_encodings,
                 send_compression_encodings: self.send_compression_encodings,
+                max_decoding_message_size: self.max_decoding_message_size,
+                max_encoding_message_size: self.max_encoding_message_size,
             }
         }
     }
     impl<T: Health> Clone for _Inner<T> {
         fn clone(&self) -> Self {
-            Self(self.0.clone())
+            Self(Arc::clone(&self.0))
         }
     }
     impl<T: std::fmt::Debug> std::fmt::Debug for _Inner<T> {

--- a/codegen/proto/src/generated/grpc.health.v1.rs
+++ b/codegen/proto/src/generated/grpc.health.v1.rs
@@ -227,7 +227,7 @@ pub mod health_server {
             tonic::Status,
         >;
         /// Server streaming response type for the Watch method.
-        type WatchStream: futures_core::Stream<
+        type WatchStream: tonic::codegen::tokio_stream::Stream<
                 Item = std::result::Result<super::HealthCheckResponse, tonic::Status>,
             >
             + Send
@@ -348,7 +348,9 @@ pub mod health_server {
                             request: tonic::Request<super::HealthCheckRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
-                            let fut = async move { (*inner).check(request).await };
+                            let fut = async move {
+                                <T as Health>::check(&inner, request).await
+                            };
                             Box::pin(fut)
                         }
                     }
@@ -393,7 +395,9 @@ pub mod health_server {
                             request: tonic::Request<super::HealthCheckRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
-                            let fut = async move { (*inner).watch(request).await };
+                            let fut = async move {
+                                <T as Health>::watch(&inner, request).await
+                            };
                             Box::pin(fut)
                         }
                     }

--- a/codegen/proto/src/generated/moby.buildkit.v1.rs
+++ b/codegen/proto/src/generated/moby.buildkit.v1.rs
@@ -1,3 +1,4 @@
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct PruneRequest {
     #[prost(string, repeated, tag = "1")]
@@ -9,16 +10,19 @@ pub struct PruneRequest {
     #[prost(int64, tag = "4")]
     pub keep_bytes: i64,
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct DiskUsageRequest {
     #[prost(string, repeated, tag = "1")]
     pub filter: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct DiskUsageResponse {
     #[prost(message, repeated, tag = "1")]
     pub record: ::prost::alloc::vec::Vec<UsageRecord>,
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct UsageRecord {
     #[prost(string, tag = "1")]
@@ -51,6 +55,7 @@ pub struct UsageRecord {
     #[prost(string, repeated, tag = "12")]
     pub parents: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SolveRequest {
     #[prost(string, tag = "1")]
@@ -83,6 +88,7 @@ pub struct SolveRequest {
         super::super::super::pb::Definition,
     >,
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CacheOptions {
     /// ExportRefDeprecated is deprecated in favor or the new Exports since BuildKit v0.4.0.
@@ -111,6 +117,7 @@ pub struct CacheOptions {
     #[prost(message, repeated, tag = "5")]
     pub imports: ::prost::alloc::vec::Vec<CacheOptionsEntry>,
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CacheOptionsEntry {
     /// Type is like "registry" or "local"
@@ -124,6 +131,7 @@ pub struct CacheOptionsEntry {
         ::prost::alloc::string::String,
     >,
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SolveResponse {
     #[prost(map = "string, string", tag = "1")]
@@ -132,11 +140,13 @@ pub struct SolveResponse {
         ::prost::alloc::string::String,
     >,
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct StatusRequest {
     #[prost(string, tag = "1")]
     pub r#ref: ::prost::alloc::string::String,
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct StatusResponse {
     #[prost(message, repeated, tag = "1")]
@@ -148,6 +158,7 @@ pub struct StatusResponse {
     #[prost(message, repeated, tag = "4")]
     pub warnings: ::prost::alloc::vec::Vec<VertexWarning>,
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Vertex {
     #[prost(string, tag = "1")]
@@ -172,6 +183,7 @@ pub struct Vertex {
     #[prost(message, optional, tag = "8")]
     pub progress_group: ::core::option::Option<super::super::super::pb::ProgressGroup>,
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct VertexStatus {
     #[prost(string, tag = "1")]
@@ -197,6 +209,7 @@ pub struct VertexStatus {
         super::super::super::google::protobuf::Timestamp,
     >,
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct VertexLog {
     #[prost(string, tag = "1")]
@@ -210,6 +223,7 @@ pub struct VertexLog {
     #[prost(bytes = "vec", tag = "4")]
     pub msg: ::prost::alloc::vec::Vec<u8>,
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct VertexWarning {
     #[prost(string, tag = "1")]
@@ -227,88 +241,357 @@ pub struct VertexWarning {
     #[prost(message, repeated, tag = "7")]
     pub ranges: ::prost::alloc::vec::Vec<super::super::super::pb::Range>,
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct BytesMessage {
     #[prost(bytes = "vec", tag = "1")]
     pub data: ::prost::alloc::vec::Vec<u8>,
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ListWorkersRequest {
     /// containerd style
     #[prost(string, repeated, tag = "1")]
     pub filter: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ListWorkersResponse {
     #[prost(message, repeated, tag = "1")]
     pub record: ::prost::alloc::vec::Vec<types::WorkerRecord>,
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct InfoRequest {}
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct InfoResponse {
     #[prost(message, optional, tag = "1")]
     pub buildkit_version: ::core::option::Option<types::BuildkitVersion>,
 }
+/// Generated client implementations.
+pub mod control_client {
+    #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
+    use tonic::codegen::*;
+    use tonic::codegen::http::Uri;
+    #[derive(Debug, Clone)]
+    pub struct ControlClient<T> {
+        inner: tonic::client::Grpc<T>,
+    }
+    impl ControlClient<tonic::transport::Channel> {
+        /// Attempt to create a new client by connecting to a given endpoint.
+        pub async fn connect<D>(dst: D) -> Result<Self, tonic::transport::Error>
+        where
+            D: TryInto<tonic::transport::Endpoint>,
+            D::Error: Into<StdError>,
+        {
+            let conn = tonic::transport::Endpoint::new(dst)?.connect().await?;
+            Ok(Self::new(conn))
+        }
+    }
+    impl<T> ControlClient<T>
+    where
+        T: tonic::client::GrpcService<tonic::body::BoxBody>,
+        T::Error: Into<StdError>,
+        T::ResponseBody: Body<Data = Bytes> + Send + 'static,
+        <T::ResponseBody as Body>::Error: Into<StdError> + Send,
+    {
+        pub fn new(inner: T) -> Self {
+            let inner = tonic::client::Grpc::new(inner);
+            Self { inner }
+        }
+        pub fn with_origin(inner: T, origin: Uri) -> Self {
+            let inner = tonic::client::Grpc::with_origin(inner, origin);
+            Self { inner }
+        }
+        pub fn with_interceptor<F>(
+            inner: T,
+            interceptor: F,
+        ) -> ControlClient<InterceptedService<T, F>>
+        where
+            F: tonic::service::Interceptor,
+            T::ResponseBody: Default,
+            T: tonic::codegen::Service<
+                http::Request<tonic::body::BoxBody>,
+                Response = http::Response<
+                    <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
+                >,
+            >,
+            <T as tonic::codegen::Service<
+                http::Request<tonic::body::BoxBody>,
+            >>::Error: Into<StdError> + Send + Sync,
+        {
+            ControlClient::new(InterceptedService::new(inner, interceptor))
+        }
+        /// Compress requests with the given encoding.
+        ///
+        /// This requires the server to support it otherwise it might respond with an
+        /// error.
+        #[must_use]
+        pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.send_compressed(encoding);
+            self
+        }
+        /// Enable decompressing responses.
+        #[must_use]
+        pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.accept_compressed(encoding);
+            self
+        }
+        /// Limits the maximum size of a decoded message.
+        ///
+        /// Default: `4MB`
+        #[must_use]
+        pub fn max_decoding_message_size(mut self, limit: usize) -> Self {
+            self.inner = self.inner.max_decoding_message_size(limit);
+            self
+        }
+        /// Limits the maximum size of an encoded message.
+        ///
+        /// Default: `usize::MAX`
+        #[must_use]
+        pub fn max_encoding_message_size(mut self, limit: usize) -> Self {
+            self.inner = self.inner.max_encoding_message_size(limit);
+            self
+        }
+        pub async fn disk_usage(
+            &mut self,
+            request: impl tonic::IntoRequest<super::DiskUsageRequest>,
+        ) -> std::result::Result<
+            tonic::Response<super::DiskUsageResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/moby.buildkit.v1.Control/DiskUsage",
+            );
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("moby.buildkit.v1.Control", "DiskUsage"));
+            self.inner.unary(req, path, codec).await
+        }
+        pub async fn prune(
+            &mut self,
+            request: impl tonic::IntoRequest<super::PruneRequest>,
+        ) -> std::result::Result<
+            tonic::Response<tonic::codec::Streaming<super::UsageRecord>>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/moby.buildkit.v1.Control/Prune",
+            );
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("moby.buildkit.v1.Control", "Prune"));
+            self.inner.server_streaming(req, path, codec).await
+        }
+        pub async fn solve(
+            &mut self,
+            request: impl tonic::IntoRequest<super::SolveRequest>,
+        ) -> std::result::Result<tonic::Response<super::SolveResponse>, tonic::Status> {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/moby.buildkit.v1.Control/Solve",
+            );
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("moby.buildkit.v1.Control", "Solve"));
+            self.inner.unary(req, path, codec).await
+        }
+        pub async fn status(
+            &mut self,
+            request: impl tonic::IntoRequest<super::StatusRequest>,
+        ) -> std::result::Result<
+            tonic::Response<tonic::codec::Streaming<super::StatusResponse>>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/moby.buildkit.v1.Control/Status",
+            );
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("moby.buildkit.v1.Control", "Status"));
+            self.inner.server_streaming(req, path, codec).await
+        }
+        pub async fn session(
+            &mut self,
+            request: impl tonic::IntoStreamingRequest<Message = super::BytesMessage>,
+        ) -> std::result::Result<
+            tonic::Response<tonic::codec::Streaming<super::BytesMessage>>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/moby.buildkit.v1.Control/Session",
+            );
+            let mut req = request.into_streaming_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("moby.buildkit.v1.Control", "Session"));
+            self.inner.streaming(req, path, codec).await
+        }
+        pub async fn list_workers(
+            &mut self,
+            request: impl tonic::IntoRequest<super::ListWorkersRequest>,
+        ) -> std::result::Result<
+            tonic::Response<super::ListWorkersResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/moby.buildkit.v1.Control/ListWorkers",
+            );
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("moby.buildkit.v1.Control", "ListWorkers"));
+            self.inner.unary(req, path, codec).await
+        }
+        pub async fn info(
+            &mut self,
+            request: impl tonic::IntoRequest<super::InfoRequest>,
+        ) -> std::result::Result<tonic::Response<super::InfoResponse>, tonic::Status> {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/moby.buildkit.v1.Control/Info",
+            );
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("moby.buildkit.v1.Control", "Info"));
+            self.inner.unary(req, path, codec).await
+        }
+    }
+}
 /// Generated server implementations.
 pub mod control_server {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
     use tonic::codegen::*;
-    ///Generated trait containing gRPC methods that should be implemented for use with ControlServer.
+    /// Generated trait containing gRPC methods that should be implemented for use with ControlServer.
     #[async_trait]
     pub trait Control: Send + Sync + 'static {
         async fn disk_usage(
             &self,
             request: tonic::Request<super::DiskUsageRequest>,
-        ) -> Result<tonic::Response<super::DiskUsageResponse>, tonic::Status>;
-        ///Server streaming response type for the Prune method.
+        ) -> std::result::Result<
+            tonic::Response<super::DiskUsageResponse>,
+            tonic::Status,
+        >;
+        /// Server streaming response type for the Prune method.
         type PruneStream: futures_core::Stream<
-                Item = Result<super::UsageRecord, tonic::Status>,
+                Item = std::result::Result<super::UsageRecord, tonic::Status>,
             >
             + Send
             + 'static;
         async fn prune(
             &self,
             request: tonic::Request<super::PruneRequest>,
-        ) -> Result<tonic::Response<Self::PruneStream>, tonic::Status>;
+        ) -> std::result::Result<tonic::Response<Self::PruneStream>, tonic::Status>;
         async fn solve(
             &self,
             request: tonic::Request<super::SolveRequest>,
-        ) -> Result<tonic::Response<super::SolveResponse>, tonic::Status>;
-        ///Server streaming response type for the Status method.
+        ) -> std::result::Result<tonic::Response<super::SolveResponse>, tonic::Status>;
+        /// Server streaming response type for the Status method.
         type StatusStream: futures_core::Stream<
-                Item = Result<super::StatusResponse, tonic::Status>,
+                Item = std::result::Result<super::StatusResponse, tonic::Status>,
             >
             + Send
             + 'static;
         async fn status(
             &self,
             request: tonic::Request<super::StatusRequest>,
-        ) -> Result<tonic::Response<Self::StatusStream>, tonic::Status>;
-        ///Server streaming response type for the Session method.
+        ) -> std::result::Result<tonic::Response<Self::StatusStream>, tonic::Status>;
+        /// Server streaming response type for the Session method.
         type SessionStream: futures_core::Stream<
-                Item = Result<super::BytesMessage, tonic::Status>,
+                Item = std::result::Result<super::BytesMessage, tonic::Status>,
             >
             + Send
             + 'static;
         async fn session(
             &self,
             request: tonic::Request<tonic::Streaming<super::BytesMessage>>,
-        ) -> Result<tonic::Response<Self::SessionStream>, tonic::Status>;
+        ) -> std::result::Result<tonic::Response<Self::SessionStream>, tonic::Status>;
         async fn list_workers(
             &self,
             request: tonic::Request<super::ListWorkersRequest>,
-        ) -> Result<tonic::Response<super::ListWorkersResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::ListWorkersResponse>,
+            tonic::Status,
+        >;
         async fn info(
             &self,
             request: tonic::Request<super::InfoRequest>,
-        ) -> Result<tonic::Response<super::InfoResponse>, tonic::Status>;
+        ) -> std::result::Result<tonic::Response<super::InfoResponse>, tonic::Status>;
     }
     #[derive(Debug)]
     pub struct ControlServer<T: Control> {
         inner: _Inner<T>,
         accept_compression_encodings: EnabledCompressionEncodings,
         send_compression_encodings: EnabledCompressionEncodings,
+        max_decoding_message_size: Option<usize>,
+        max_encoding_message_size: Option<usize>,
     }
     struct _Inner<T>(Arc<T>);
     impl<T: Control> ControlServer<T> {
@@ -321,6 +604,8 @@ pub mod control_server {
                 inner,
                 accept_compression_encodings: Default::default(),
                 send_compression_encodings: Default::default(),
+                max_decoding_message_size: None,
+                max_encoding_message_size: None,
             }
         }
         pub fn with_interceptor<F>(
@@ -344,6 +629,22 @@ pub mod control_server {
             self.send_compression_encodings.enable(encoding);
             self
         }
+        /// Limits the maximum size of a decoded message.
+        ///
+        /// Default: `4MB`
+        #[must_use]
+        pub fn max_decoding_message_size(mut self, limit: usize) -> Self {
+            self.max_decoding_message_size = Some(limit);
+            self
+        }
+        /// Limits the maximum size of an encoded message.
+        ///
+        /// Default: `usize::MAX`
+        #[must_use]
+        pub fn max_encoding_message_size(mut self, limit: usize) -> Self {
+            self.max_encoding_message_size = Some(limit);
+            self
+        }
     }
     impl<T, B> tonic::codegen::Service<http::Request<B>> for ControlServer<T>
     where
@@ -357,7 +658,7 @@ pub mod control_server {
         fn poll_ready(
             &mut self,
             _cx: &mut Context<'_>,
-        ) -> Poll<Result<(), Self::Error>> {
+        ) -> Poll<std::result::Result<(), Self::Error>> {
             Poll::Ready(Ok(()))
         }
         fn call(&mut self, req: http::Request<B>) -> Self::Future {
@@ -377,13 +678,15 @@ pub mod control_server {
                             &mut self,
                             request: tonic::Request<super::DiskUsageRequest>,
                         ) -> Self::Future {
-                            let inner = self.0.clone();
+                            let inner = Arc::clone(&self.0);
                             let fut = async move { (*inner).disk_usage(request).await };
                             Box::pin(fut)
                         }
                     }
                     let accept_compression_encodings = self.accept_compression_encodings;
                     let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
                     let inner = self.inner.clone();
                     let fut = async move {
                         let inner = inner.0;
@@ -393,6 +696,10 @@ pub mod control_server {
                             .apply_compression_config(
                                 accept_compression_encodings,
                                 send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
                             );
                         let res = grpc.unary(method, req).await;
                         Ok(res)
@@ -416,13 +723,15 @@ pub mod control_server {
                             &mut self,
                             request: tonic::Request<super::PruneRequest>,
                         ) -> Self::Future {
-                            let inner = self.0.clone();
+                            let inner = Arc::clone(&self.0);
                             let fut = async move { (*inner).prune(request).await };
                             Box::pin(fut)
                         }
                     }
                     let accept_compression_encodings = self.accept_compression_encodings;
                     let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
                     let inner = self.inner.clone();
                     let fut = async move {
                         let inner = inner.0;
@@ -432,6 +741,10 @@ pub mod control_server {
                             .apply_compression_config(
                                 accept_compression_encodings,
                                 send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
                             );
                         let res = grpc.server_streaming(method, req).await;
                         Ok(res)
@@ -452,13 +765,15 @@ pub mod control_server {
                             &mut self,
                             request: tonic::Request<super::SolveRequest>,
                         ) -> Self::Future {
-                            let inner = self.0.clone();
+                            let inner = Arc::clone(&self.0);
                             let fut = async move { (*inner).solve(request).await };
                             Box::pin(fut)
                         }
                     }
                     let accept_compression_encodings = self.accept_compression_encodings;
                     let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
                     let inner = self.inner.clone();
                     let fut = async move {
                         let inner = inner.0;
@@ -468,6 +783,10 @@ pub mod control_server {
                             .apply_compression_config(
                                 accept_compression_encodings,
                                 send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
                             );
                         let res = grpc.unary(method, req).await;
                         Ok(res)
@@ -491,13 +810,15 @@ pub mod control_server {
                             &mut self,
                             request: tonic::Request<super::StatusRequest>,
                         ) -> Self::Future {
-                            let inner = self.0.clone();
+                            let inner = Arc::clone(&self.0);
                             let fut = async move { (*inner).status(request).await };
                             Box::pin(fut)
                         }
                     }
                     let accept_compression_encodings = self.accept_compression_encodings;
                     let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
                     let inner = self.inner.clone();
                     let fut = async move {
                         let inner = inner.0;
@@ -507,6 +828,10 @@ pub mod control_server {
                             .apply_compression_config(
                                 accept_compression_encodings,
                                 send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
                             );
                         let res = grpc.server_streaming(method, req).await;
                         Ok(res)
@@ -530,13 +855,15 @@ pub mod control_server {
                                 tonic::Streaming<super::BytesMessage>,
                             >,
                         ) -> Self::Future {
-                            let inner = self.0.clone();
+                            let inner = Arc::clone(&self.0);
                             let fut = async move { (*inner).session(request).await };
                             Box::pin(fut)
                         }
                     }
                     let accept_compression_encodings = self.accept_compression_encodings;
                     let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
                     let inner = self.inner.clone();
                     let fut = async move {
                         let inner = inner.0;
@@ -546,6 +873,10 @@ pub mod control_server {
                             .apply_compression_config(
                                 accept_compression_encodings,
                                 send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
                             );
                         let res = grpc.streaming(method, req).await;
                         Ok(res)
@@ -568,7 +899,7 @@ pub mod control_server {
                             &mut self,
                             request: tonic::Request<super::ListWorkersRequest>,
                         ) -> Self::Future {
-                            let inner = self.0.clone();
+                            let inner = Arc::clone(&self.0);
                             let fut = async move {
                                 (*inner).list_workers(request).await
                             };
@@ -577,6 +908,8 @@ pub mod control_server {
                     }
                     let accept_compression_encodings = self.accept_compression_encodings;
                     let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
                     let inner = self.inner.clone();
                     let fut = async move {
                         let inner = inner.0;
@@ -586,6 +919,10 @@ pub mod control_server {
                             .apply_compression_config(
                                 accept_compression_encodings,
                                 send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
                             );
                         let res = grpc.unary(method, req).await;
                         Ok(res)
@@ -606,13 +943,15 @@ pub mod control_server {
                             &mut self,
                             request: tonic::Request<super::InfoRequest>,
                         ) -> Self::Future {
-                            let inner = self.0.clone();
+                            let inner = Arc::clone(&self.0);
                             let fut = async move { (*inner).info(request).await };
                             Box::pin(fut)
                         }
                     }
                     let accept_compression_encodings = self.accept_compression_encodings;
                     let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
                     let inner = self.inner.clone();
                     let fut = async move {
                         let inner = inner.0;
@@ -622,6 +961,10 @@ pub mod control_server {
                             .apply_compression_config(
                                 accept_compression_encodings,
                                 send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
                             );
                         let res = grpc.unary(method, req).await;
                         Ok(res)
@@ -650,12 +993,14 @@ pub mod control_server {
                 inner,
                 accept_compression_encodings: self.accept_compression_encodings,
                 send_compression_encodings: self.send_compression_encodings,
+                max_decoding_message_size: self.max_decoding_message_size,
+                max_encoding_message_size: self.max_encoding_message_size,
             }
         }
     }
     impl<T: Control> Clone for _Inner<T> {
         fn clone(&self) -> Self {
-            Self(self.0.clone())
+            Self(Arc::clone(&self.0))
         }
     }
     impl<T: std::fmt::Debug> std::fmt::Debug for _Inner<T> {

--- a/codegen/proto/src/generated/moby.buildkit.v1.rs
+++ b/codegen/proto/src/generated/moby.buildkit.v1.rs
@@ -540,7 +540,7 @@ pub mod control_server {
             tonic::Status,
         >;
         /// Server streaming response type for the Prune method.
-        type PruneStream: futures_core::Stream<
+        type PruneStream: tonic::codegen::tokio_stream::Stream<
                 Item = std::result::Result<super::UsageRecord, tonic::Status>,
             >
             + Send
@@ -554,7 +554,7 @@ pub mod control_server {
             request: tonic::Request<super::SolveRequest>,
         ) -> std::result::Result<tonic::Response<super::SolveResponse>, tonic::Status>;
         /// Server streaming response type for the Status method.
-        type StatusStream: futures_core::Stream<
+        type StatusStream: tonic::codegen::tokio_stream::Stream<
                 Item = std::result::Result<super::StatusResponse, tonic::Status>,
             >
             + Send
@@ -564,7 +564,7 @@ pub mod control_server {
             request: tonic::Request<super::StatusRequest>,
         ) -> std::result::Result<tonic::Response<Self::StatusStream>, tonic::Status>;
         /// Server streaming response type for the Session method.
-        type SessionStream: futures_core::Stream<
+        type SessionStream: tonic::codegen::tokio_stream::Stream<
                 Item = std::result::Result<super::BytesMessage, tonic::Status>,
             >
             + Send
@@ -679,7 +679,9 @@ pub mod control_server {
                             request: tonic::Request<super::DiskUsageRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
-                            let fut = async move { (*inner).disk_usage(request).await };
+                            let fut = async move {
+                                <T as Control>::disk_usage(&inner, request).await
+                            };
                             Box::pin(fut)
                         }
                     }
@@ -724,7 +726,9 @@ pub mod control_server {
                             request: tonic::Request<super::PruneRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
-                            let fut = async move { (*inner).prune(request).await };
+                            let fut = async move {
+                                <T as Control>::prune(&inner, request).await
+                            };
                             Box::pin(fut)
                         }
                     }
@@ -766,7 +770,9 @@ pub mod control_server {
                             request: tonic::Request<super::SolveRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
-                            let fut = async move { (*inner).solve(request).await };
+                            let fut = async move {
+                                <T as Control>::solve(&inner, request).await
+                            };
                             Box::pin(fut)
                         }
                     }
@@ -811,7 +817,9 @@ pub mod control_server {
                             request: tonic::Request<super::StatusRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
-                            let fut = async move { (*inner).status(request).await };
+                            let fut = async move {
+                                <T as Control>::status(&inner, request).await
+                            };
                             Box::pin(fut)
                         }
                     }
@@ -856,7 +864,9 @@ pub mod control_server {
                             >,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
-                            let fut = async move { (*inner).session(request).await };
+                            let fut = async move {
+                                <T as Control>::session(&inner, request).await
+                            };
                             Box::pin(fut)
                         }
                     }
@@ -901,7 +911,7 @@ pub mod control_server {
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                (*inner).list_workers(request).await
+                                <T as Control>::list_workers(&inner, request).await
                             };
                             Box::pin(fut)
                         }
@@ -944,7 +954,9 @@ pub mod control_server {
                             request: tonic::Request<super::InfoRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
-                            let fut = async move { (*inner).info(request).await };
+                            let fut = async move {
+                                <T as Control>::info(&inner, request).await
+                            };
                             Box::pin(fut)
                         }
                     }

--- a/codegen/proto/src/generated/moby.buildkit.v1.types.rs
+++ b/codegen/proto/src/generated/moby.buildkit.v1.types.rs
@@ -1,3 +1,4 @@
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct WorkerRecord {
     #[prost(string, tag = "1")]
@@ -14,6 +15,7 @@ pub struct WorkerRecord {
     #[prost(message, optional, tag = "5")]
     pub buildkit_version: ::core::option::Option<BuildkitVersion>,
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GcPolicy {
     #[prost(bool, tag = "1")]
@@ -25,6 +27,7 @@ pub struct GcPolicy {
     #[prost(string, repeated, tag = "4")]
     pub filters: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct BuildkitVersion {
     #[prost(string, tag = "1")]

--- a/codegen/proto/src/generated/moby.filesync.v1.rs
+++ b/codegen/proto/src/generated/moby.filesync.v1.rs
@@ -274,7 +274,7 @@ pub mod file_sync_server {
     #[async_trait]
     pub trait FileSync: Send + Sync + 'static {
         /// Server streaming response type for the DiffCopy method.
-        type DiffCopyStream: futures_core::Stream<
+        type DiffCopyStream: tonic::codegen::tokio_stream::Stream<
                 Item = std::result::Result<
                     super::super::super::super::fsutil::types::Packet,
                     tonic::Status,
@@ -289,7 +289,7 @@ pub mod file_sync_server {
             >,
         ) -> std::result::Result<tonic::Response<Self::DiffCopyStream>, tonic::Status>;
         /// Server streaming response type for the TarStream method.
-        type TarStreamStream: futures_core::Stream<
+        type TarStreamStream: tonic::codegen::tokio_stream::Stream<
                 Item = std::result::Result<
                     super::super::super::super::fsutil::types::Packet,
                     tonic::Status,
@@ -406,7 +406,9 @@ pub mod file_sync_server {
                             >,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
-                            let fut = async move { (*inner).diff_copy(request).await };
+                            let fut = async move {
+                                <T as FileSync>::diff_copy(&inner, request).await
+                            };
                             Box::pin(fut)
                         }
                     }
@@ -456,7 +458,9 @@ pub mod file_sync_server {
                             >,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
-                            let fut = async move { (*inner).tar_stream(request).await };
+                            let fut = async move {
+                                <T as FileSync>::tar_stream(&inner, request).await
+                            };
                             Box::pin(fut)
                         }
                     }
@@ -532,7 +536,7 @@ pub mod file_send_server {
     #[async_trait]
     pub trait FileSend: Send + Sync + 'static {
         /// Server streaming response type for the DiffCopy method.
-        type DiffCopyStream: futures_core::Stream<
+        type DiffCopyStream: tonic::codegen::tokio_stream::Stream<
                 Item = std::result::Result<super::BytesMessage, tonic::Status>,
             >
             + Send
@@ -641,7 +645,9 @@ pub mod file_send_server {
                             >,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
-                            let fut = async move { (*inner).diff_copy(request).await };
+                            let fut = async move {
+                                <T as FileSend>::diff_copy(&inner, request).await
+                            };
                             Box::pin(fut)
                         }
                     }

--- a/codegen/proto/src/generated/moby.filesync.v1.rs
+++ b/codegen/proto/src/generated/moby.filesync.v1.rs
@@ -1,0 +1,711 @@
+/// BytesMessage contains a chunk of byte data
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct BytesMessage {
+    #[prost(bytes = "vec", tag = "1")]
+    pub data: ::prost::alloc::vec::Vec<u8>,
+}
+/// Generated client implementations.
+pub mod file_sync_client {
+    #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
+    use tonic::codegen::*;
+    use tonic::codegen::http::Uri;
+    #[derive(Debug, Clone)]
+    pub struct FileSyncClient<T> {
+        inner: tonic::client::Grpc<T>,
+    }
+    impl FileSyncClient<tonic::transport::Channel> {
+        /// Attempt to create a new client by connecting to a given endpoint.
+        pub async fn connect<D>(dst: D) -> Result<Self, tonic::transport::Error>
+        where
+            D: TryInto<tonic::transport::Endpoint>,
+            D::Error: Into<StdError>,
+        {
+            let conn = tonic::transport::Endpoint::new(dst)?.connect().await?;
+            Ok(Self::new(conn))
+        }
+    }
+    impl<T> FileSyncClient<T>
+    where
+        T: tonic::client::GrpcService<tonic::body::BoxBody>,
+        T::Error: Into<StdError>,
+        T::ResponseBody: Body<Data = Bytes> + Send + 'static,
+        <T::ResponseBody as Body>::Error: Into<StdError> + Send,
+    {
+        pub fn new(inner: T) -> Self {
+            let inner = tonic::client::Grpc::new(inner);
+            Self { inner }
+        }
+        pub fn with_origin(inner: T, origin: Uri) -> Self {
+            let inner = tonic::client::Grpc::with_origin(inner, origin);
+            Self { inner }
+        }
+        pub fn with_interceptor<F>(
+            inner: T,
+            interceptor: F,
+        ) -> FileSyncClient<InterceptedService<T, F>>
+        where
+            F: tonic::service::Interceptor,
+            T::ResponseBody: Default,
+            T: tonic::codegen::Service<
+                http::Request<tonic::body::BoxBody>,
+                Response = http::Response<
+                    <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
+                >,
+            >,
+            <T as tonic::codegen::Service<
+                http::Request<tonic::body::BoxBody>,
+            >>::Error: Into<StdError> + Send + Sync,
+        {
+            FileSyncClient::new(InterceptedService::new(inner, interceptor))
+        }
+        /// Compress requests with the given encoding.
+        ///
+        /// This requires the server to support it otherwise it might respond with an
+        /// error.
+        #[must_use]
+        pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.send_compressed(encoding);
+            self
+        }
+        /// Enable decompressing responses.
+        #[must_use]
+        pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.accept_compressed(encoding);
+            self
+        }
+        /// Limits the maximum size of a decoded message.
+        ///
+        /// Default: `4MB`
+        #[must_use]
+        pub fn max_decoding_message_size(mut self, limit: usize) -> Self {
+            self.inner = self.inner.max_decoding_message_size(limit);
+            self
+        }
+        /// Limits the maximum size of an encoded message.
+        ///
+        /// Default: `usize::MAX`
+        #[must_use]
+        pub fn max_encoding_message_size(mut self, limit: usize) -> Self {
+            self.inner = self.inner.max_encoding_message_size(limit);
+            self
+        }
+        pub async fn diff_copy(
+            &mut self,
+            request: impl tonic::IntoStreamingRequest<
+                Message = super::super::super::super::fsutil::types::Packet,
+            >,
+        ) -> std::result::Result<
+            tonic::Response<
+                tonic::codec::Streaming<
+                    super::super::super::super::fsutil::types::Packet,
+                >,
+            >,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/moby.filesync.v1.FileSync/DiffCopy",
+            );
+            let mut req = request.into_streaming_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("moby.filesync.v1.FileSync", "DiffCopy"));
+            self.inner.streaming(req, path, codec).await
+        }
+        pub async fn tar_stream(
+            &mut self,
+            request: impl tonic::IntoStreamingRequest<
+                Message = super::super::super::super::fsutil::types::Packet,
+            >,
+        ) -> std::result::Result<
+            tonic::Response<
+                tonic::codec::Streaming<
+                    super::super::super::super::fsutil::types::Packet,
+                >,
+            >,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/moby.filesync.v1.FileSync/TarStream",
+            );
+            let mut req = request.into_streaming_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("moby.filesync.v1.FileSync", "TarStream"));
+            self.inner.streaming(req, path, codec).await
+        }
+    }
+}
+/// Generated client implementations.
+pub mod file_send_client {
+    #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
+    use tonic::codegen::*;
+    use tonic::codegen::http::Uri;
+    #[derive(Debug, Clone)]
+    pub struct FileSendClient<T> {
+        inner: tonic::client::Grpc<T>,
+    }
+    impl FileSendClient<tonic::transport::Channel> {
+        /// Attempt to create a new client by connecting to a given endpoint.
+        pub async fn connect<D>(dst: D) -> Result<Self, tonic::transport::Error>
+        where
+            D: TryInto<tonic::transport::Endpoint>,
+            D::Error: Into<StdError>,
+        {
+            let conn = tonic::transport::Endpoint::new(dst)?.connect().await?;
+            Ok(Self::new(conn))
+        }
+    }
+    impl<T> FileSendClient<T>
+    where
+        T: tonic::client::GrpcService<tonic::body::BoxBody>,
+        T::Error: Into<StdError>,
+        T::ResponseBody: Body<Data = Bytes> + Send + 'static,
+        <T::ResponseBody as Body>::Error: Into<StdError> + Send,
+    {
+        pub fn new(inner: T) -> Self {
+            let inner = tonic::client::Grpc::new(inner);
+            Self { inner }
+        }
+        pub fn with_origin(inner: T, origin: Uri) -> Self {
+            let inner = tonic::client::Grpc::with_origin(inner, origin);
+            Self { inner }
+        }
+        pub fn with_interceptor<F>(
+            inner: T,
+            interceptor: F,
+        ) -> FileSendClient<InterceptedService<T, F>>
+        where
+            F: tonic::service::Interceptor,
+            T::ResponseBody: Default,
+            T: tonic::codegen::Service<
+                http::Request<tonic::body::BoxBody>,
+                Response = http::Response<
+                    <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
+                >,
+            >,
+            <T as tonic::codegen::Service<
+                http::Request<tonic::body::BoxBody>,
+            >>::Error: Into<StdError> + Send + Sync,
+        {
+            FileSendClient::new(InterceptedService::new(inner, interceptor))
+        }
+        /// Compress requests with the given encoding.
+        ///
+        /// This requires the server to support it otherwise it might respond with an
+        /// error.
+        #[must_use]
+        pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.send_compressed(encoding);
+            self
+        }
+        /// Enable decompressing responses.
+        #[must_use]
+        pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.accept_compressed(encoding);
+            self
+        }
+        /// Limits the maximum size of a decoded message.
+        ///
+        /// Default: `4MB`
+        #[must_use]
+        pub fn max_decoding_message_size(mut self, limit: usize) -> Self {
+            self.inner = self.inner.max_decoding_message_size(limit);
+            self
+        }
+        /// Limits the maximum size of an encoded message.
+        ///
+        /// Default: `usize::MAX`
+        #[must_use]
+        pub fn max_encoding_message_size(mut self, limit: usize) -> Self {
+            self.inner = self.inner.max_encoding_message_size(limit);
+            self
+        }
+        pub async fn diff_copy(
+            &mut self,
+            request: impl tonic::IntoStreamingRequest<Message = super::BytesMessage>,
+        ) -> std::result::Result<
+            tonic::Response<tonic::codec::Streaming<super::BytesMessage>>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/moby.filesync.v1.FileSend/DiffCopy",
+            );
+            let mut req = request.into_streaming_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("moby.filesync.v1.FileSend", "DiffCopy"));
+            self.inner.streaming(req, path, codec).await
+        }
+    }
+}
+/// Generated server implementations.
+pub mod file_sync_server {
+    #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
+    use tonic::codegen::*;
+    /// Generated trait containing gRPC methods that should be implemented for use with FileSyncServer.
+    #[async_trait]
+    pub trait FileSync: Send + Sync + 'static {
+        /// Server streaming response type for the DiffCopy method.
+        type DiffCopyStream: futures_core::Stream<
+                Item = std::result::Result<
+                    super::super::super::super::fsutil::types::Packet,
+                    tonic::Status,
+                >,
+            >
+            + Send
+            + 'static;
+        async fn diff_copy(
+            &self,
+            request: tonic::Request<
+                tonic::Streaming<super::super::super::super::fsutil::types::Packet>,
+            >,
+        ) -> std::result::Result<tonic::Response<Self::DiffCopyStream>, tonic::Status>;
+        /// Server streaming response type for the TarStream method.
+        type TarStreamStream: futures_core::Stream<
+                Item = std::result::Result<
+                    super::super::super::super::fsutil::types::Packet,
+                    tonic::Status,
+                >,
+            >
+            + Send
+            + 'static;
+        async fn tar_stream(
+            &self,
+            request: tonic::Request<
+                tonic::Streaming<super::super::super::super::fsutil::types::Packet>,
+            >,
+        ) -> std::result::Result<tonic::Response<Self::TarStreamStream>, tonic::Status>;
+    }
+    #[derive(Debug)]
+    pub struct FileSyncServer<T: FileSync> {
+        inner: _Inner<T>,
+        accept_compression_encodings: EnabledCompressionEncodings,
+        send_compression_encodings: EnabledCompressionEncodings,
+        max_decoding_message_size: Option<usize>,
+        max_encoding_message_size: Option<usize>,
+    }
+    struct _Inner<T>(Arc<T>);
+    impl<T: FileSync> FileSyncServer<T> {
+        pub fn new(inner: T) -> Self {
+            Self::from_arc(Arc::new(inner))
+        }
+        pub fn from_arc(inner: Arc<T>) -> Self {
+            let inner = _Inner(inner);
+            Self {
+                inner,
+                accept_compression_encodings: Default::default(),
+                send_compression_encodings: Default::default(),
+                max_decoding_message_size: None,
+                max_encoding_message_size: None,
+            }
+        }
+        pub fn with_interceptor<F>(
+            inner: T,
+            interceptor: F,
+        ) -> InterceptedService<Self, F>
+        where
+            F: tonic::service::Interceptor,
+        {
+            InterceptedService::new(Self::new(inner), interceptor)
+        }
+        /// Enable decompressing requests with the given encoding.
+        #[must_use]
+        pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.accept_compression_encodings.enable(encoding);
+            self
+        }
+        /// Compress responses with the given encoding, if the client supports it.
+        #[must_use]
+        pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.send_compression_encodings.enable(encoding);
+            self
+        }
+        /// Limits the maximum size of a decoded message.
+        ///
+        /// Default: `4MB`
+        #[must_use]
+        pub fn max_decoding_message_size(mut self, limit: usize) -> Self {
+            self.max_decoding_message_size = Some(limit);
+            self
+        }
+        /// Limits the maximum size of an encoded message.
+        ///
+        /// Default: `usize::MAX`
+        #[must_use]
+        pub fn max_encoding_message_size(mut self, limit: usize) -> Self {
+            self.max_encoding_message_size = Some(limit);
+            self
+        }
+    }
+    impl<T, B> tonic::codegen::Service<http::Request<B>> for FileSyncServer<T>
+    where
+        T: FileSync,
+        B: Body + Send + 'static,
+        B::Error: Into<StdError> + Send + 'static,
+    {
+        type Response = http::Response<tonic::body::BoxBody>;
+        type Error = std::convert::Infallible;
+        type Future = BoxFuture<Self::Response, Self::Error>;
+        fn poll_ready(
+            &mut self,
+            _cx: &mut Context<'_>,
+        ) -> Poll<std::result::Result<(), Self::Error>> {
+            Poll::Ready(Ok(()))
+        }
+        fn call(&mut self, req: http::Request<B>) -> Self::Future {
+            let inner = self.inner.clone();
+            match req.uri().path() {
+                "/moby.filesync.v1.FileSync/DiffCopy" => {
+                    #[allow(non_camel_case_types)]
+                    struct DiffCopySvc<T: FileSync>(pub Arc<T>);
+                    impl<
+                        T: FileSync,
+                    > tonic::server::StreamingService<
+                        super::super::super::super::fsutil::types::Packet,
+                    > for DiffCopySvc<T> {
+                        type Response = super::super::super::super::fsutil::types::Packet;
+                        type ResponseStream = T::DiffCopyStream;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::ResponseStream>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<
+                                tonic::Streaming<
+                                    super::super::super::super::fsutil::types::Packet,
+                                >,
+                            >,
+                        ) -> Self::Future {
+                            let inner = Arc::clone(&self.0);
+                            let fut = async move { (*inner).diff_copy(request).await };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let inner = inner.0;
+                        let method = DiffCopySvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
+                        let res = grpc.streaming(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/moby.filesync.v1.FileSync/TarStream" => {
+                    #[allow(non_camel_case_types)]
+                    struct TarStreamSvc<T: FileSync>(pub Arc<T>);
+                    impl<
+                        T: FileSync,
+                    > tonic::server::StreamingService<
+                        super::super::super::super::fsutil::types::Packet,
+                    > for TarStreamSvc<T> {
+                        type Response = super::super::super::super::fsutil::types::Packet;
+                        type ResponseStream = T::TarStreamStream;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::ResponseStream>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<
+                                tonic::Streaming<
+                                    super::super::super::super::fsutil::types::Packet,
+                                >,
+                            >,
+                        ) -> Self::Future {
+                            let inner = Arc::clone(&self.0);
+                            let fut = async move { (*inner).tar_stream(request).await };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let inner = inner.0;
+                        let method = TarStreamSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
+                        let res = grpc.streaming(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                _ => {
+                    Box::pin(async move {
+                        Ok(
+                            http::Response::builder()
+                                .status(200)
+                                .header("grpc-status", "12")
+                                .header("content-type", "application/grpc")
+                                .body(empty_body())
+                                .unwrap(),
+                        )
+                    })
+                }
+            }
+        }
+    }
+    impl<T: FileSync> Clone for FileSyncServer<T> {
+        fn clone(&self) -> Self {
+            let inner = self.inner.clone();
+            Self {
+                inner,
+                accept_compression_encodings: self.accept_compression_encodings,
+                send_compression_encodings: self.send_compression_encodings,
+                max_decoding_message_size: self.max_decoding_message_size,
+                max_encoding_message_size: self.max_encoding_message_size,
+            }
+        }
+    }
+    impl<T: FileSync> Clone for _Inner<T> {
+        fn clone(&self) -> Self {
+            Self(Arc::clone(&self.0))
+        }
+    }
+    impl<T: std::fmt::Debug> std::fmt::Debug for _Inner<T> {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "{:?}", self.0)
+        }
+    }
+    impl<T: FileSync> tonic::server::NamedService for FileSyncServer<T> {
+        const NAME: &'static str = "moby.filesync.v1.FileSync";
+    }
+}
+/// Generated server implementations.
+pub mod file_send_server {
+    #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
+    use tonic::codegen::*;
+    /// Generated trait containing gRPC methods that should be implemented for use with FileSendServer.
+    #[async_trait]
+    pub trait FileSend: Send + Sync + 'static {
+        /// Server streaming response type for the DiffCopy method.
+        type DiffCopyStream: futures_core::Stream<
+                Item = std::result::Result<super::BytesMessage, tonic::Status>,
+            >
+            + Send
+            + 'static;
+        async fn diff_copy(
+            &self,
+            request: tonic::Request<tonic::Streaming<super::BytesMessage>>,
+        ) -> std::result::Result<tonic::Response<Self::DiffCopyStream>, tonic::Status>;
+    }
+    #[derive(Debug)]
+    pub struct FileSendServer<T: FileSend> {
+        inner: _Inner<T>,
+        accept_compression_encodings: EnabledCompressionEncodings,
+        send_compression_encodings: EnabledCompressionEncodings,
+        max_decoding_message_size: Option<usize>,
+        max_encoding_message_size: Option<usize>,
+    }
+    struct _Inner<T>(Arc<T>);
+    impl<T: FileSend> FileSendServer<T> {
+        pub fn new(inner: T) -> Self {
+            Self::from_arc(Arc::new(inner))
+        }
+        pub fn from_arc(inner: Arc<T>) -> Self {
+            let inner = _Inner(inner);
+            Self {
+                inner,
+                accept_compression_encodings: Default::default(),
+                send_compression_encodings: Default::default(),
+                max_decoding_message_size: None,
+                max_encoding_message_size: None,
+            }
+        }
+        pub fn with_interceptor<F>(
+            inner: T,
+            interceptor: F,
+        ) -> InterceptedService<Self, F>
+        where
+            F: tonic::service::Interceptor,
+        {
+            InterceptedService::new(Self::new(inner), interceptor)
+        }
+        /// Enable decompressing requests with the given encoding.
+        #[must_use]
+        pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.accept_compression_encodings.enable(encoding);
+            self
+        }
+        /// Compress responses with the given encoding, if the client supports it.
+        #[must_use]
+        pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.send_compression_encodings.enable(encoding);
+            self
+        }
+        /// Limits the maximum size of a decoded message.
+        ///
+        /// Default: `4MB`
+        #[must_use]
+        pub fn max_decoding_message_size(mut self, limit: usize) -> Self {
+            self.max_decoding_message_size = Some(limit);
+            self
+        }
+        /// Limits the maximum size of an encoded message.
+        ///
+        /// Default: `usize::MAX`
+        #[must_use]
+        pub fn max_encoding_message_size(mut self, limit: usize) -> Self {
+            self.max_encoding_message_size = Some(limit);
+            self
+        }
+    }
+    impl<T, B> tonic::codegen::Service<http::Request<B>> for FileSendServer<T>
+    where
+        T: FileSend,
+        B: Body + Send + 'static,
+        B::Error: Into<StdError> + Send + 'static,
+    {
+        type Response = http::Response<tonic::body::BoxBody>;
+        type Error = std::convert::Infallible;
+        type Future = BoxFuture<Self::Response, Self::Error>;
+        fn poll_ready(
+            &mut self,
+            _cx: &mut Context<'_>,
+        ) -> Poll<std::result::Result<(), Self::Error>> {
+            Poll::Ready(Ok(()))
+        }
+        fn call(&mut self, req: http::Request<B>) -> Self::Future {
+            let inner = self.inner.clone();
+            match req.uri().path() {
+                "/moby.filesync.v1.FileSend/DiffCopy" => {
+                    #[allow(non_camel_case_types)]
+                    struct DiffCopySvc<T: FileSend>(pub Arc<T>);
+                    impl<
+                        T: FileSend,
+                    > tonic::server::StreamingService<super::BytesMessage>
+                    for DiffCopySvc<T> {
+                        type Response = super::BytesMessage;
+                        type ResponseStream = T::DiffCopyStream;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::ResponseStream>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<
+                                tonic::Streaming<super::BytesMessage>,
+                            >,
+                        ) -> Self::Future {
+                            let inner = Arc::clone(&self.0);
+                            let fut = async move { (*inner).diff_copy(request).await };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let inner = inner.0;
+                        let method = DiffCopySvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
+                        let res = grpc.streaming(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                _ => {
+                    Box::pin(async move {
+                        Ok(
+                            http::Response::builder()
+                                .status(200)
+                                .header("grpc-status", "12")
+                                .header("content-type", "application/grpc")
+                                .body(empty_body())
+                                .unwrap(),
+                        )
+                    })
+                }
+            }
+        }
+    }
+    impl<T: FileSend> Clone for FileSendServer<T> {
+        fn clone(&self) -> Self {
+            let inner = self.inner.clone();
+            Self {
+                inner,
+                accept_compression_encodings: self.accept_compression_encodings,
+                send_compression_encodings: self.send_compression_encodings,
+                max_decoding_message_size: self.max_decoding_message_size,
+                max_encoding_message_size: self.max_encoding_message_size,
+            }
+        }
+    }
+    impl<T: FileSend> Clone for _Inner<T> {
+        fn clone(&self) -> Self {
+            Self(Arc::clone(&self.0))
+        }
+    }
+    impl<T: std::fmt::Debug> std::fmt::Debug for _Inner<T> {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "{:?}", self.0)
+        }
+    }
+    impl<T: FileSend> tonic::server::NamedService for FileSendServer<T> {
+        const NAME: &'static str = "moby.filesync.v1.FileSend";
+    }
+}

--- a/codegen/proto/src/generated/moby.upload.v1.rs
+++ b/codegen/proto/src/generated/moby.upload.v1.rs
@@ -1,0 +1,302 @@
+/// BytesMessage contains a chunk of byte data
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct BytesMessage {
+    #[prost(bytes = "vec", tag = "1")]
+    pub data: ::prost::alloc::vec::Vec<u8>,
+}
+/// Generated client implementations.
+pub mod upload_client {
+    #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
+    use tonic::codegen::*;
+    use tonic::codegen::http::Uri;
+    #[derive(Debug, Clone)]
+    pub struct UploadClient<T> {
+        inner: tonic::client::Grpc<T>,
+    }
+    impl UploadClient<tonic::transport::Channel> {
+        /// Attempt to create a new client by connecting to a given endpoint.
+        pub async fn connect<D>(dst: D) -> Result<Self, tonic::transport::Error>
+        where
+            D: TryInto<tonic::transport::Endpoint>,
+            D::Error: Into<StdError>,
+        {
+            let conn = tonic::transport::Endpoint::new(dst)?.connect().await?;
+            Ok(Self::new(conn))
+        }
+    }
+    impl<T> UploadClient<T>
+    where
+        T: tonic::client::GrpcService<tonic::body::BoxBody>,
+        T::Error: Into<StdError>,
+        T::ResponseBody: Body<Data = Bytes> + Send + 'static,
+        <T::ResponseBody as Body>::Error: Into<StdError> + Send,
+    {
+        pub fn new(inner: T) -> Self {
+            let inner = tonic::client::Grpc::new(inner);
+            Self { inner }
+        }
+        pub fn with_origin(inner: T, origin: Uri) -> Self {
+            let inner = tonic::client::Grpc::with_origin(inner, origin);
+            Self { inner }
+        }
+        pub fn with_interceptor<F>(
+            inner: T,
+            interceptor: F,
+        ) -> UploadClient<InterceptedService<T, F>>
+        where
+            F: tonic::service::Interceptor,
+            T::ResponseBody: Default,
+            T: tonic::codegen::Service<
+                http::Request<tonic::body::BoxBody>,
+                Response = http::Response<
+                    <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
+                >,
+            >,
+            <T as tonic::codegen::Service<
+                http::Request<tonic::body::BoxBody>,
+            >>::Error: Into<StdError> + Send + Sync,
+        {
+            UploadClient::new(InterceptedService::new(inner, interceptor))
+        }
+        /// Compress requests with the given encoding.
+        ///
+        /// This requires the server to support it otherwise it might respond with an
+        /// error.
+        #[must_use]
+        pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.send_compressed(encoding);
+            self
+        }
+        /// Enable decompressing responses.
+        #[must_use]
+        pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.accept_compressed(encoding);
+            self
+        }
+        /// Limits the maximum size of a decoded message.
+        ///
+        /// Default: `4MB`
+        #[must_use]
+        pub fn max_decoding_message_size(mut self, limit: usize) -> Self {
+            self.inner = self.inner.max_decoding_message_size(limit);
+            self
+        }
+        /// Limits the maximum size of an encoded message.
+        ///
+        /// Default: `usize::MAX`
+        #[must_use]
+        pub fn max_encoding_message_size(mut self, limit: usize) -> Self {
+            self.inner = self.inner.max_encoding_message_size(limit);
+            self
+        }
+        pub async fn pull(
+            &mut self,
+            request: impl tonic::IntoStreamingRequest<Message = super::BytesMessage>,
+        ) -> std::result::Result<
+            tonic::Response<tonic::codec::Streaming<super::BytesMessage>>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/moby.upload.v1.Upload/Pull",
+            );
+            let mut req = request.into_streaming_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("moby.upload.v1.Upload", "Pull"));
+            self.inner.streaming(req, path, codec).await
+        }
+    }
+}
+/// Generated server implementations.
+pub mod upload_server {
+    #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
+    use tonic::codegen::*;
+    /// Generated trait containing gRPC methods that should be implemented for use with UploadServer.
+    #[async_trait]
+    pub trait Upload: Send + Sync + 'static {
+        /// Server streaming response type for the Pull method.
+        type PullStream: futures_core::Stream<
+                Item = std::result::Result<super::BytesMessage, tonic::Status>,
+            >
+            + Send
+            + 'static;
+        async fn pull(
+            &self,
+            request: tonic::Request<tonic::Streaming<super::BytesMessage>>,
+        ) -> std::result::Result<tonic::Response<Self::PullStream>, tonic::Status>;
+    }
+    #[derive(Debug)]
+    pub struct UploadServer<T: Upload> {
+        inner: _Inner<T>,
+        accept_compression_encodings: EnabledCompressionEncodings,
+        send_compression_encodings: EnabledCompressionEncodings,
+        max_decoding_message_size: Option<usize>,
+        max_encoding_message_size: Option<usize>,
+    }
+    struct _Inner<T>(Arc<T>);
+    impl<T: Upload> UploadServer<T> {
+        pub fn new(inner: T) -> Self {
+            Self::from_arc(Arc::new(inner))
+        }
+        pub fn from_arc(inner: Arc<T>) -> Self {
+            let inner = _Inner(inner);
+            Self {
+                inner,
+                accept_compression_encodings: Default::default(),
+                send_compression_encodings: Default::default(),
+                max_decoding_message_size: None,
+                max_encoding_message_size: None,
+            }
+        }
+        pub fn with_interceptor<F>(
+            inner: T,
+            interceptor: F,
+        ) -> InterceptedService<Self, F>
+        where
+            F: tonic::service::Interceptor,
+        {
+            InterceptedService::new(Self::new(inner), interceptor)
+        }
+        /// Enable decompressing requests with the given encoding.
+        #[must_use]
+        pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.accept_compression_encodings.enable(encoding);
+            self
+        }
+        /// Compress responses with the given encoding, if the client supports it.
+        #[must_use]
+        pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.send_compression_encodings.enable(encoding);
+            self
+        }
+        /// Limits the maximum size of a decoded message.
+        ///
+        /// Default: `4MB`
+        #[must_use]
+        pub fn max_decoding_message_size(mut self, limit: usize) -> Self {
+            self.max_decoding_message_size = Some(limit);
+            self
+        }
+        /// Limits the maximum size of an encoded message.
+        ///
+        /// Default: `usize::MAX`
+        #[must_use]
+        pub fn max_encoding_message_size(mut self, limit: usize) -> Self {
+            self.max_encoding_message_size = Some(limit);
+            self
+        }
+    }
+    impl<T, B> tonic::codegen::Service<http::Request<B>> for UploadServer<T>
+    where
+        T: Upload,
+        B: Body + Send + 'static,
+        B::Error: Into<StdError> + Send + 'static,
+    {
+        type Response = http::Response<tonic::body::BoxBody>;
+        type Error = std::convert::Infallible;
+        type Future = BoxFuture<Self::Response, Self::Error>;
+        fn poll_ready(
+            &mut self,
+            _cx: &mut Context<'_>,
+        ) -> Poll<std::result::Result<(), Self::Error>> {
+            Poll::Ready(Ok(()))
+        }
+        fn call(&mut self, req: http::Request<B>) -> Self::Future {
+            let inner = self.inner.clone();
+            match req.uri().path() {
+                "/moby.upload.v1.Upload/Pull" => {
+                    #[allow(non_camel_case_types)]
+                    struct PullSvc<T: Upload>(pub Arc<T>);
+                    impl<T: Upload> tonic::server::StreamingService<super::BytesMessage>
+                    for PullSvc<T> {
+                        type Response = super::BytesMessage;
+                        type ResponseStream = T::PullStream;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::ResponseStream>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<
+                                tonic::Streaming<super::BytesMessage>,
+                            >,
+                        ) -> Self::Future {
+                            let inner = Arc::clone(&self.0);
+                            let fut = async move { (*inner).pull(request).await };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let inner = inner.0;
+                        let method = PullSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
+                        let res = grpc.streaming(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                _ => {
+                    Box::pin(async move {
+                        Ok(
+                            http::Response::builder()
+                                .status(200)
+                                .header("grpc-status", "12")
+                                .header("content-type", "application/grpc")
+                                .body(empty_body())
+                                .unwrap(),
+                        )
+                    })
+                }
+            }
+        }
+    }
+    impl<T: Upload> Clone for UploadServer<T> {
+        fn clone(&self) -> Self {
+            let inner = self.inner.clone();
+            Self {
+                inner,
+                accept_compression_encodings: self.accept_compression_encodings,
+                send_compression_encodings: self.send_compression_encodings,
+                max_decoding_message_size: self.max_decoding_message_size,
+                max_encoding_message_size: self.max_encoding_message_size,
+            }
+        }
+    }
+    impl<T: Upload> Clone for _Inner<T> {
+        fn clone(&self) -> Self {
+            Self(Arc::clone(&self.0))
+        }
+    }
+    impl<T: std::fmt::Debug> std::fmt::Debug for _Inner<T> {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "{:?}", self.0)
+        }
+    }
+    impl<T: Upload> tonic::server::NamedService for UploadServer<T> {
+        const NAME: &'static str = "moby.upload.v1.Upload";
+    }
+}

--- a/codegen/proto/src/generated/moby.upload.v1.rs
+++ b/codegen/proto/src/generated/moby.upload.v1.rs
@@ -125,7 +125,7 @@ pub mod upload_server {
     #[async_trait]
     pub trait Upload: Send + Sync + 'static {
         /// Server streaming response type for the Pull method.
-        type PullStream: futures_core::Stream<
+        type PullStream: tonic::codegen::tokio_stream::Stream<
                 Item = std::result::Result<super::BytesMessage, tonic::Status>,
             >
             + Send
@@ -232,7 +232,9 @@ pub mod upload_server {
                             >,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
-                            let fut = async move { (*inner).pull(request).await };
+                            let fut = async move {
+                                <T as Upload>::pull(&inner, request).await
+                            };
                             Box::pin(fut)
                         }
                     }

--- a/codegen/proto/src/generated/pb.rs
+++ b/codegen/proto/src/generated/pb.rs
@@ -1,4 +1,5 @@
 /// Op represents a vertex of the LLB DAG.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Op {
     /// inputs is a set of input edges.
@@ -13,6 +14,7 @@ pub struct Op {
 }
 /// Nested message and enum types in `Op`.
 pub mod op {
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Op {
         #[prost(message, tag = "2")]
@@ -30,6 +32,7 @@ pub mod op {
     }
 }
 /// Platform is github.com/opencontainers/image-spec/specs-go/v1.Platform
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Platform {
     #[prost(string, tag = "1")]
@@ -46,6 +49,7 @@ pub struct Platform {
     pub os_features: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
 }
 /// Input represents an input edge for an Op.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Input {
     /// digest of the marshaled input Op
@@ -56,6 +60,7 @@ pub struct Input {
     pub index: i64,
 }
 /// ExecOp executes a command in a container.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ExecOp {
     #[prost(message, optional, tag = "1")]
@@ -72,6 +77,7 @@ pub struct ExecOp {
 /// Meta is a set of arguments for ExecOp.
 /// Meta is unrelated to LLB metadata.
 /// FIXME: rename (ExecContext? ExecArgs?)
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Meta {
     #[prost(string, repeated, tag = "1")]
@@ -93,6 +99,7 @@ pub struct Meta {
     #[prost(string, tag = "10")]
     pub cgroup_parent: ::prost::alloc::string::String,
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct HostIp {
     #[prost(string, tag = "1")]
@@ -100,6 +107,7 @@ pub struct HostIp {
     #[prost(string, tag = "2")]
     pub ip: ::prost::alloc::string::String,
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Ulimit {
     #[prost(string, tag = "1")]
@@ -110,6 +118,7 @@ pub struct Ulimit {
     pub hard: i64,
 }
 /// SecretEnv is an environment variable that is backed by a secret.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SecretEnv {
     #[prost(string, tag = "1")]
@@ -120,6 +129,7 @@ pub struct SecretEnv {
     pub optional: bool,
 }
 /// Mount specifies how to mount an input Op as a filesystem.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Mount {
     #[prost(int64, tag = "1")]
@@ -146,6 +156,7 @@ pub struct Mount {
     pub result_id: ::prost::alloc::string::String,
 }
 /// TmpfsOpt defines options describing tpmfs mounts
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct TmpfsOpt {
     /// Specify an upper limit on the size of the filesystem.
@@ -153,6 +164,7 @@ pub struct TmpfsOpt {
     pub size: i64,
 }
 /// CacheOpt defines options specific to cache mounts
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CacheOpt {
     /// ID is an optional namespace for the mount
@@ -163,6 +175,7 @@ pub struct CacheOpt {
     pub sharing: i32,
 }
 /// SecretOpt defines options describing secret mounts
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SecretOpt {
     /// ID of secret. Used for quering the value.
@@ -183,6 +196,7 @@ pub struct SecretOpt {
     pub optional: bool,
 }
 /// SSHOpt defines options describing ssh mounts
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SshOpt {
     /// ID of exposed ssh rule. Used for quering the value.
@@ -203,6 +217,7 @@ pub struct SshOpt {
     pub optional: bool,
 }
 /// SourceOp specifies a source such as build contexts and images.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SourceOp {
     /// TODO: use source type or any type instead of URL protocol.
@@ -218,6 +233,7 @@ pub struct SourceOp {
 }
 /// BuildOp is used for nested build invocation.
 /// BuildOp is experimental and can break without backwards compatibility
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct BuildOp {
     #[prost(int64, tag = "1")]
@@ -234,12 +250,14 @@ pub struct BuildOp {
     >,
 }
 /// BuildInput is used for BuildOp.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct BuildInput {
     #[prost(int64, tag = "1")]
     pub input: i64,
 }
 /// OpMetadata is a per-vertex metadata entry, which can be defined for arbitrary Op vertex and overridable on the run time.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct OpMetadata {
     /// ignore_cache specifies to ignore the cache for this Op.
@@ -261,6 +279,7 @@ pub struct OpMetadata {
     pub progress_group: ::core::option::Option<ProgressGroup>,
 }
 /// Source is a source mapping description for a file
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Source {
     #[prost(map = "string, message", tag = "1")]
@@ -272,12 +291,14 @@ pub struct Source {
     pub infos: ::prost::alloc::vec::Vec<SourceInfo>,
 }
 /// Locations is a list of ranges with a index to its source map.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Locations {
     #[prost(message, repeated, tag = "1")]
     pub locations: ::prost::alloc::vec::Vec<Location>,
 }
 /// Source info contains the shared metadata of a source mapping
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SourceInfo {
     #[prost(string, tag = "1")]
@@ -288,6 +309,7 @@ pub struct SourceInfo {
     pub definition: ::core::option::Option<Definition>,
 }
 /// Location defines list of areas in to source file
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Location {
     #[prost(int32, tag = "1")]
@@ -296,6 +318,7 @@ pub struct Location {
     pub ranges: ::prost::alloc::vec::Vec<Range>,
 }
 /// Range is an area in the source file
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Range {
     #[prost(message, optional, tag = "1")]
@@ -304,6 +327,7 @@ pub struct Range {
     pub end: ::core::option::Option<Position>,
 }
 /// Position is single location in a source file
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Position {
     #[prost(int32, tag = "1")]
@@ -311,11 +335,13 @@ pub struct Position {
     #[prost(int32, tag = "2")]
     pub character: i32,
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ExportCache {
     #[prost(bool, tag = "1")]
     pub value: bool,
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ProgressGroup {
     #[prost(string, tag = "1")]
@@ -325,6 +351,7 @@ pub struct ProgressGroup {
     #[prost(bool, tag = "3")]
     pub weak: bool,
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ProxyEnv {
     #[prost(string, tag = "1")]
@@ -339,6 +366,7 @@ pub struct ProxyEnv {
     pub all_proxy: ::prost::alloc::string::String,
 }
 /// WorkerConstraints defines conditions for the worker
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct WorkerConstraints {
     /// containerd-style filter
@@ -346,6 +374,7 @@ pub struct WorkerConstraints {
     pub filter: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
 }
 /// Definition is the LLB definition structure with per-vertex metadata entries
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Definition {
     /// def is a list of marshaled Op messages
@@ -362,11 +391,13 @@ pub struct Definition {
     #[prost(message, optional, tag = "3")]
     pub source: ::core::option::Option<Source>,
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct FileOp {
     #[prost(message, repeated, tag = "2")]
     pub actions: ::prost::alloc::vec::Vec<FileAction>,
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct FileAction {
     /// could be real input or target (target index + max input index)
@@ -382,6 +413,7 @@ pub struct FileAction {
 }
 /// Nested message and enum types in `FileAction`.
 pub mod file_action {
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Action {
         /// FileActionCopy copies files from secondaryInput on top of input
@@ -398,6 +430,7 @@ pub mod file_action {
         Rm(super::FileActionRm),
     }
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct FileActionCopy {
     /// src is the source path
@@ -440,6 +473,7 @@ pub struct FileActionCopy {
     #[prost(string, repeated, tag = "13")]
     pub exclude_patterns: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct FileActionMkFile {
     /// path for the new file
@@ -458,6 +492,7 @@ pub struct FileActionMkFile {
     #[prost(int64, tag = "5")]
     pub timestamp: i64,
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct FileActionMkDir {
     /// path for the new directory
@@ -476,6 +511,7 @@ pub struct FileActionMkDir {
     #[prost(int64, tag = "5")]
     pub timestamp: i64,
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct FileActionRm {
     /// path to remove
@@ -488,6 +524,7 @@ pub struct FileActionRm {
     #[prost(bool, tag = "3")]
     pub allow_wildcard: bool,
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ChownOpt {
     #[prost(message, optional, tag = "1")]
@@ -495,6 +532,7 @@ pub struct ChownOpt {
     #[prost(message, optional, tag = "2")]
     pub group: ::core::option::Option<UserOpt>,
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct UserOpt {
     #[prost(oneof = "user_opt::User", tags = "1, 2")]
@@ -502,6 +540,7 @@ pub struct UserOpt {
 }
 /// Nested message and enum types in `UserOpt`.
 pub mod user_opt {
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum User {
         #[prost(message, tag = "1")]
@@ -510,6 +549,7 @@ pub mod user_opt {
         ById(u32),
     }
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct NamedUserOpt {
     #[prost(string, tag = "1")]
@@ -517,26 +557,31 @@ pub struct NamedUserOpt {
     #[prost(int64, tag = "2")]
     pub input: i64,
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct MergeInput {
     #[prost(int64, tag = "1")]
     pub input: i64,
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct MergeOp {
     #[prost(message, repeated, tag = "1")]
     pub inputs: ::prost::alloc::vec::Vec<MergeInput>,
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct LowerDiffInput {
     #[prost(int64, tag = "1")]
     pub input: i64,
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct UpperDiffInput {
     #[prost(int64, tag = "1")]
     pub input: i64,
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct DiffOp {
     #[prost(message, optional, tag = "1")]
@@ -564,6 +609,15 @@ impl NetMode {
             NetMode::None => "NONE",
         }
     }
+    /// Creates an enum from field names used in the ProtoBuf definition.
+    pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+        match value {
+            "UNSET" => Some(Self::Unset),
+            "HOST" => Some(Self::Host),
+            "NONE" => Some(Self::None),
+            _ => None,
+        }
+    }
 }
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
 #[repr(i32)]
@@ -581,6 +635,14 @@ impl SecurityMode {
         match self {
             SecurityMode::Sandbox => "SANDBOX",
             SecurityMode::Insecure => "INSECURE",
+        }
+    }
+    /// Creates an enum from field names used in the ProtoBuf definition.
+    pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+        match value {
+            "SANDBOX" => Some(Self::Sandbox),
+            "INSECURE" => Some(Self::Insecure),
+            _ => None,
         }
     }
 }
@@ -608,6 +670,17 @@ impl MountType {
             MountType::Tmpfs => "TMPFS",
         }
     }
+    /// Creates an enum from field names used in the ProtoBuf definition.
+    pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+        match value {
+            "BIND" => Some(Self::Bind),
+            "SECRET" => Some(Self::Secret),
+            "SSH" => Some(Self::Ssh),
+            "CACHE" => Some(Self::Cache),
+            "TMPFS" => Some(Self::Tmpfs),
+            _ => None,
+        }
+    }
 }
 /// CacheSharingOpt defines different sharing modes for cache mount
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
@@ -630,6 +703,15 @@ impl CacheSharingOpt {
             CacheSharingOpt::Shared => "SHARED",
             CacheSharingOpt::Private => "PRIVATE",
             CacheSharingOpt::Locked => "LOCKED",
+        }
+    }
+    /// Creates an enum from field names used in the ProtoBuf definition.
+    pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+        match value {
+            "SHARED" => Some(Self::Shared),
+            "PRIVATE" => Some(Self::Private),
+            "LOCKED" => Some(Self::Locked),
+            _ => None,
         }
     }
 }

--- a/codegen/proto/src/lib.rs
+++ b/codegen/proto/src/lib.rs
@@ -88,4 +88,3 @@ impl AsRef<[u8]> for moby::buildkit::v1::BytesMessage {
         self.data.as_ref()
     }
 }
-

--- a/codegen/proto/src/lib.rs
+++ b/codegen/proto/src/lib.rs
@@ -30,7 +30,6 @@ pub mod moby {
             include!("generated/moby.upload.v1.rs");
         }
     }
-
 }
 
 pub mod google {
@@ -58,7 +57,6 @@ impl Display for moby::buildkit::v1::StatusResponse {
                 let mut next = iter.next();
                 let mut result = Ok(());
                 while next.is_some() {
-
                     result = result.and_then(|_| write!(f, "{}", next.unwrap()));
                     next = iter.next();
                     if iter.peek().is_some() {
@@ -84,3 +82,10 @@ impl Display for moby::buildkit::v1::VertexLog {
         )
     }
 }
+
+impl AsRef<[u8]> for moby::buildkit::v1::BytesMessage {
+    fn as_ref(&self) -> &[u8] {
+        self.data.as_ref()
+    }
+}
+

--- a/codegen/proto/src/lib.rs
+++ b/codegen/proto/src/lib.rs
@@ -1,6 +1,12 @@
 #![allow(missing_docs, unused_qualifications)]
 #![cfg(not(feature = "build"))]
 
+pub mod fsutil {
+    pub mod types {
+        include!("generated/fsutil.types.rs");
+    }
+}
+
 pub mod health {
     include!("generated/grpc.health.v1.rs");
 }
@@ -14,6 +20,17 @@ pub mod moby {
             }
         }
     }
+    pub mod filesync {
+        pub mod v1 {
+            include!("generated/moby.filesync.v1.rs");
+        }
+    }
+    pub mod upload {
+        pub mod v1 {
+            include!("generated/moby.upload.v1.rs");
+        }
+    }
+
 }
 
 pub mod google {

--- a/codegen/swagger/Cargo.toml
+++ b/codegen/swagger/Cargo.toml
@@ -15,7 +15,7 @@ bollard-buildkit-proto = { path = "../proto", version = "=0.1.0", optional = tru
 bytes = { version = "1", optional = true }
 chrono = { version = "0.4", default-features = false, features = ["std", "clock", "serde"], optional = true }
 serde = { version = "1.0", features = ["derive"] }
-prost = { version = "0.11", optional = true }
+prost = { version = "0.12", optional = true }
 time = { version = "0.3", features = ["formatting", "parsing"], optional = true }
 
 serde_with = {version = "3.0", default-features = false, features = ["std"]}

--- a/examples/export_oci_image.rs
+++ b/examples/export_oci_image.rs
@@ -1,58 +1,57 @@
 //! Builds a container with a bunch of extra options for testing
 #![allow(unused_variables, unused_mut)]
 
-use bollard::image::{BuildImageOptions, BuilderVersion};
-#[cfg(feature = "buildkit")]
-use bollard::models::BuildInfoAux;
-use bollard::Docker;
-
-#[cfg(feature = "buildkit")]
-use futures_util::stream::StreamExt;
-
-use std::{collections::HashMap, io::Write};
-
 #[tokio::main]
 async fn main() {
-    env_logger::init();
-    let mut docker = Docker::connect_with_http_defaults().unwrap();
+    #[cfg(feature = "buildkit")]
+    {
+        use bollard::models::BuildInfoAux;
+        use bollard::Docker;
+        use futures_util::stream::StreamExt;
+        use std::io::Write;
 
-    let dockerfile = String::from(
-        "FROM alpine as builder1
-RUN touch bollard.txt
-FROM alpine as builder2
-RUN --mount=type=bind,from=builder1,target=mnt cp mnt/bollard.txt buildkit-bollard.txt
-ENTRYPOINT ls buildkit-bollard.txt
-",
-    );
+        env_logger::init();
 
-    let mut header = tar::Header::new_gnu();
-    header.set_path("Dockerfile").unwrap();
-    header.set_size(dockerfile.len() as u64);
-    header.set_mode(0o755);
-    header.set_cksum();
-    let mut tar = tar::Builder::new(Vec::new());
-    tar.append(&header, dockerfile.as_bytes()).unwrap();
+        let mut docker = Docker::connect_with_http_defaults().unwrap();
 
-    let uncompressed = tar.into_inner().unwrap();
-    let mut c = flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::default());
-    c.write_all(&uncompressed).unwrap();
-    let compressed = c.finish().unwrap();
+        let dockerfile = String::from(
+            "FROM alpine as builder1
+            RUN touch bollard.txt
+            FROM alpine as builder2
+            RUN --mount=type=bind,from=builder1,target=mnt cp mnt/bollard.txt buildkit-bollard.txt
+            ENTRYPOINT ls buildkit-bollard.txt
+            ",
+        );
 
-    let session_id = "bollard-oci-export-buildkit-example";
+        let mut header = tar::Header::new_gnu();
+        header.set_path("Dockerfile").unwrap();
+        header.set_size(dockerfile.len() as u64);
+        header.set_mode(0o755);
+        header.set_cksum();
+        let mut tar = tar::Builder::new(Vec::new());
+        tar.append(&header, dockerfile.as_bytes()).unwrap();
 
-    let frontend_opts = bollard::grpc::export::ImageBuildFrontendOptions::builder()
-        .pull(true)
-        .build();
-    let output = bollard::grpc::export::ImageExporterOCIOutputBuilder::new(
-        "docker.io/library/bollard-oci-export-buildkit-example:latest",
-    )
-    .annotation("exporter", "Bollard")
-    .dest(&std::path::Path::new("/tmp/oci-image.tar"));
+        let uncompressed = tar.into_inner().unwrap();
+        let mut c = flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::default());
+        c.write_all(&uncompressed).unwrap();
+        let compressed = c.finish().unwrap();
 
-    let load_input =
-        bollard::grpc::export::ImageExporterLoadInput::Upload(bytes::Bytes::from(compressed));
+        let session_id = "bollard-oci-export-buildkit-example";
 
-    docker
-        .image_export_oci(session_id, frontend_opts, output, load_input)
-        .await;
+        let frontend_opts = bollard::grpc::export::ImageBuildFrontendOptions::builder()
+            .pull(true)
+            .build();
+        let output = bollard::grpc::export::ImageExporterOCIOutputBuilder::new(
+            "docker.io/library/bollard-oci-export-buildkit-example:latest",
+        )
+        .annotation("exporter", "Bollard")
+        .dest(&std::path::Path::new("/tmp/oci-image.tar"));
+
+        let load_input =
+            bollard::grpc::export::ImageExporterLoadInput::Upload(bytes::Bytes::from(compressed));
+
+        docker
+            .image_export_oci(session_id, frontend_opts, output, load_input)
+            .await;
+    }
 }

--- a/examples/export_oci_image.rs
+++ b/examples/export_oci_image.rs
@@ -5,9 +5,7 @@
 async fn main() {
     #[cfg(feature = "buildkit")]
     {
-        use bollard::models::BuildInfoAux;
         use bollard::Docker;
-        use futures_util::stream::StreamExt;
         use std::io::Write;
 
         env_logger::init();
@@ -53,6 +51,7 @@ async fn main() {
 
         docker
             .image_export_oci(session_id, frontend_opts, output, load_input)
-            .await;
+            .await
+            .unwrap();
     }
 }

--- a/examples/export_oci_image.rs
+++ b/examples/export_oci_image.rs
@@ -12,7 +12,7 @@ async fn main() {
 
         env_logger::init();
 
-        let mut docker = Docker::connect_with_http_defaults().unwrap();
+        let mut docker = Docker::connect_with_socket_defaults().unwrap();
 
         let dockerfile = String::from(
             "FROM alpine as builder1
@@ -41,6 +41,7 @@ async fn main() {
         let frontend_opts = bollard::grpc::export::ImageBuildFrontendOptions::builder()
             .pull(true)
             .build();
+
         let output = bollard::grpc::export::ImageExporterOCIOutputBuilder::new(
             "docker.io/library/bollard-oci-export-buildkit-example:latest",
         )

--- a/examples/export_oci_image.rs
+++ b/examples/export_oci_image.rs
@@ -1,0 +1,75 @@
+//! Builds a container with a bunch of extra options for testing
+#![allow(unused_variables, unused_mut)]
+
+use bollard::image::{BuildImageOptions, BuilderVersion};
+#[cfg(feature = "buildkit")]
+use bollard::models::BuildInfoAux;
+use bollard::Docker;
+
+#[cfg(feature = "buildkit")]
+use futures_util::stream::StreamExt;
+
+use std::{collections::HashMap, io::Write};
+
+#[tokio::main]
+async fn main() {
+    env_logger::init();
+    let mut docker = Docker::connect_with_http_defaults().unwrap();
+
+    let dockerfile = String::from(
+        "FROM alpine as builder1
+RUN touch bollard.txt
+FROM alpine as builder2
+RUN --mount=type=bind,from=builder1,target=mnt cp mnt/bollard.txt buildkit-bollard.txt
+ENTRYPOINT ls buildkit-bollard.txt
+",
+    );
+
+    let mut header = tar::Header::new_gnu();
+    header.set_path("Dockerfile").unwrap();
+    header.set_size(dockerfile.len() as u64);
+    header.set_mode(0o755);
+    header.set_cksum();
+    let mut tar = tar::Builder::new(Vec::new());
+    tar.append(&header, dockerfile.as_bytes()).unwrap();
+
+    let uncompressed = tar.into_inner().unwrap();
+    let mut c = flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::default());
+    c.write_all(&uncompressed).unwrap();
+    let compressed = c.finish().unwrap();
+
+    let mut attrs = HashMap::new();
+    attrs.insert("name", "alpine-bollard");
+    attrs.insert("dest", "/tmp/alpine-oci-image");
+    attrs.insert("annotation.exporter", "Bollard");
+
+    #[cfg(feature = "buildkit")]
+    let outputs = vec![
+        bollard::image::ImageBuildOutput { typ: "oci", attrs: attrs.clone() },
+    ];
+
+    let id = "bollard-oci-export-buildkit-example";
+    let build_image_options = BuildImageOptions {
+        t: id,
+        version: BuilderVersion::BuilderBuildKit,
+        pull: true,
+        #[cfg(feature = "buildkit")]
+        session: Some(String::from(id)),
+        #[cfg(feature = "buildkit")]
+        outputs: Some(outputs),
+        ..Default::default()
+    };
+
+    docker.export_oci_image(build_image_options, Some(compressed)).await;
+    //let mut image_build_stream =
+    //    docker.build_image(build_image_options, None, Some(compressed.into()));
+
+    //#[cfg(feature = "buildkit")]
+    //while let Some(Ok(bollard::models::BuildInfo {
+    //    aux: Some(BuildInfoAux::BuildKit(inner)),
+    //    ..
+    //})) = image_build_stream.next().await
+    //{
+    //    println!("Response: {:?}", inner);
+    //}
+}

--- a/src/container.rs
+++ b/src/container.rs
@@ -1,7 +1,7 @@
 //! Container API: run docker containers and manage their lifecycle
 
 use futures_core::Stream;
-use futures_util::StreamExt;
+use futures_util::{StreamExt, TryStreamExt};
 use http::header::{CONNECTION, CONTENT_TYPE, UPGRADE};
 use http::request::Builder;
 use hyper::{body::Bytes, Body, Method};
@@ -1510,7 +1510,7 @@ impl Docker {
         );
 
         let (read, write) = self.process_upgraded(req).await?;
-        let log = FramedRead::new(read, NewlineLogOutputDecoder::new(true));
+        let log = FramedRead::new(read, NewlineLogOutputDecoder::new(true)).map_err(|e| e.into());
 
         Ok(AttachContainerResults {
             output: Box::pin(log),

--- a/src/container.rs
+++ b/src/container.rs
@@ -420,7 +420,7 @@ where
     /// If stream is also enabled, once all the previous output has been returned, it will seamlessly transition into streaming current output.
     pub logs: Option<bool>,
     /// Override the key sequence for detaching a container.
-    /// Format is a single character [a-Z] or ctrl-<value> where <value> is one of: a-z, @, ^, [, , or _.
+    /// Format is a single character [a-Z] or ctrl-\<value\> where \<value\> is one of: a-z, @, ^, [, , or _.
     #[serde(rename = "detachKeys")]
     pub detach_keys: Option<T>,
 }
@@ -1776,7 +1776,7 @@ impl Docker {
     ///
     /// # Returns
     ///
-    ///  - An Option of Vector of [Container Change Response Item](ContainerChangeResponseItem) structs, wrapped in a
+    ///  - An Option of Vector of [File System Change](FilesystemChange) structs, wrapped in a
     ///  Future.
     ///
     /// # Examples

--- a/src/container.rs
+++ b/src/container.rs
@@ -565,6 +565,17 @@ impl fmt::Display for LogOutput {
     }
 }
 
+impl AsRef<[u8]> for LogOutput {
+    fn as_ref(&self) -> &[u8] {
+        match self {
+            LogOutput::StdErr { message } => message.as_ref(),
+            LogOutput::StdOut { message } => message.as_ref(),
+            LogOutput::StdIn { message } => message.as_ref(),
+            LogOutput::Console { message } => message.as_ref(),
+        }
+    }
+}
+
 impl LogOutput {
     /// Get the raw bytes of the output
     pub fn into_bytes(self) -> Bytes {

--- a/src/docker.rs
+++ b/src/docker.rs
@@ -58,7 +58,7 @@ const DEFAULT_TIMEOUT: u64 = 120;
 /// Default Client Version to communicate with the server.
 pub const API_DEFAULT_VERSION: &ClientVersion = &ClientVersion {
     major_version: 1,
-    minor_version: 40,
+    minor_version: 42,
 };
 
 /// 2 years from ct_logs 0.9 release

--- a/src/docker.rs
+++ b/src/docker.rs
@@ -1195,6 +1195,7 @@ impl Docker {
             StreamReader::new(res.into_body().map_err(Error::from)),
             NewlineLogOutputDecoder::new(false),
         )
+        .map_err(Error::from)
     }
 
     async fn decode_into_string(response: Response<Body>) -> Result<String, Error> {

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -143,4 +143,12 @@ pub enum Error {
         #[from]
         err: tonic::transport::Error,
     },
+    #[cfg(feature = "buildkit")]
+    /// Error emitted when a GRPC network request emits a non-OK status code
+    #[error(transparent)]
+    TonicStatus {
+        /// The tonic status emitted.
+        #[from]
+        err: tonic::Status,
+    },
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -3,7 +3,7 @@
 #[cfg(feature = "ssl")]
 use std::path::PathBuf;
 
-/// The type of error embedded in an Error.
+/// Generic Docker errors
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
     /// Error emitted during client instantiation when the `DOCKER_CERT_PATH` environment variable
@@ -134,29 +134,5 @@ pub enum Error {
         /// The original error emitted.
         #[from]
         err: serde_urlencoded::ser::Error,
-    },
-    #[cfg(feature = "buildkit")]
-    /// Error emitted when a GRPC network request or response fails with docker's buildkit client
-    #[error(transparent)]
-    TonicError {
-        /// The tonic error emitted.
-        #[from]
-        err: tonic::transport::Error,
-    },
-    #[cfg(feature = "buildkit")]
-    /// Error emitted when a GRPC network request emits a non-OK status code
-    #[error(transparent)]
-    TonicStatus {
-        /// The tonic status emitted.
-        #[from]
-        err: tonic::Status,
-    },
-    #[cfg(feature = "buildkit")]
-    /// Error emitted when a GRPC metadata value does not parse correctly
-    #[error(transparent)]
-    MetadataValue {
-        /// The tonic metadata value.
-        #[from]
-        err: tonic::metadata::errors::InvalidMetadataValue,
     },
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -151,4 +151,12 @@ pub enum Error {
         #[from]
         err: tonic::Status,
     },
+    #[cfg(feature = "buildkit")]
+    /// Error emitted when a GRPC metadata value does not parse correctly
+    #[error(transparent)]
+    MetadataValue {
+        /// The tonic metadata value.
+        #[from]
+        err: tonic::metadata::errors::InvalidMetadataValue,
+    },
 }

--- a/src/grpc/driver.rs
+++ b/src/grpc/driver.rs
@@ -1,0 +1,500 @@
+use std::{
+    cmp,
+    collections::HashMap,
+    path::Path,
+    pin::Pin,
+    sync::Arc,
+    task::{Context, Poll},
+    time::Duration,
+};
+//use std::io::Bytes;
+
+use bollard_buildkit_proto::moby;
+use bollard_stubs::models::{
+    ContainerWaitExitError, ContainerWaitResponse, ExecInspectResponse, HostConfig, Mount,
+    MountTypeEnum, SystemInfoCgroupDriverEnum, Volume,
+};
+use bytes::{BufMut, Bytes, BytesMut};
+use futures_core::{ready, Future, TryStream};
+use futures_util::{StreamExt, TryStreamExt};
+use http::{
+    header::{CONNECTION, UPGRADE},
+    request::Builder,
+    Method,
+};
+use hyper::Body;
+use pin_project_lite::pin_project;
+use tokio::io::{AsyncRead, AsyncWrite};
+use tokio_util::codec::FramedRead;
+use tonic::transport::server::Connected;
+use tower_service::Service;
+
+use crate::{
+    container::{Config, CreateContainerOptions, LogOutput, WaitContainerOptions},
+    errors::Error,
+    exec::{CreateExecOptions, StartExecOptions, StartExecResults},
+    image::CreateImageOptions,
+    read::NewlineLogOutputDecoder,
+    Docker,
+};
+
+const DEFAULT_IMAGE: &str = "moby/buildkit:master";
+const DEFAULT_STATE_DIR: &str = "/var/lib/buildkit";
+const DEFAULT_BUILDKIT_CONFIG_DIR: &str = "/etc/buildkit";
+
+pin_project! {
+    /// Reader for the [`into_async_read`](super::TryStreamExt::into_async_read) method.
+    #[derive(Debug)]
+    pub struct IntoAsyncRead<St>
+    where
+        St: TryStream<Error = std::io::Error>,
+        St::Ok: AsRef<[u8]>,
+    {
+        #[pin]
+        stream: St,
+        state: ReadState<St::Ok>,
+    }
+}
+
+#[derive(Debug)]
+enum ReadState<T: AsRef<[u8]>> {
+    Ready { chunk: T, chunk_start: usize },
+    PendingChunk,
+    Eof,
+}
+
+impl<St> IntoAsyncRead<St>
+where
+    St: TryStream<Error = std::io::Error>,
+    St::Ok: AsRef<[u8]>,
+{
+    pub(super) fn new(stream: St) -> Self {
+        Self {
+            stream,
+            state: ReadState::PendingChunk,
+        }
+    }
+}
+
+impl<St> AsyncRead for IntoAsyncRead<St>
+where
+    St: TryStream<Error = std::io::Error>,
+    St::Ok: AsRef<[u8]>,
+{
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut tokio::io::ReadBuf<'_>,
+    ) -> Poll<std::io::Result<()>> {
+        let mut this = self.project();
+
+        loop {
+            match this.state {
+                ReadState::Ready { chunk, chunk_start } => {
+                    let chunk = chunk.as_ref();
+                    let len = cmp::min(buf.remaining(), chunk.len() - *chunk_start);
+
+                    buf.put_slice(&chunk[*chunk_start..*chunk_start + len]);
+
+                    *chunk_start += len;
+
+                    if chunk.len() == *chunk_start {
+                        *this.state = ReadState::PendingChunk;
+                    }
+
+                    return Poll::Ready(Ok(()));
+                }
+                ReadState::PendingChunk => match ready!(this.stream.as_mut().try_poll_next(cx)) {
+                    Some(Ok(chunk)) => {
+                        if !chunk.as_ref().is_empty() {
+                            *this.state = ReadState::Ready {
+                                chunk,
+                                chunk_start: 0,
+                            };
+                        }
+                    }
+                    Some(Err(err)) => {
+                        *this.state = ReadState::Eof;
+                        return Poll::Ready(Err(err));
+                    }
+                    None => {
+                        *this.state = ReadState::Eof;
+                        return Poll::Ready(Ok(()));
+                    }
+                },
+                ReadState::Eof => {
+                    return Poll::Ready(Ok(()));
+                }
+            }
+        }
+    }
+}
+
+#[allow(missing_debug_implementations)]
+/// TODO
+pub struct GrpcFramedTransport {
+    read: IntoAsyncRead<FramedRead<Pin<Box<dyn AsyncRead + Send>>, NewlineLogOutputDecoder>>,
+    write: Pin<Box<dyn AsyncWrite + Send>>,
+}
+
+impl AsRef<[u8]> for LogOutput {
+    fn as_ref(&self) -> &[u8] {
+        match self {
+            LogOutput::StdErr { message } => message.as_ref(),
+            LogOutput::StdOut { message } => message.as_ref(),
+            LogOutput::StdIn { message } => message.as_ref(),
+            LogOutput::Console { message } => message.as_ref(),
+        }
+    }
+}
+
+impl GrpcFramedTransport {
+    pub(crate) fn new(
+        read: Pin<Box<dyn AsyncRead + Send>>,
+        write: Pin<Box<dyn AsyncWrite + Send>>,
+        capacity: usize,
+    ) -> Self {
+        let output = FramedRead::with_capacity(read, NewlineLogOutputDecoder::new(true), capacity);
+        let read = IntoAsyncRead::new(output);
+        Self { read, write }
+    }
+}
+
+impl Connected for GrpcFramedTransport {
+    type ConnectInfo = ();
+
+    fn connect_info(&self) -> Self::ConnectInfo {}
+}
+
+impl AsyncRead for GrpcFramedTransport {
+    fn poll_read(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut tokio::io::ReadBuf<'_>,
+    ) -> Poll<std::io::Result<()>> {
+        Pin::new(&mut self.read).poll_read(cx, buf)
+    }
+}
+
+impl AsyncWrite for GrpcFramedTransport {
+    fn poll_write(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<std::io::Result<usize>> {
+        Pin::new(&mut self.write).poll_write(cx, buf)
+    }
+
+    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+        Pin::new(&mut self.write).poll_flush(cx)
+    }
+
+    fn poll_shutdown(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Result<(), std::io::Error>> {
+        Pin::new(&mut self.write).poll_shutdown(cx)
+    }
+}
+
+impl Service<http::Uri> for Driver {
+    type Response = GrpcFramedTransport;
+    type Error = Error;
+    type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send>>;
+
+    fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn call(&mut self, _req: http::Uri) -> Self::Future {
+        let client = Docker::clone(&self.docker);
+        let name = String::clone(&self.name);
+        let session_id = String::clone(&self.session_id);
+
+        let fut = async move {
+            let exec_id = client
+                .create_exec(
+                    &name,
+                    CreateExecOptions {
+                        attach_stdin: Some(true),
+                        attach_stdout: Some(true),
+                        attach_stderr: Some(true),
+                        cmd: Some(vec!["buildctl", "dial-stdio"]),
+                        ..Default::default()
+                    },
+                )
+                .await?
+                .id;
+
+            let url = format!("/exec/{exec_id}/start");
+            let capacity = 8 * 1024;
+
+            let req = client.build_request(
+                &url,
+                Builder::new()
+                    .method(Method::POST)
+                    .header(CONNECTION, "Upgrade")
+                    .header(UPGRADE, "tcp"),
+                None::<String>,
+                Docker::serialize_payload(Some(StartExecOptions {
+                    output_capacity: Some(capacity),
+                    ..Default::default()
+                })),
+            );
+
+            client
+                .process_upgraded(req)
+                .await
+                .and_then(|(read, write)| {
+                    let output = Box::pin(read);
+                    let input = Box::pin(write);
+                    Ok(GrpcFramedTransport::new(output, input, capacity))
+                })
+        };
+
+        // Return the response as an immediate future
+        Box::pin(fut)
+    }
+}
+
+/// TODO
+#[derive(Debug)]
+pub struct DriverBuilder {
+    inner: Driver,
+}
+
+impl DriverBuilder {
+    /// TODO
+    pub fn new(name: &str, docker: &Docker, session_id: &str) -> Self {
+        Self {
+            inner: Driver {
+                name: String::from(name),
+                docker: Docker::clone(docker),
+                session_id: String::from(session_id),
+                net_mode: None,
+                image: None,
+                cgroup_parent: None,
+                env: vec![],
+                args: vec![],
+            },
+        }
+    }
+
+    /// TODO
+    pub async fn bootstrap(mut self) -> Result<Driver, Error> {
+        debug!("booting buildkit");
+
+        if self.inner.net_mode.is_none() {
+            self.network("host");
+        }
+
+        let container_name = &self.inner.name;
+        match self
+            .inner
+            .docker
+            .inspect_container(&self.inner.name, None)
+            .await
+        {
+            Err(Error::DockerResponseServerError {
+                status_code: 404,
+                message: _,
+            }) => self.inner.create().await?,
+            _ => (),
+        };
+
+        debug!("starting container {}", &container_name);
+
+        self.inner.start().await?;
+        self.inner.wait().await?;
+
+        Ok(self.inner)
+    }
+
+    /// TODO
+    pub fn network(&mut self, net: &str) -> &mut DriverBuilder {
+        if net == "host" {
+            self.inner
+                .args
+                .push(String::from("--allow-insecure-entitlement=network.host"));
+        }
+
+        self.inner.net_mode = Some(net.to_string());
+        self
+    }
+}
+
+/// TODO
+#[derive(Debug)]
+pub struct Driver {
+    /// TODO
+    name: String,
+    /// TODO
+    docker: Docker,
+    /// TODO
+    session_id: String,
+    /// TODO
+    net_mode: Option<String>,
+    /// TODO
+    image: Option<String>,
+    /// TODO
+    cgroup_parent: Option<String>,
+    /// TODO
+    env: Vec<String>,
+    /// TODO
+    args: Vec<String>,
+}
+
+impl Driver {
+    /// TODO
+    pub async fn create(&self) -> Result<(), Error> {
+        let image_name = if let Some(image) = &self.image {
+            image
+        } else {
+            DEFAULT_IMAGE
+        };
+
+        debug!("pulling image {}", &image_name);
+
+        // TODO: registry auth
+
+        let create_image_options = CreateImageOptions {
+            from_image: String::from(image_name),
+            ..Default::default()
+        };
+
+        self.docker
+            .create_image(Some(create_image_options), None, None)
+            .try_collect::<Vec<_>>()
+            .await?;
+
+        debug!("creating container {}", &self.name);
+
+        let container_options = CreateContainerOptions {
+            name: String::from(&self.name),
+            ..Default::default()
+        };
+
+        let info = self.docker.info().await?;
+        let cgroup_parent = match &info.cgroup_driver {
+            Some(SystemInfoCgroupDriverEnum::CGROUPFS) =>
+            // place all buildkit containers into this cgroup
+            {
+                Some(if let Some(cgroup_parent) = &self.cgroup_parent {
+                    String::clone(&cgroup_parent)
+                } else {
+                    String::from("/docker/buildx")
+                })
+            }
+            _ => None,
+        };
+
+        let network_mode = if let Some(net_mode) = &self.net_mode {
+            Some(String::clone(&net_mode))
+        } else {
+            None
+        };
+
+        let userns_mode = if let Some(security_options) = &info.security_options {
+            if security_options.iter().any(|f| f == "userns") {
+                Some(String::from("host"))
+            } else {
+                None
+            }
+        } else {
+            None
+        };
+
+        let host_config = HostConfig {
+            privileged: Some(true),
+            mounts: Some(vec![Mount {
+                typ: Some(MountTypeEnum::VOLUME),
+                source: Some(format!("{}_state", &self.name)),
+                target: Some(String::from(DEFAULT_STATE_DIR)),
+                ..Default::default()
+            }]),
+            init: Some(true),
+            network_mode,
+            cgroup_parent,
+            userns_mode,
+            ..Default::default()
+        };
+
+        let container_config = Config {
+            image: Some(String::from(image_name)),
+            env: Some(Vec::clone(&self.env)),
+            host_config: Some(host_config),
+            cmd: Some(Vec::clone(&self.args)),
+            ..Default::default()
+        };
+
+        self.docker
+            .create_container(Some(container_options), container_config)
+            .await?;
+
+        self.start().await?;
+
+        self.wait().await?;
+
+        Ok(())
+    }
+
+    async fn start(&self) -> Result<(), Error> {
+        self.docker
+            .start_container::<String>(&self.name, None)
+            .await?;
+
+        Ok(())
+    }
+
+    async fn wait(&self) -> Result<(), Error> {
+        let mut attempts = 1;
+        let mut stdout = BytesMut::new();
+        loop {
+            let exec = self
+                .docker
+                .create_exec(
+                    &self.name,
+                    CreateExecOptions {
+                        attach_stdout: Some(true),
+                        attach_stderr: Some(true),
+                        cmd: Some(vec!["buildctl", "debug", "workers"]),
+                        ..Default::default()
+                    },
+                )
+                .await?
+                .id;
+
+            if let StartExecResults::Attached {
+                mut output,
+                input: _,
+            } = self.docker.start_exec(&exec, None).await?
+            {
+                while let Some(Ok(output)) = output.next().await {
+                    stdout.extend_from_slice(output.into_bytes().as_ref());
+                }
+            };
+
+            let inspect: ExecInspectResponse = self.docker.inspect_exec(&exec).await?;
+
+            match inspect {
+                ExecInspectResponse {
+                    exit_code: Some(0), ..
+                } => return Ok(()),
+                ExecInspectResponse {
+                    exit_code: Some(status_code),
+                    ..
+                } if attempts > 15 => {
+                    info!("{}", std::str::from_utf8(stdout.as_ref())?);
+                    return Err(Error::DockerContainerWaitError {
+                        error: String::from(std::str::from_utf8(stdout.as_ref())?),
+                        code: status_code,
+                    });
+                }
+                _ => {
+                    tokio::time::sleep(Duration::from_millis(attempts * 120)).await;
+                    attempts = attempts + 1;
+                }
+            }
+        }
+    }
+}

--- a/src/grpc/driver/docker_container.rs
+++ b/src/grpc/driver/docker_container.rs
@@ -1,40 +1,28 @@
 use std::{
-    cmp,
-    collections::HashMap,
-    path::Path,
     pin::Pin,
-    sync::Arc,
     task::{Context, Poll},
     time::Duration,
 };
-//use std::io::Bytes;
 
-use bollard_buildkit_proto::moby;
 use bollard_stubs::models::{
-    ContainerWaitExitError, ContainerWaitResponse, ExecInspectResponse, HostConfig, Mount,
-    MountTypeEnum, SystemInfoCgroupDriverEnum, Volume,
+    ExecInspectResponse, HostConfig, Mount, MountTypeEnum, SystemInfoCgroupDriverEnum,
 };
-use bytes::{BufMut, Bytes, BytesMut};
-use futures_core::{ready, Future, TryStream};
+use bytes::BytesMut;
+use futures_core::Future;
 use futures_util::{StreamExt, TryStreamExt};
 use http::{
     header::{CONNECTION, UPGRADE},
     request::Builder,
     Method,
 };
-use hyper::Body;
-use pin_project_lite::pin_project;
-use tokio::io::{AsyncRead, AsyncWrite};
-use tokio_util::codec::FramedRead;
-use tonic::transport::server::Connected;
 use tower_service::Service;
 
 use crate::{
-    container::{Config, CreateContainerOptions, LogOutput, WaitContainerOptions},
+    container::{Config, CreateContainerOptions},
     errors::Error,
     exec::{CreateExecOptions, StartExecOptions, StartExecResults},
+    grpc::io::GrpcFramedTransport,
     image::CreateImageOptions,
-    read::NewlineLogOutputDecoder,
     Docker,
 };
 
@@ -42,162 +30,7 @@ const DEFAULT_IMAGE: &str = "moby/buildkit:master";
 const DEFAULT_STATE_DIR: &str = "/var/lib/buildkit";
 const DEFAULT_BUILDKIT_CONFIG_DIR: &str = "/etc/buildkit";
 
-pin_project! {
-    /// Reader for the [`into_async_read`](super::TryStreamExt::into_async_read) method.
-    #[derive(Debug)]
-    pub struct IntoAsyncRead<St>
-    where
-        St: TryStream<Error = std::io::Error>,
-        St::Ok: AsRef<[u8]>,
-    {
-        #[pin]
-        stream: St,
-        state: ReadState<St::Ok>,
-    }
-}
-
-#[derive(Debug)]
-enum ReadState<T: AsRef<[u8]>> {
-    Ready { chunk: T, chunk_start: usize },
-    PendingChunk,
-    Eof,
-}
-
-impl<St> IntoAsyncRead<St>
-where
-    St: TryStream<Error = std::io::Error>,
-    St::Ok: AsRef<[u8]>,
-{
-    pub(super) fn new(stream: St) -> Self {
-        Self {
-            stream,
-            state: ReadState::PendingChunk,
-        }
-    }
-}
-
-impl<St> AsyncRead for IntoAsyncRead<St>
-where
-    St: TryStream<Error = std::io::Error>,
-    St::Ok: AsRef<[u8]>,
-{
-    fn poll_read(
-        self: Pin<&mut Self>,
-        cx: &mut Context<'_>,
-        buf: &mut tokio::io::ReadBuf<'_>,
-    ) -> Poll<std::io::Result<()>> {
-        let mut this = self.project();
-
-        loop {
-            match this.state {
-                ReadState::Ready { chunk, chunk_start } => {
-                    let chunk = chunk.as_ref();
-                    let len = cmp::min(buf.remaining(), chunk.len() - *chunk_start);
-
-                    buf.put_slice(&chunk[*chunk_start..*chunk_start + len]);
-
-                    *chunk_start += len;
-
-                    if chunk.len() == *chunk_start {
-                        *this.state = ReadState::PendingChunk;
-                    }
-
-                    return Poll::Ready(Ok(()));
-                }
-                ReadState::PendingChunk => match ready!(this.stream.as_mut().try_poll_next(cx)) {
-                    Some(Ok(chunk)) => {
-                        if !chunk.as_ref().is_empty() {
-                            *this.state = ReadState::Ready {
-                                chunk,
-                                chunk_start: 0,
-                            };
-                        }
-                    }
-                    Some(Err(err)) => {
-                        *this.state = ReadState::Eof;
-                        return Poll::Ready(Err(err));
-                    }
-                    None => {
-                        *this.state = ReadState::Eof;
-                        return Poll::Ready(Ok(()));
-                    }
-                },
-                ReadState::Eof => {
-                    return Poll::Ready(Ok(()));
-                }
-            }
-        }
-    }
-}
-
-#[allow(missing_debug_implementations)]
-/// TODO
-pub struct GrpcFramedTransport {
-    read: IntoAsyncRead<FramedRead<Pin<Box<dyn AsyncRead + Send>>, NewlineLogOutputDecoder>>,
-    write: Pin<Box<dyn AsyncWrite + Send>>,
-}
-
-impl AsRef<[u8]> for LogOutput {
-    fn as_ref(&self) -> &[u8] {
-        match self {
-            LogOutput::StdErr { message } => message.as_ref(),
-            LogOutput::StdOut { message } => message.as_ref(),
-            LogOutput::StdIn { message } => message.as_ref(),
-            LogOutput::Console { message } => message.as_ref(),
-        }
-    }
-}
-
-impl GrpcFramedTransport {
-    pub(crate) fn new(
-        read: Pin<Box<dyn AsyncRead + Send>>,
-        write: Pin<Box<dyn AsyncWrite + Send>>,
-        capacity: usize,
-    ) -> Self {
-        let output = FramedRead::with_capacity(read, NewlineLogOutputDecoder::new(true), capacity);
-        let read = IntoAsyncRead::new(output);
-        Self { read, write }
-    }
-}
-
-impl Connected for GrpcFramedTransport {
-    type ConnectInfo = ();
-
-    fn connect_info(&self) -> Self::ConnectInfo {}
-}
-
-impl AsyncRead for GrpcFramedTransport {
-    fn poll_read(
-        mut self: Pin<&mut Self>,
-        cx: &mut Context<'_>,
-        buf: &mut tokio::io::ReadBuf<'_>,
-    ) -> Poll<std::io::Result<()>> {
-        Pin::new(&mut self.read).poll_read(cx, buf)
-    }
-}
-
-impl AsyncWrite for GrpcFramedTransport {
-    fn poll_write(
-        mut self: Pin<&mut Self>,
-        cx: &mut Context<'_>,
-        buf: &[u8],
-    ) -> Poll<std::io::Result<usize>> {
-        Pin::new(&mut self.write).poll_write(cx, buf)
-    }
-
-    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
-        Pin::new(&mut self.write).poll_flush(cx)
-    }
-
-    fn poll_shutdown(
-        mut self: Pin<&mut Self>,
-        cx: &mut Context<'_>,
-    ) -> Poll<Result<(), std::io::Error>> {
-        Pin::new(&mut self.write).poll_shutdown(cx)
-    }
-}
-
-impl Service<http::Uri> for Driver {
+impl Service<http::Uri> for DockerContainer {
     type Response = GrpcFramedTransport;
     type Error = Error;
     type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send>>;
@@ -209,7 +42,6 @@ impl Service<http::Uri> for Driver {
     fn call(&mut self, _req: http::Uri) -> Self::Future {
         let client = Docker::clone(&self.docker);
         let name = String::clone(&self.name);
-        let session_id = String::clone(&self.session_id);
 
         let fut = async move {
             let exec_id = client
@@ -252,22 +84,21 @@ impl Service<http::Uri> for Driver {
                 })
         };
 
-        // Return the response as an immediate future
         Box::pin(fut)
     }
 }
 
 /// TODO
 #[derive(Debug)]
-pub struct DriverBuilder {
-    inner: Driver,
+pub struct DockerContainerBuilder {
+    inner: DockerContainer,
 }
 
-impl DriverBuilder {
+impl DockerContainerBuilder {
     /// TODO
     pub fn new(name: &str, docker: &Docker, session_id: &str) -> Self {
         Self {
-            inner: Driver {
+            inner: DockerContainer {
                 name: String::from(name),
                 docker: Docker::clone(docker),
                 session_id: String::from(session_id),
@@ -281,7 +112,7 @@ impl DriverBuilder {
     }
 
     /// TODO
-    pub async fn bootstrap(mut self) -> Result<Driver, Error> {
+    pub async fn bootstrap(mut self) -> Result<DockerContainer, Error> {
         debug!("booting buildkit");
 
         if self.inner.net_mode.is_none() {
@@ -311,7 +142,7 @@ impl DriverBuilder {
     }
 
     /// TODO
-    pub fn network(&mut self, net: &str) -> &mut DriverBuilder {
+    pub fn network(&mut self, net: &str) -> &mut DockerContainerBuilder {
         if net == "host" {
             self.inner
                 .args
@@ -321,11 +152,36 @@ impl DriverBuilder {
         self.inner.net_mode = Some(net.to_string());
         self
     }
+
+    /// The image to use when spinning up a `Buildkit` container. The default is [`DEFAULT_IMAGE`]
+    pub fn image(&mut self, image: &str) -> &mut DockerContainerBuilder {
+        self.inner.image = Some(String::from(image));
+        self
+    }
+
+    /// The cgroup to attach to - by default all `Buildkit` containers are placed under the same
+    /// cgroup so that limits are applied across the whole host
+    pub fn cgroup_parent(&mut self, cgroup_parent: &str) -> &mut DockerContainerBuilder {
+        self.inner.cgroup_parent = Some(String::from(cgroup_parent));
+        self
+    }
+
+    /// Set an env variable for the `Buildkit` container.
+    pub fn env(&mut self, env: &str) -> &mut DockerContainerBuilder {
+        self.inner.env.push(String::from(env));
+        self
+    }
+
+    /// Set a additional run command arguments to the `Buildkit` docker execution.
+    pub fn arg(&mut self, arg: &str) -> &mut DockerContainerBuilder {
+        self.inner.args.push(String::from(arg));
+        self
+    }
 }
 
 /// TODO
 #[derive(Debug)]
-pub struct Driver {
+pub struct DockerContainer {
     /// TODO
     name: String,
     /// TODO
@@ -344,7 +200,7 @@ pub struct Driver {
     args: Vec<String>,
 }
 
-impl Driver {
+impl DockerContainer {
     /// TODO
     pub async fn create(&self) -> Result<(), Error> {
         let image_name = if let Some(image) = &self.image {

--- a/src/grpc/driver/docker_container.rs
+++ b/src/grpc/driver/docker_container.rs
@@ -39,7 +39,8 @@ use crate::{
     Docker,
 };
 
-const DEFAULT_IMAGE: &str = "moby/buildkit:master";
+/// The default `Buildkit` image to use for the [`DockerContainer] driver.
+pub const DEFAULT_IMAGE: &str = "moby/buildkit:master";
 const DEFAULT_STATE_DIR: &str = "/var/lib/buildkit";
 const DUPLEX_BUF_SIZE: usize = 8 * 1024;
 
@@ -101,14 +102,40 @@ impl Service<http::Uri> for DockerContainer {
     }
 }
 
-/// TODO
+/// Builder used to create a driver, needed to communicate with `Buildkit`, such as with the
+/// [`image_export_oci`][crate::Docker::image_export_oci] functionality.
+///
+/// <div class="warning">
+///  Warning: Buildkit features in Bollard are currently in Developer Preview and are intended strictly for feedback purposes only. 
+/// </div>
+///
+/// ## Examples
+///
+/// ```rust
+/// use bollard::grpc::driver::docker_container::DockerContainerBuilder;
+/// use bollard::Docker;
+///
+/// // Use a connection function
+/// // let docker = Docker::connect_...;
+/// # let docker = Docker::connect_with_local_defaults().unwrap();
+///
+/// let builder = DockerContainerBuilder::new("buildkit_doctest", &docker, "buildkit_session_id");
+///
+/// ```
+///
 #[derive(Debug)]
 pub struct DockerContainerBuilder {
     inner: DockerContainer,
 }
 
 impl DockerContainerBuilder {
-    /// TODO
+    /// Construct a new `DockerContainerBuilder` to build a [`DockerContainer`]
+    ///
+    /// # Arguments
+    ///
+    ///  - The container name used to identify the buildkit in Docker
+    ///  - A reference to the docker client
+    ///  - A unique session id to identify the GRPC connection
     pub fn new(name: &str, docker: &Docker, session_id: &str) -> Self {
         Self {
             inner: DockerContainer {
@@ -124,7 +151,7 @@ impl DockerContainerBuilder {
         }
     }
 
-    /// TODO
+    /// Consume this builder to construct a [`DockerContainer`]
     pub async fn bootstrap(mut self) -> Result<DockerContainer, Error> {
         debug!("booting buildkit");
 
@@ -154,7 +181,7 @@ impl DockerContainerBuilder {
         Ok(self.inner)
     }
 
-    /// TODO
+    /// The network mode to apply to the `Buildkit` docker container.
     pub fn network(&mut self, net: &str) -> &mut DockerContainerBuilder {
         if net == "host" {
             self.inner
@@ -192,34 +219,32 @@ impl DockerContainerBuilder {
     }
 }
 
-/// TODO
+/// DockerContainer plumbing to communicate with `Buildkit` using an execution pipe.
+/// Underneath, the `buildkit` CLI will open a stdin/stdout pipe, which we can hook into to call
+/// further GRPC methods.
+///
+/// Construct a `DockerContainer` using a [`DockerContainerBuilder`].
+///
+///
 #[derive(Debug)]
 pub struct DockerContainer {
-    /// TODO
     name: String,
-    /// TODO
     docker: Docker,
-    /// TODO
     session_id: String,
-    /// TODO
     net_mode: Option<String>,
-    /// TODO
     image: Option<String>,
-    /// TODO
     cgroup_parent: Option<String>,
-    /// TODO
     env: Vec<String>,
-    /// TODO
     args: Vec<String>,
 }
 
 impl<'a> DockerContainer {
-    /// TODO
+    /// Identifies the docker container name that runs `Buildkit`. This should be unique if you
+    /// intend to run multiple instances building in parallel on the same host.
     pub fn name(&self) -> &str {
         &self.name
     }
 
-    /// TODO
     pub(crate) async fn grpc_handle(
         self,
         session_id: &'a str,

--- a/src/grpc/driver/moby.rs
+++ b/src/grpc/driver/moby.rs
@@ -11,11 +11,11 @@ use crate::{
     Docker,
 };
 
-/// TODO
+/// The Moby driver handles a GRPC connection with an upgraded `/session` and `/grpc` endpoints in
+/// Docker itself.
 #[derive(Debug)]
 pub struct Moby {
-    /// TODO
-    pub docker: Docker,
+    pub(crate) docker: Docker,
 }
 
 impl Moby {

--- a/src/grpc/driver/moby.rs
+++ b/src/grpc/driver/moby.rs
@@ -1,0 +1,91 @@
+#![cfg(feature = "buildkit")]
+
+use bollard_buildkit_proto::{health, moby::buildkit::v1::control_client::ControlClient};
+use http::{request::Builder, Method};
+use hyper::Body;
+use tonic::transport::{Channel, Endpoint};
+
+use crate::{
+    errors::Error,
+    grpc::{io::GrpcTransport, GrpcClient, GrpcServer, HealthServerImpl},
+    Docker,
+};
+
+/// TODO
+#[derive(Debug)]
+pub struct Moby {
+    /// TODO
+    pub docker: Docker,
+}
+
+impl Moby {
+    async fn grpc_handle(
+        &mut self,
+        session_id: &str,
+        services: Vec<GrpcServer>,
+    ) -> Result<ControlClient<Channel>, Error> {
+        let grpc_client = GrpcClient {
+            client: self.docker.clone(),
+            session_id: String::from(session_id),
+        };
+
+        let channel = Endpoint::try_from("http://[::]:50051")?
+            .connect_with_connector(grpc_client)
+            .await?;
+
+        let control_client = ControlClient::new(channel);
+
+        let url = "/session";
+
+        let opt: Option<serde_json::Value> = None;
+        let metadata_grpc_method: Vec<String> = services.iter().flat_map(|s| s.names()).collect();
+
+        let req = self.docker.build_request(
+            &url,
+            Builder::new()
+                .method(Method::POST)
+                .header("Connection", "Upgrade")
+                .header("Upgrade", "h2c")
+                .header("X-Docker-Expose-Session-Uuid", session_id)
+                .header(
+                    "X-Docker-Expose-Session-Grpc-Method",
+                    metadata_grpc_method.join(","),
+                ),
+            opt,
+            Ok(Body::empty()),
+        );
+
+        let (read, write) = self.docker.process_upgraded(req).await?;
+
+        let output = Box::pin(read);
+        let input = Box::pin(write);
+        let transport = GrpcTransport {
+            read: output,
+            write: input,
+        };
+
+        tokio::spawn(async {
+            let health = health::health_server::HealthServer::new(HealthServerImpl::new());
+            let mut builder = tonic::transport::Server::builder();
+            let mut router = builder.add_service(health);
+            for service in services {
+                router = service.append(router);
+            }
+            trace!("router: {:#?}", router);
+            match router
+                .serve_with_incoming(futures_util::stream::iter(vec![Ok::<
+                    _,
+                    tonic::transport::Error,
+                >(
+                    transport
+                )]))
+                .await
+            {
+                Err(e) => error!("Failed to serve grpc connection: {}", e),
+                _ => (),
+            }
+        });
+
+        Ok(control_client)
+    }
+}

--- a/src/grpc/driver/moby.rs
+++ b/src/grpc/driver/moby.rs
@@ -6,7 +6,7 @@ use hyper::Body;
 use tonic::transport::{Channel, Endpoint};
 
 use crate::{
-    errors::Error,
+    grpc::error::GrpcError,
     grpc::{io::GrpcTransport, GrpcClient, GrpcServer, HealthServerImpl},
     Docker,
 };
@@ -23,7 +23,7 @@ impl Moby {
         &mut self,
         session_id: &str,
         services: Vec<GrpcServer>,
-    ) -> Result<ControlClient<Channel>, Error> {
+    ) -> Result<ControlClient<Channel>, GrpcError> {
         let grpc_client = GrpcClient {
             client: self.docker.clone(),
             session_id: String::from(session_id),

--- a/src/grpc/driver/mod.rs
+++ b/src/grpc/driver/mod.rs
@@ -1,4 +1,6 @@
-/// TODO
+/// The Docker Container driver opens a GRPC connection by instantiating a Buildkit container over
+/// the traditional docker socket, and communicating over a docker execution Stdin/Stdout pipe.
 pub mod docker_container;
-/// TODO
+/// The Moby driver opens a bi-directional GRPC connection by upgrading HTTP `/session` and `/grpc`
+/// endpoints over the traditional docker socket.
 pub mod moby;

--- a/src/grpc/driver/mod.rs
+++ b/src/grpc/driver/mod.rs
@@ -1,0 +1,2 @@
+/// TODO
+pub mod docker_container;

--- a/src/grpc/driver/mod.rs
+++ b/src/grpc/driver/mod.rs
@@ -1,2 +1,4 @@
 /// TODO
 pub mod docker_container;
+/// TODO
+pub mod moby;

--- a/src/grpc/error.rs
+++ b/src/grpc/error.rs
@@ -11,28 +11,28 @@ pub enum GrpcError {
         err: crate::errors::Error,
     },
     /// Error emitted when log output generates an I/O error.
-    #[error(transparent)]
+    #[error("Invalid UTF-8 string: {}", err)]
     StrParseError {
         /// The original error emitted.
         #[from]
         err: std::str::Utf8Error,
     },
     /// Error emitted when a GRPC network request or response fails with docker's buildkit client
-    #[error(transparent)]
+    #[error("Grpc network failure: description = {}", err)]
     TonicError {
         /// The tonic error emitted.
         #[from]
         err: tonic::transport::Error,
     },
     /// Error emitted when a GRPC network request emits a non-OK status code
-    #[error(transparent)]
+    #[error("Grpc response failure: status = {}, message = {}", err.code(), err.message())]
     TonicStatus {
         /// The tonic status emitted.
         #[from]
         err: tonic::Status,
     },
     /// Error emitted when a GRPC metadata value does not parse correctly
-    #[error(transparent)]
+    #[error("Invalid grpc metadata value: {}", err)]
     MetadataValue {
         /// The tonic metadata value.
         #[from]

--- a/src/grpc/error.rs
+++ b/src/grpc/error.rs
@@ -1,0 +1,41 @@
+#![cfg(feature = "buildkit")]
+
+/// Errors related to the Grpc functionality
+#[derive(Debug, thiserror::Error)]
+pub enum GrpcError {
+    /// Generic error emitted by the bollard codebase.
+    #[error(transparent)]
+    DockerError {
+        /// The original error of the bollard codebase.
+        #[from]
+        err: crate::errors::Error,
+    },
+    /// Error emitted when log output generates an I/O error.
+    #[error(transparent)]
+    StrParseError {
+        /// The original error emitted.
+        #[from]
+        err: std::str::Utf8Error,
+    },
+    /// Error emitted when a GRPC network request or response fails with docker's buildkit client
+    #[error(transparent)]
+    TonicError {
+        /// The tonic error emitted.
+        #[from]
+        err: tonic::transport::Error,
+    },
+    /// Error emitted when a GRPC network request emits a non-OK status code
+    #[error(transparent)]
+    TonicStatus {
+        /// The tonic status emitted.
+        #[from]
+        err: tonic::Status,
+    },
+    /// Error emitted when a GRPC metadata value does not parse correctly
+    #[error(transparent)]
+    MetadataValue {
+        /// The tonic metadata value.
+        #[from]
+        err: tonic::metadata::errors::InvalidMetadataValue,
+    },
+}

--- a/src/grpc/export.rs
+++ b/src/grpc/export.rs
@@ -10,8 +10,8 @@ use std::collections::HashMap;
 use std::net::IpAddr;
 use std::path::Path;
 
+use super::error::GrpcError;
 use crate::container::KillContainerOptions;
-use crate::errors::Error;
 
 use super::driver::docker_container::DockerContainer;
 
@@ -629,7 +629,7 @@ impl<'a> super::super::Docker {
         frontend_opts: ImageBuildFrontendOptions,
         exporter_request: ImageExporterOCIRequest,
         load_input: ImageExporterLoadInput,
-    ) -> Result<(), Error> {
+    ) -> Result<(), GrpcError> {
         let buildkit_name = String::from(driver.name());
 
         let payload = match load_input {
@@ -654,7 +654,7 @@ impl<'a> super::super::Docker {
             super::GrpcServer::Upload(upload),
         ];
 
-        let mut control_client = driver.grpc_handle(session_id, services).await.unwrap();
+        let mut control_client = driver.grpc_handle(session_id, services).await?;
 
         let id = super::new_id();
 

--- a/src/grpc/export.rs
+++ b/src/grpc/export.rs
@@ -1,0 +1,639 @@
+#![cfg(feature = "buildkit")]
+
+pub use bollard_buildkit_proto::fsutil;
+pub use bollard_buildkit_proto::health;
+pub use bollard_buildkit_proto::moby;
+
+use bytes::Bytes;
+use http::request::Builder;
+use hyper::Body;
+use hyper::Method;
+
+use std::collections::HashMap;
+use std::net::IpAddr;
+use std::path::Path;
+
+use crate::errors::Error;
+
+/// TODO
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct ImageBuildFrontendOptions {
+    //pub(crate) cgroupparent: Option<String>,
+    //pub(crate) multiplatform: bool,
+    //pub(crate) attests: HashMap<String, String>,
+    pub(crate) cachefrom: Vec<String>,
+    pub(crate) image_resolve_mode: bool,
+    pub(crate) target: Option<String>,
+    pub(crate) nocache: bool,
+    pub(crate) buildargs: HashMap<String, String>,
+    pub(crate) labels: HashMap<String, String>,
+    pub(crate) platforms: Vec<ImageBuildPlatform>,
+    pub(crate) force_network_mode: ImageBuildNetworkMode,
+    pub(crate) extrahosts: Vec<ImageBuildHostIp>,
+    pub(crate) shmsize: u64,
+    //pub(crate) ulimit: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+/// TODO
+pub struct ImageBuildHostIp {
+    /// TODO
+    pub host: String,
+    /// TODO
+    pub ip: IpAddr,
+}
+
+impl ToString for ImageBuildHostIp {
+    fn to_string(&self) -> String {
+        format!("{}={}", self.host, self.ip)
+    }
+}
+
+#[derive(Debug, Copy, Clone, PartialEq)]
+#[non_exhaustive]
+/// TODO
+pub enum ImageBuildNetworkMode {
+    /// TODO
+    Bridge,
+    /// TODO
+    Host,
+    /// TODO
+    None,
+}
+
+impl Default for ImageBuildNetworkMode {
+    fn default() -> Self {
+        ImageBuildNetworkMode::Bridge
+    }
+}
+
+impl ToString for ImageBuildNetworkMode {
+    fn to_string(&self) -> String {
+        match self {
+            ImageBuildNetworkMode::Bridge => String::from("default"),
+            ImageBuildNetworkMode::Host => String::from("host"),
+            ImageBuildNetworkMode::None => String::from("none"),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default, PartialEq)]
+// from https://github.com/opencontainers/image-spec/blob/main/specs-go/v1/descriptor.go
+/// TODO
+pub struct ImageBuildPlatform {
+    /// TODO
+    pub architecture: String,
+    /// TODO
+    pub os: String,
+    /// TODO
+    pub variant: Option<String>,
+}
+
+impl ToString for ImageBuildPlatform {
+    fn to_string(&self) -> String {
+        let prefix = Path::new(&self.architecture).join(Path::new(&self.os));
+        if let Some(variant) = &self.variant {
+            prefix.join(Path::new(&variant))
+        } else {
+            prefix
+        }
+        .display()
+        .to_string()
+    }
+}
+
+impl ImageBuildFrontendOptions {
+    /// TODO
+    pub fn builder() -> ImageBuildFrontendOptionsBuilder {
+        ImageBuildFrontendOptionsBuilder::new()
+    }
+
+    /// TODO
+    pub fn to_map(self) -> HashMap<String, String> {
+        let mut attrs = HashMap::new();
+
+        if self.image_resolve_mode {
+            attrs.insert(String::from("image-resolve-mode"), String::from("pull"));
+        } else {
+            attrs.insert(String::from("image-resolve-mode"), String::from("default"));
+        }
+
+        if let Some(target) = self.target {
+            attrs.insert(String::from("target"), target);
+        }
+
+        if self.nocache {
+            attrs.insert(String::from("no-cache"), String::new());
+        }
+
+        if !self.buildargs.is_empty() {
+            for (key, value) in self.buildargs {
+                attrs.insert(format!("build-arg:{}", key), value);
+            }
+        }
+
+        if !self.labels.is_empty() {
+            for (key, value) in self.labels {
+                attrs.insert(format!("label:{}", key), value);
+            }
+        }
+
+        if !self.platforms.is_empty() {
+            attrs.insert(
+                String::from("platform"),
+                self.platforms
+                    .iter()
+                    .map(|v| v.to_string())
+                    .collect::<Vec<_>>()
+                    .join(","),
+            );
+        }
+
+        match self.force_network_mode {
+            ImageBuildNetworkMode::Host => {
+                attrs.insert(String::from("force-network-mode"), String::from("host"));
+            }
+            ImageBuildNetworkMode::None => {
+                attrs.insert(String::from("force-network-mode"), String::from("none"));
+            }
+            _ => (),
+        }
+
+        if !self.extrahosts.is_empty() {
+            attrs.insert(
+                String::from("add-hosts"),
+                self.extrahosts
+                    .iter()
+                    .map(|v| v.to_string())
+                    .collect::<Vec<_>>()
+                    .join(","),
+            );
+        }
+
+        if self.shmsize > 0 {
+            attrs.insert(String::from("shm-size"), self.shmsize.to_string());
+        }
+
+        if !self.cachefrom.is_empty() {
+            attrs.insert(String::from("cache-from"), self.cachefrom.join(","));
+        }
+
+        attrs
+    }
+}
+
+/// TODO
+#[derive(Debug, Clone, Default, PartialEq)]
+#[cfg(feature = "buildkit")]
+pub struct ImageBuildFrontendOptionsBuilder {
+    inner: ImageBuildFrontendOptions,
+}
+
+/// TODO
+#[cfg(feature = "buildkit")]
+impl ImageBuildFrontendOptionsBuilder {
+    /// TODO
+    pub fn new() -> Self {
+        Self {
+            inner: ImageBuildFrontendOptions {
+                ..Default::default()
+            },
+        }
+    }
+
+    /// TODO
+    pub fn cachefrom(mut self, value: &str) -> Self {
+        self.inner.cachefrom.push(value.to_owned());
+        self
+    }
+
+    /// TODO
+    pub fn pull(mut self, pull: bool) -> Self {
+        self.inner.image_resolve_mode = pull;
+        self
+    }
+
+    /// TODO
+    pub fn target(mut self, target: &str) -> Self {
+        self.inner.target = Some(String::from(target));
+        self
+    }
+
+    /// TODO
+    pub fn nocache(mut self, nocache: bool) -> Self {
+        self.inner.nocache = nocache;
+        self
+    }
+
+    /// TODO
+    pub fn buildarg(mut self, key: &str, value: &str) -> Self {
+        self.inner
+            .buildargs
+            .insert(String::from(key), String::from(value));
+        self
+    }
+
+    /// TODO
+    pub fn label(mut self, key: &str, value: &str) -> Self {
+        self.inner
+            .labels
+            .insert(String::from(key), String::from(value));
+        self
+    }
+
+    /// TODO
+    pub fn platforms(mut self, value: &ImageBuildPlatform) -> Self {
+        self.inner.platforms.push(value.to_owned());
+        self
+    }
+
+    /// TODO
+    pub fn force_network_mode(mut self, value: &ImageBuildNetworkMode) -> Self {
+        self.inner.force_network_mode = value.to_owned();
+        self
+    }
+
+    /// TODO
+    pub fn extrahost(mut self, value: &ImageBuildHostIp) -> Self {
+        self.inner.extrahosts.push(value.to_owned());
+        self
+    }
+
+    /// TODO
+    pub fn shmsize(mut self, value: u64) -> Self {
+        self.inner.shmsize = value;
+        self
+    }
+
+    /// TODO
+    pub fn build(self) -> ImageBuildFrontendOptions {
+        self.inner
+    }
+}
+
+/// TODO
+#[derive(Debug, Clone, Default, PartialEq)]
+#[cfg(feature = "buildkit")]
+pub struct ImageExporterOCIOutput {
+    pub(crate) name: String,
+    pub(crate) push: bool,
+    pub(crate) push_by_digest: bool,
+    pub(crate) insecure_registry: bool,
+    pub(crate) dangling_name_prefix: Option<String>,
+    pub(crate) name_canonical: Option<bool>,
+    pub(crate) compression: ImageExporterOCIOutputCompression,
+    pub(crate) compression_level: Option<u8>,
+    pub(crate) force_compression: bool,
+    pub(crate) oci_mediatypes: bool,
+    pub(crate) unpack: bool,
+    pub(crate) store: bool,
+    pub(crate) annotation: HashMap<String, String>,
+}
+
+#[derive(Debug, Copy, Clone, PartialEq)]
+#[non_exhaustive]
+/// TODO
+pub enum ImageExporterOCIOutputCompression {
+    /// TODO
+    Uncompressed,
+    /// TODO
+    Gzip,
+    /// TODO
+    Estargz,
+    /// TODO
+    Zstd,
+}
+
+impl Default for ImageExporterOCIOutputCompression {
+    fn default() -> Self {
+        ImageExporterOCIOutputCompression::Gzip
+    }
+}
+
+impl ToString for ImageExporterOCIOutputCompression {
+    fn to_string(&self) -> String {
+        match self {
+            ImageExporterOCIOutputCompression::Uncompressed => "uncompressed",
+            ImageExporterOCIOutputCompression::Gzip => "gzip",
+            ImageExporterOCIOutputCompression::Estargz => "estargz",
+            ImageExporterOCIOutputCompression::Zstd => "zstd",
+        }
+        .to_string()
+    }
+}
+
+/// TODO
+#[derive(Debug, Clone, Default, PartialEq)]
+#[cfg(feature = "buildkit")]
+pub struct ImageExporterOCIRequest {
+    output: ImageExporterOCIOutput,
+    path: std::path::PathBuf,
+}
+
+/// TODO
+#[cfg(feature = "buildkit")]
+impl ImageExporterOCIOutput {
+    /// TODO
+    pub fn builder(&self, name: &str) -> ImageExporterOCIOutputBuilder {
+        ImageExporterOCIOutputBuilder::new(name)
+    }
+
+    /// TODO
+    pub fn new(name: &str) -> Self {
+        Self {
+            name: String::from(name),
+            ..Default::default()
+        }
+    }
+
+    /// TODO
+    pub fn to_map(self) -> HashMap<String, String> {
+        let mut attrs = HashMap::new();
+
+        attrs.insert(String::from("name"), self.name);
+        attrs.insert(String::from("push"), self.push.to_string());
+        attrs.insert(
+            String::from("push-by-digest"),
+            self.push_by_digest.to_string(),
+        );
+        attrs.insert(
+            String::from("registry.insecure"),
+            self.insecure_registry.to_string(),
+        );
+
+        if let Some(dangling_name_prefix) = self.dangling_name_prefix {
+            attrs.insert(String::from("dangling-name-prefix"), dangling_name_prefix);
+        }
+
+        if let Some(name_canonical) = self.name_canonical {
+            attrs.insert(String::from("name-canonical"), name_canonical.to_string());
+        }
+
+        attrs.insert(String::from("compression"), self.compression.to_string());
+
+        if let Some(compression_level) = self.compression_level {
+            attrs.insert(
+                String::from("compression-level"),
+                compression_level.to_string(),
+            );
+        }
+
+        attrs.insert(
+            String::from("force-compression"),
+            self.force_compression.to_string(),
+        );
+        attrs.insert(
+            String::from("oci-mediatypes"),
+            self.oci_mediatypes.to_string(),
+        );
+        attrs.insert(String::from("unpack"), self.unpack.to_string());
+        attrs.insert(String::from("store"), self.store.to_string());
+
+        for (key, value) in self.annotation {
+            attrs.insert(format!("annotation.{}", key), value);
+        }
+
+        attrs
+    }
+}
+
+/// TODO
+#[derive(Debug, Clone, Default, PartialEq)]
+#[cfg(feature = "buildkit")]
+pub struct ImageExporterOCIOutputBuilder {
+    inner: ImageExporterOCIOutput,
+}
+
+/// TODO
+#[cfg(feature = "buildkit")]
+impl ImageExporterOCIOutputBuilder {
+    /// TODO
+    pub fn new(name: &str) -> Self {
+        Self {
+            inner: ImageExporterOCIOutput {
+                name: String::from(name),
+                ..Default::default()
+            },
+        }
+    }
+
+    /// TODO
+    pub fn push(mut self, push: bool) -> Self {
+        self.inner.push = push;
+        self
+    }
+
+    /// TODO
+    pub fn push_by_digest(mut self, push_by_digest: bool) -> Self {
+        self.inner.push_by_digest = push_by_digest;
+        self
+    }
+
+    /// TODO
+    pub fn insecure_registry(mut self, insecure_registry: bool) -> Self {
+        self.inner.insecure_registry = insecure_registry;
+        self
+    }
+
+    /// TODO
+    pub fn dangling_name_prefix(mut self, dangling_name_prefix: &str) -> Self {
+        self.inner.dangling_name_prefix = Some(String::from(dangling_name_prefix));
+        self
+    }
+
+    /// TODO
+    pub fn name_canonical(mut self, name_canonical: bool) -> Self {
+        self.inner.name_canonical = Some(name_canonical);
+        self
+    }
+
+    /// TODO
+    pub fn compression(mut self, compression: &ImageExporterOCIOutputCompression) -> Self {
+        self.inner.compression = compression.to_owned();
+        self
+    }
+
+    /// TODO
+    pub fn compression_level(mut self, compression_level: u8) -> Self {
+        self.inner.compression_level = Some(compression_level);
+        self
+    }
+
+    /// TODO
+    pub fn force_compression(mut self, force_compression: bool) -> Self {
+        self.inner.force_compression = force_compression;
+        self
+    }
+
+    /// TODO
+    pub fn oci_mediatypes(mut self, oci_mediatypes: bool) -> Self {
+        self.inner.oci_mediatypes = oci_mediatypes;
+        self
+    }
+
+    /// TODO
+    pub fn unpack(mut self, unpack: bool) -> Self {
+        self.inner.unpack = unpack;
+        self
+    }
+
+    /// TODO
+    pub fn store(mut self, store: bool) -> Self {
+        self.inner.store = store;
+        self
+    }
+
+    /// TODO
+    pub fn annotation(mut self, key: &str, value: &str) -> Self {
+        self.inner
+            .annotation
+            .insert(String::from(key), String::from(value));
+        self
+    }
+
+    /// TODO
+    pub fn dest(self, path: &Path) -> ImageExporterOCIRequest {
+        ImageExporterOCIRequest {
+            output: self.inner,
+            path: path.to_owned(),
+        }
+    }
+}
+
+#[derive(Debug, PartialEq)]
+#[non_exhaustive]
+/// TODO
+pub enum ImageExporterLoadInput {
+    /// TODO
+    Upload(Bytes),
+}
+
+impl super::super::Docker {
+    /// TODO
+    #[cfg(feature = "buildkit")]
+    async fn raw_grpc_handle(
+        &mut self,
+        session_id: &str,
+        services: Vec<super::GrpcServer>,
+    ) -> Result<tonic::transport::Channel, Error> {
+        use futures_util::future::ok;
+        use std::sync::Arc;
+        use tonic::transport::{Endpoint, Uri};
+        use tower::service_fn;
+
+        let grpc_client = super::GrpcClient {
+            client: self.clone(),
+            session_id: String::from(session_id),
+        };
+
+        let channel = Endpoint::try_from("http://[::]:50051")?
+            .connect_with_connector(grpc_client)
+            .await?;
+
+        let url = "/session";
+
+        let opt: Option<serde_json::Value> = None;
+        let req = self.build_request(
+            &url,
+            Builder::new()
+                .method(Method::POST)
+                .header("Connection", "Upgrade")
+                .header("Upgrade", "h2c")
+                .header("X-Docker-Expose-Session-Uuid", session_id)
+                .header(
+                    "X-Docker-Expose-Session-Grpc-Method",
+                    "/moby.filesync.v1.FileSend/diffcopy",
+                ),
+            opt,
+            Ok(Body::empty()),
+        );
+
+        let (read, write) = self.process_upgraded(req).await?;
+
+        let output = Box::pin(read);
+        let input = Box::pin(write);
+        let transport = super::GrpcTransport {
+            read: output,
+            write: input,
+        };
+
+        tokio::spawn(async {
+            let health = health::health_server::HealthServer::new(super::HealthServerImpl::new());
+            let mut builder = tonic::transport::Server::builder();
+            let mut router = builder.add_service(health);
+            for service in services {
+                router = service.append(router);
+            }
+            debug!("router: {:#?}", router);
+            router
+                .serve_with_incoming(futures_util::stream::iter(vec![Ok::<
+                    _,
+                    tonic::transport::Error,
+                >(
+                    transport
+                )]))
+                .await;
+        });
+
+        Ok(channel)
+    }
+
+    /// TODO
+    #[cfg(feature = "buildkit")]
+    pub async fn image_export_oci(
+        &mut self,
+        session_id: &str,
+        frontend_opts: ImageBuildFrontendOptions,
+        exporter_request: ImageExporterOCIRequest,
+        load_input: ImageExporterLoadInput,
+    ) -> Result<(), Error> {
+        let payload = match load_input {
+            ImageExporterLoadInput::Upload(bytes) => bytes,
+            _ => unimplemented!(
+                "This form of loading docker images into buildkit is currently unimplemented"
+            ),
+        };
+
+        let mut upload_provider = super::UploadProvider::new();
+        let context = upload_provider.add(payload.to_vec());
+
+        let mut frontend_attrs = frontend_opts.to_map();
+        frontend_attrs.insert(String::from("context"), context);
+        let mut exporter_attrs = exporter_request.output.to_map();
+
+        let filesend = moby::filesync::v1::file_send_server::FileSendServer::new(
+            super::FileSendImpl::new(exporter_request.path.as_path()),
+        );
+
+        let upload = moby::upload::v1::upload_server::UploadServer::new(upload_provider);
+
+        let services: Vec<super::GrpcServer> = vec![
+            super::GrpcServer::FileSend(filesend),
+            super::GrpcServer::Upload(upload),
+        ];
+        let channel = self.raw_grpc_handle(session_id, services).await.unwrap();
+
+        let mut control_client = moby::buildkit::v1::control_client::ControlClient::new(channel);
+
+        let id = super::new_id();
+
+        let solve_request = moby::buildkit::v1::SolveRequest {
+            r#ref: String::from(id),
+            cache: None,
+            definition: None,
+            entitlements: vec![],
+            exporter: String::from("oci"),
+            exporter_attrs,
+            frontend: String::from("dockerfile.v0"),
+            frontend_attrs,
+            frontend_inputs: HashMap::new(),
+            session: String::from(session_id),
+        };
+
+        println!("sending solve request: {:#?}", solve_request);
+        let res = control_client.solve(solve_request).await;
+        println!("res: {:#?}", res);
+
+        Ok(())
+    }
+}

--- a/src/grpc/io/into_async_read.rs
+++ b/src/grpc/io/into_async_read.rs
@@ -1,0 +1,98 @@
+use std::{
+    cmp,
+    pin::Pin,
+    task::{Context, Poll},
+};
+
+use futures_core::TryStream;
+use pin_project_lite::pin_project;
+use tokio::io::AsyncRead;
+
+pin_project! {
+    #[derive(Debug)]
+    pub struct IntoAsyncRead<St>
+    where
+        St: TryStream<Error = std::io::Error>,
+        St::Ok: AsRef<[u8]>,
+    {
+        #[pin]
+        stream: St,
+        state: ReadState<St::Ok>,
+    }
+}
+
+#[derive(Debug)]
+enum ReadState<T: AsRef<[u8]>> {
+    Ready { chunk: T, chunk_start: usize },
+    PendingChunk,
+    Eof,
+}
+
+impl<St> IntoAsyncRead<St>
+where
+    St: TryStream<Error = std::io::Error>,
+    St::Ok: AsRef<[u8]>,
+{
+    pub(crate) fn new(stream: St) -> Self {
+        Self {
+            stream,
+            state: ReadState::PendingChunk,
+        }
+    }
+}
+
+impl<St> AsyncRead for IntoAsyncRead<St>
+where
+    St: TryStream<Error = std::io::Error>,
+    St::Ok: AsRef<[u8]>,
+{
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut tokio::io::ReadBuf<'_>,
+    ) -> Poll<std::io::Result<()>> {
+        let mut this = self.project();
+
+        loop {
+            match this.state {
+                ReadState::Ready { chunk, chunk_start } => {
+                    let chunk = chunk.as_ref();
+                    let len = cmp::min(buf.remaining(), chunk.len() - *chunk_start);
+
+                    buf.put_slice(&chunk[*chunk_start..*chunk_start + len]);
+
+                    *chunk_start += len;
+
+                    if chunk.len() == *chunk_start {
+                        *this.state = ReadState::PendingChunk;
+                    }
+
+                    return Poll::Ready(Ok(()));
+                }
+                ReadState::PendingChunk => {
+                    match futures_core::ready!(this.stream.as_mut().try_poll_next(cx)) {
+                        Some(Ok(chunk)) => {
+                            if !chunk.as_ref().is_empty() {
+                                *this.state = ReadState::Ready {
+                                    chunk,
+                                    chunk_start: 0,
+                                };
+                            }
+                        }
+                        Some(Err(err)) => {
+                            *this.state = ReadState::Eof;
+                            return Poll::Ready(Err(err));
+                        }
+                        None => {
+                            *this.state = ReadState::Eof;
+                            return Poll::Ready(Ok(()));
+                        }
+                    }
+                }
+                ReadState::Eof => {
+                    return Poll::Ready(Ok(()));
+                }
+            }
+        }
+    }
+}

--- a/src/grpc/io/into_async_read.rs
+++ b/src/grpc/io/into_async_read.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "buildkit")]
+
 use std::{
     cmp,
     pin::Pin,

--- a/src/grpc/io/mod.rs
+++ b/src/grpc/io/mod.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "buildkit")]
+
 use std::{
     pin::Pin,
     task::{Context, Poll},

--- a/src/grpc/io/mod.rs
+++ b/src/grpc/io/mod.rs
@@ -1,0 +1,1 @@
+pub(crate) mod reader_stream;

--- a/src/grpc/io/mod.rs
+++ b/src/grpc/io/mod.rs
@@ -59,7 +59,7 @@ impl AsyncWrite for GrpcTransport {
 }
 
 #[allow(missing_debug_implementations)]
-/// TODO
+/// An AsyncRead/AsyncWrite type allowing reads along a docker container exec pipe.
 pub struct GrpcFramedTransport {
     read: IntoAsyncRead<FramedRead<Pin<Box<dyn AsyncRead + Send>>, NewlineLogOutputDecoder>>,
     write: Pin<Box<dyn AsyncWrite + Send>>,

--- a/src/grpc/io/mod.rs
+++ b/src/grpc/io/mod.rs
@@ -1,1 +1,113 @@
+use std::{
+    pin::Pin,
+    task::{Context, Poll},
+};
+
+use tokio::io::{AsyncRead, AsyncWrite};
+use tokio_util::codec::FramedRead;
+use tonic::transport::server::Connected;
+
+use crate::read::NewlineLogOutputDecoder;
+
+use self::into_async_read::IntoAsyncRead;
+
+pub(crate) mod into_async_read;
 pub(crate) mod reader_stream;
+
+pub(crate) struct GrpcTransport {
+    pub(crate) read: Pin<Box<dyn AsyncRead + Send>>,
+    pub(crate) write: Pin<Box<dyn AsyncWrite + Send>>,
+}
+
+impl Connected for GrpcTransport {
+    type ConnectInfo = ();
+
+    fn connect_info(&self) -> Self::ConnectInfo {}
+}
+
+impl AsyncRead for GrpcTransport {
+    fn poll_read(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut tokio::io::ReadBuf<'_>,
+    ) -> Poll<std::io::Result<()>> {
+        Pin::new(&mut self.read).poll_read(cx, buf)
+    }
+}
+
+impl AsyncWrite for GrpcTransport {
+    fn poll_write(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<std::io::Result<usize>> {
+        Pin::new(&mut self.write).poll_write(cx, buf)
+    }
+
+    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+        Pin::new(&mut self.write).poll_flush(cx)
+    }
+
+    fn poll_shutdown(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Result<(), std::io::Error>> {
+        Pin::new(&mut self.write).poll_shutdown(cx)
+    }
+}
+
+#[allow(missing_debug_implementations)]
+/// TODO
+pub struct GrpcFramedTransport {
+    read: IntoAsyncRead<FramedRead<Pin<Box<dyn AsyncRead + Send>>, NewlineLogOutputDecoder>>,
+    write: Pin<Box<dyn AsyncWrite + Send>>,
+}
+
+impl GrpcFramedTransport {
+    pub(crate) fn new(
+        read: Pin<Box<dyn AsyncRead + Send>>,
+        write: Pin<Box<dyn AsyncWrite + Send>>,
+        capacity: usize,
+    ) -> Self {
+        let output = FramedRead::with_capacity(read, NewlineLogOutputDecoder::new(true), capacity);
+        let read = IntoAsyncRead::new(output);
+        Self { read, write }
+    }
+}
+
+impl Connected for GrpcFramedTransport {
+    type ConnectInfo = ();
+
+    fn connect_info(&self) -> Self::ConnectInfo {}
+}
+
+impl AsyncRead for GrpcFramedTransport {
+    fn poll_read(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut tokio::io::ReadBuf<'_>,
+    ) -> Poll<std::io::Result<()>> {
+        Pin::new(&mut self.read).poll_read(cx, buf)
+    }
+}
+
+impl AsyncWrite for GrpcFramedTransport {
+    fn poll_write(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<std::io::Result<usize>> {
+        Pin::new(&mut self.write).poll_write(cx, buf)
+    }
+
+    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+        Pin::new(&mut self.write).poll_flush(cx)
+    }
+
+    fn poll_shutdown(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Result<(), std::io::Error>> {
+        Pin::new(&mut self.write).poll_shutdown(cx)
+    }
+}

--- a/src/grpc/io/reader_stream.rs
+++ b/src/grpc/io/reader_stream.rs
@@ -1,0 +1,77 @@
+use bollard_buildkit_proto::moby::buildkit::v1::BytesMessage;
+use bytes::{BufMut, BytesMut};
+use futures_core::ready;
+use futures_core::stream::Stream;
+use pin_project_lite::pin_project;
+use std::mem::MaybeUninit;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+use tokio::io::{AsyncRead, ReadBuf};
+
+const DEFAULT_CAPACITY: usize = 4096;
+
+pin_project! {
+    #[derive(Debug)]
+    pub struct ReaderStream<R> {
+        #[pin]
+        reader: Option<R>,
+        buf: BytesMessage,
+        capacity: usize,
+    }
+}
+
+impl<R: AsyncRead> ReaderStream<R> {
+    pub(crate) fn new(reader: R) -> Self {
+        ReaderStream {
+            reader: Some(reader),
+            buf: BytesMessage { data: vec![] },
+            capacity: DEFAULT_CAPACITY,
+        }
+    }
+
+    pub(crate) fn with_capacity(reader: R, capacity: usize) -> Self {
+        ReaderStream {
+            reader: Some(reader),
+            buf: BytesMessage {
+                data: Vec::with_capacity(capacity),
+            },
+            capacity,
+        }
+    }
+}
+
+impl<R: AsyncRead> Stream for ReaderStream<R> {
+    type Item = BytesMessage;
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        use tokio_util::io::poll_read_buf;
+
+        let this = self.as_mut().project();
+
+        let reader = match this.reader.as_pin_mut() {
+            Some(r) => r,
+            None => return Poll::Ready(None),
+        };
+
+        if this.buf.data.capacity() == 0 {
+            this.buf.data.reserve(*this.capacity);
+        }
+
+        match poll_read_buf(reader, cx, &mut this.buf.data) {
+            Poll::Pending => Poll::Pending,
+            Poll::Ready(Err(err)) => {
+                self.project().reader.set(None);
+                // Reading into poll_read_buf and poll_read suggests this can't happen..
+                error!("Reading from async reader failed: {err}");
+                Poll::Ready(None)
+            }
+            Poll::Ready(Ok(0)) => {
+                self.project().reader.set(None);
+                Poll::Ready(None)
+            }
+            Poll::Ready(Ok(_)) => {
+                let chunk = this.buf.data.split_off(0);
+                Poll::Ready(Some(BytesMessage { data: chunk }))
+            }
+        }
+    }
+}

--- a/src/grpc/io/reader_stream.rs
+++ b/src/grpc/io/reader_stream.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "buildkit")]
+
 use bollard_buildkit_proto::moby::buildkit::v1::BytesMessage;
 use futures_core::stream::Stream;
 use pin_project_lite::pin_project;

--- a/src/grpc/io/reader_stream.rs
+++ b/src/grpc/io/reader_stream.rs
@@ -1,12 +1,9 @@
 use bollard_buildkit_proto::moby::buildkit::v1::BytesMessage;
-use bytes::{BufMut, BytesMut};
-use futures_core::ready;
 use futures_core::stream::Stream;
 use pin_project_lite::pin_project;
-use std::mem::MaybeUninit;
 use std::pin::Pin;
 use std::task::{Context, Poll};
-use tokio::io::{AsyncRead, ReadBuf};
+use tokio::io::AsyncRead;
 
 const DEFAULT_CAPACITY: usize = 4096;
 

--- a/src/grpc/mod.rs
+++ b/src/grpc/mod.rs
@@ -3,7 +3,11 @@
 #![allow(dead_code)]
 
 /// TODO
+pub mod driver;
+/// TODO
 pub mod export;
+/// TODO
+pub(crate) mod io;
 
 use crate::health::health_check_response::ServingStatus;
 use crate::health::health_server::Health;
@@ -52,7 +56,6 @@ impl GrpcServer {
     }
 }
 
-#[allow(missing_debug_implementations)]
 pub(crate) struct GrpcTransport {
     pub(crate) read: Pin<Box<dyn AsyncRead + Send>>,
     pub(crate) write: Pin<Box<dyn AsyncWrite + Send>>,

--- a/src/grpc/mod.rs
+++ b/src/grpc/mod.rs
@@ -2,11 +2,11 @@
 #![cfg(feature = "buildkit")]
 #![allow(dead_code)]
 
-/// TODO
+/// A package of GRPC buildkit connection implementations
 pub mod driver;
-/// TODO
+/// End-user buildkit export functions 
 pub mod export;
-/// TODO
+/// Internal interfaces to convert types for GRPC communication
 pub(crate) mod io;
 
 use crate::health::health_check_response::ServingStatus;
@@ -38,18 +38,14 @@ use tower::Service;
 
 use self::io::GrpcTransport;
 
-// GrpcServer is a helper to allow static dispatch
-/// TODO
+/// A static dispatch wrapper for GRPC implementations to generated GRPC traits
 #[derive(Debug)]
-pub enum GrpcServer {
-    /// TODO
+pub(crate) enum GrpcServer {
     Upload(UploadServer<UploadProvider>),
-    /// TODO
     FileSend(FileSendServer<FileSendImpl>),
 }
 
 impl GrpcServer {
-    /// TODO
     pub fn append(
         self,
         builder: tonic::transport::server::Router,
@@ -60,7 +56,6 @@ impl GrpcServer {
         }
     }
 
-    /// TODO
     pub fn names(&self) -> Vec<String> {
         match self {
             GrpcServer::Upload(_upload_server) => {
@@ -125,13 +120,11 @@ impl Health for HealthServerImpl {
 }
 
 #[derive(Clone, Debug)]
-/// TODO
-pub struct FileSendImpl {
+pub(crate) struct FileSendImpl {
     pub(crate) dest: PathBuf,
 }
 
 impl FileSendImpl {
-    /// TODO
     pub fn new(dest: &Path) -> Self {
         Self {
             dest: dest.to_owned(),
@@ -168,20 +161,17 @@ impl FileSend for FileSendImpl {
 }
 
 #[derive(Debug)]
-/// TODO
-pub struct UploadProvider {
+pub(crate) struct UploadProvider {
     pub(crate) store: HashMap<String, Vec<u8>>,
 }
 
 impl UploadProvider {
-    /// TODO
     pub fn new() -> Self {
         Self {
             store: HashMap::new(),
         }
     }
 
-    /// TODO
     pub fn add(&mut self, reader: Vec<u8>) -> String {
         let id = new_id();
         let key = format!("http://buildkit-session/{}", id);

--- a/src/image.rs
+++ b/src/image.rs
@@ -17,10 +17,6 @@ use crate::models::*;
 
 #[cfg(feature = "buildkit")]
 use super::health;
-#[cfg(feature = "buildkit")]
-use super::moby;
-#[cfg(feature = "buildkit")]
-use crate::grpc;
 
 use std::cmp::Eq;
 use std::collections::HashMap;
@@ -1179,6 +1175,8 @@ impl Docker {
 
     #[cfg(feature = "buildkit")]
     async fn start_session(&self, id: String) -> Result<(), Error> {
+        use crate::grpc::io::GrpcTransport;
+
         let url = "/session";
 
         let opt: Option<serde_json::Value> = None;
@@ -1197,7 +1195,7 @@ impl Docker {
 
         let output = Box::pin(read);
         let input = Box::pin(write);
-        let transport = crate::grpc::GrpcTransport {
+        let transport = GrpcTransport {
             read: output,
             write: input,
         };

--- a/src/image.rs
+++ b/src/image.rs
@@ -442,17 +442,13 @@ where
 /// Builder Version to use
 #[derive(Clone, Copy, Debug, PartialEq, Serialize_repr)]
 #[repr(u8)]
+#[derive(Default)]
 pub enum BuilderVersion {
     /// BuilderV1 is the first generation builder in docker daemon
+    #[default]
     BuilderV1 = 1,
     /// BuilderBuildKit is builder based on moby/buildkit project
     BuilderBuildKit = 2,
-}
-
-impl Default for BuilderVersion {
-    fn default() -> Self {
-        BuilderVersion::BuilderV1
-    }
 }
 
 /// Parameters to the [Import Image API](Docker::import_image())

--- a/src/image.rs
+++ b/src/image.rs
@@ -1174,7 +1174,7 @@ impl Docker {
     }
 
     #[cfg(feature = "buildkit")]
-    async fn start_session(&self, id: String) -> Result<(), Error> {
+    async fn start_session(&self, id: String) -> Result<(), crate::grpc::error::GrpcError> {
         use crate::grpc::io::GrpcTransport;
 
         let url = "/session";

--- a/src/image.rs
+++ b/src/image.rs
@@ -421,7 +421,7 @@ where
 }
 
 #[cfg(feature = "buildkit")]
-/// Buildkit Image Output configuration: https://docs.docker.com/build/exporters/oci-docker/
+/// Buildkit Image Output configuration: <https://docs.docker.com/build/exporters/oci-docker/>
 #[derive(Debug, Clone, Default, PartialEq, Serialize)]
 pub struct ImageBuildOutput<T>
 where

--- a/src/image.rs
+++ b/src/image.rs
@@ -411,6 +411,25 @@ where
     pub platform: T,
     /// Builder version to use
     pub version: BuilderVersion,
+    #[cfg(feature = "buildkit")]
+    /// Buildkit output configuration for exporters
+    #[serde(serialize_with = "crate::docker::serialize_as_json")]
+    pub outputs: Option<Vec<ImageBuildOutput<T>>>,
+}
+
+#[cfg(feature = "buildkit")]
+/// Buildkit Image Output configuration: https://docs.docker.com/build/exporters/oci-docker/
+#[derive(Debug, Clone, Default, PartialEq, Serialize)]
+pub struct ImageBuildOutput<T>
+where
+    T: Into<String> + Eq + Hash + Serialize,
+{
+    /// The base type for a container image: [oci|docker]
+    #[serde(rename = "type")]
+    pub typ: T,
+    /// The set of parameters to export the image
+    #[serde(rename = "attrs")]
+    pub attrs: HashMap<T, T>,
 }
 
 /// Builder Version to use
@@ -1166,10 +1185,15 @@ impl Docker {
                 .method(Method::POST)
                 .header("Connection", "Upgrade")
                 .header("Upgrade", "h2c")
-                .header("X-Docker-Expose-Session-Uuid", &id),
+                .header("X-Docker-Expose-Session-Uuid", &id)
+                .header(
+                    "X-Docker-Expose-Session-Grpc-Method",
+                    "/moby.filesync.v1.FileSend/diffcopy",
+                ),
             opt,
             Ok(Body::empty()),
         );
+
         let (read, write) = self.process_upgraded(req).await?;
 
         let output = Box::pin(read);
@@ -1180,13 +1204,211 @@ impl Docker {
         };
         let service =
             crate::health::health_server::HealthServer::new(crate::grpc::HealthServerImpl::new());
+        let filesend = crate::moby::filesync::v1::file_send_server::FileSendServer::new(
+            crate::grpc::FileSendImpl::new(),
+        );
+
+        /*
+         * *github.com/moby/buildkit/api/services/control.SolveRequest {
+                Ref: "uu0agdhi5rtq203c77emcwq59",
+                Definition: *github.com/moby/buildkit/solver/pb.Definition nil,
+                Exporter: "oci",
+                ExporterAttrs: map[string]string [
+                    "name": "docker.io/library/bollard-oci-export-buildkit-example:latest",
+                    "annotation.exporter": "Bollard",
+                    "dest": "/tmp/alpine-oci-image",
+                ],
+                Session: "bollard-oci-export-buildkit-example",
+                Frontend: "dockerfile.v0",
+                FrontendAttrs: map[string]string [
+                    "context": "http://build-context-u5jjzq0nmmw3mua6leiyw8lxj",
+                    "cache-from": "",
+                    "image-resolve-mode": "pull",
+                    "add-hosts": "",
+                ],
+                Cache: github.com/moby/buildkit/api/services/control.CacheOptions {
+                    ExportRefDeprecated: "",
+                    ImportRefsDeprecated: []string len: 0, cap: 0, nil,
+                    ExportAttrsDeprecated: map[string]string nil,
+                    Exports: []*github.com/moby/buildkit/api/services/control.CacheOptionsEntry len: 0, cap: 0, nil,
+                    Imports: []*github.com/moby/buildkit/api/services/control.CacheOptionsEntry len: 0, cap: 0, nil,
+                    XXX_NoUnkeyedLiteral: struct {} {},
+                    XXX_unrecognized: []uint8 len: 0, cap: 0, nil,
+                    XXX_sizecache: 0,},
+                Entitlements: []github.com/moby/buildkit/util/entitlements.Entitlement len: 0, cap: 0, nil,
+                FrontendInputs: map[string]*github.com/moby/buildkit/solver/pb.Definition nil,
+                Internal: false,
+                SourcePolicy: *github.com/moby/buildkit/sourcepolicy/pb.Policy nil,
+                XXX_NoUnkeyedLiteral: struct {} {},
+                XXX_unrecognized: []uint8 len: 0, cap: 0, nil,
+                XXX_sizecache: 0,}
+         */
 
         Ok(tonic::transport::Server::builder()
             .add_service(service)
+            //.add_service(filesync)
+            .add_service(filesend)
             .serve_with_incoming(stream::iter(vec![Ok::<_, tonic::transport::Error>(
                 transport,
             )]))
             .await?)
+    }
+
+    /// TODO
+    #[cfg(feature = "buildkit")]
+    pub async fn export_oci_image<T>(&mut self, options: BuildImageOptions<T>, tar: Option<Vec<u8>>) -> Result<(), Error> // impl Stream<Item = Result<Bytes, Error>> + '_
+    where
+        T: Into<String> + Eq + Hash + Serialize,
+        //R: std::io::Read + Send + Sync + 'static,
+    {
+
+        use std::sync::Arc;
+        use tonic::transport::{Endpoint, Uri};
+        use tower::service_fn;
+        use futures_util::future::ok;
+
+        let session_id = "bollard-oci-export-buildkit-example";
+
+        //type ClosureFut = Box<dyn std::future::Future<Output=Result<crate::grpc::GrpcTransport, Error>>>;
+        //let dyn_service_fn = Box::new(move |_| { async move { Box::new(self.process_upgraded(req).await.and_then(|(read, write)| {
+        //                let output = Box::pin(read);
+        //                let input = Box::pin(write);
+        //                Ok(crate::grpc::GrpcTransport {
+        //                    read: output,
+        //                    write: input,
+        //                })
+        //            })) } } as ClosureFut);
+        //
+        let grpc_client = crate::grpc::GrpcClient { 
+            client: self.clone(), 
+            session_id: String::from(session_id),
+
+        };
+
+        let channel = Endpoint::try_from("http://[::]:50051")?
+            .connect_with_connector(grpc_client)
+        .await?;
+
+        let mut control_client = crate::moby::buildkit::v1::control_client::ControlClient::new(channel);
+
+        let url = "/session";
+
+        let id = crate::grpc::new_id();
+
+        let opt: Option<serde_json::Value> = None;
+        let req = self.build_request(
+            &url,
+            Builder::new()
+                .method(Method::POST)
+                .header("Connection", "Upgrade")
+                .header("Upgrade", "h2c")
+                .header("X-Docker-Expose-Session-Uuid", session_id)
+                .header(
+                    "X-Docker-Expose-Session-Grpc-Method",
+                    "/moby.filesync.v1.FileSend/diffcopy",
+                ),
+            opt,
+            Ok(Body::empty()),
+        );
+
+        let (read, write) = self.process_upgraded(req).await?;
+
+        let output = Box::pin(read);
+        let input = Box::pin(write);
+        let transport = crate::grpc::GrpcTransport {
+            read: output,
+            write: input,
+        };
+        let service =
+            crate::health::health_server::HealthServer::new(crate::grpc::HealthServerImpl::new());
+        let filesend = crate::moby::filesync::v1::file_send_server::FileSendServer::new(
+            crate::grpc::FileSendImpl::new(),
+        );
+        let mut upload_provider = crate::grpc::UploadProvider::new();
+        let context = upload_provider.add(tar.unwrap());
+        let upload = crate::moby::upload::v1::upload_server::UploadServer::new(
+            upload_provider,
+        );
+
+        let mut attrs = HashMap::new();
+        attrs.insert(String::from("name"), String::from("docker.io/library/bollard-oci-export-buildkit-example:latest"));
+        attrs.insert(String::from("annotation.exporter"), String::from("Bollard"));
+        attrs.insert(String::from("dest"), String::from("/tmp/alpine-oci-image"));
+
+        let mut frontend_attrs = HashMap::new();
+        frontend_attrs.insert(String::from("context"), context);
+        frontend_attrs.insert(String::from("cache-from"), String::new());
+        frontend_attrs.insert(String::from("image-resolve-mode"), String::from("pull"));
+        frontend_attrs.insert(String::from("add-hosts"), String::new());
+
+
+        let solve_request = crate::moby::buildkit::v1::SolveRequest {
+            r#ref: String::from(id),
+            cache: None,
+            definition: None,
+            entitlements: vec![],
+            exporter: String::from("oci"), 
+            exporter_attrs: attrs,
+            frontend: String::from("dockerfile.v0"),
+            frontend_attrs,
+            frontend_inputs: HashMap::new(),
+            session: String::from(session_id),
+
+        };
+        /*
+         * *github.com/moby/buildkit/api/services/control.SolveRequest {
+                Ref: "uu0agdhi5rtq203c77emcwq59",
+                Definition: *github.com/moby/buildkit/solver/pb.Definition nil,
+                Exporter: "oci",
+                ExporterAttrs: map[string]string [
+                    "name": "docker.io/library/bollard-oci-export-buildkit-example:latest",
+                    "annotation.exporter": "Bollard",
+                    "dest": "/tmp/alpine-oci-image",
+                ],
+                Session: "bollard-oci-export-buildkit-example",
+                Frontend: "dockerfile.v0",
+                FrontendAttrs: map[string]string [
+                    "context": "http://build-context-u5jjzq0nmmw3mua6leiyw8lxj",
+                    "cache-from": "",
+                    "image-resolve-mode": "pull",
+                    "add-hosts": "",
+                ],
+                Cache: github.com/moby/buildkit/api/services/control.CacheOptions {
+                    ExportRefDeprecated: "",
+                    ImportRefsDeprecated: []string len: 0, cap: 0, nil,
+                    ExportAttrsDeprecated: map[string]string nil,
+                    Exports: []*github.com/moby/buildkit/api/services/control.CacheOptionsEntry len: 0, cap: 0, nil,
+                    Imports: []*github.com/moby/buildkit/api/services/control.CacheOptionsEntry len: 0, cap: 0, nil,
+                    XXX_NoUnkeyedLiteral: struct {} {},
+                    XXX_unrecognized: []uint8 len: 0, cap: 0, nil,
+                    XXX_sizecache: 0,},
+                Entitlements: []github.com/moby/buildkit/util/entitlements.Entitlement len: 0, cap: 0, nil,
+                FrontendInputs: map[string]*github.com/moby/buildkit/solver/pb.Definition nil,
+                Internal: false,
+                SourcePolicy: *github.com/moby/buildkit/sourcepolicy/pb.Policy nil,
+                XXX_NoUnkeyedLiteral: struct {} {},
+                XXX_unrecognized: []uint8 len: 0, cap: 0, nil,
+                XXX_sizecache: 0,}
+         */
+        //crate::moby::buildkit::v1::control_client::ControlClient::new
+        //
+
+        tokio::spawn(async {
+            tonic::transport::Server::builder()
+                .add_service(service)
+                .add_service(upload)
+                .add_service(filesend)
+                .serve_with_incoming(stream::iter(vec![Ok::<_, tonic::transport::Error>(
+                    transport,
+                )])).await;
+        });
+
+        debug!("sending solve request");
+        let res = control_client.solve(solve_request).await;
+        debug!("res: {:#?}", res);
+
+
+        return Ok(());
     }
 
     /// ---

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -294,6 +294,9 @@ pub use crate::docker::{ClientVersion, Docker, API_DEFAULT_VERSION};
 pub use bollard_stubs::models;
 
 #[cfg(feature = "buildkit")]
+pub use bollard_buildkit_proto::fsutil;
+
+#[cfg(feature = "buildkit")]
 pub use bollard_buildkit_proto::health;
 
 #[cfg(feature = "buildkit")]

--- a/src/system.rs
+++ b/src/system.rs
@@ -223,12 +223,7 @@ impl Docker {
     /// # Ping
     ///
     /// This is a dummy endpoint you can use to test if the server is accessible.
-    ///
-    /// # Returns
-    ///
-    ///  - A [String](std::string::String), wrapped in a Future.
-    ///
-    /// # Examples
+    /// # Returns - A [String](std::string::String), wrapped in a Future. # Examples
     ///
     /// ```rust
     /// # use bollard::Docker;
@@ -257,7 +252,7 @@ impl Docker {
     ///
     /// # Returns
     ///
-    ///  - [System Events Response](SystemEventsResponse),
+    ///  - [EventMessage](crate::models::EventMessage),
     ///  wrapped in a Stream.
     ///
     /// # Examples

--- a/tests/container_test.rs
+++ b/tests/container_test.rs
@@ -523,7 +523,7 @@ async fn prune_containers_test(docker: Docker) -> Result<(), Error> {
                 "stefanscherer/registry-windows",
                 "moby/buildkit:master",
                 // Containers existing on CircleCI after a prune
-                "docker:20.10.16",
+                "docker:24.0.5",
                 "public.ecr.aws/eks-distro/kubernetes/pause:3.6"
             ]
             .into_iter()

--- a/tests/export_test.rs
+++ b/tests/export_test.rs
@@ -81,13 +81,14 @@ async fn export_buildkit_oci_test(mut docker: Docker) -> Result<(), Error> {
         paths.push(path);
     }
 
+    println!("{:#?}", &paths);
+
     assert!(paths.contains(&String::from("blobs/")));
     assert!(paths.contains(&String::from("blobs/sha256/")));
-    assert!(paths.contains(&String::from(
-        "blobs/sha256/199d118cabd11758f8769dfc159fafea701b93b09449e3502943f3e1de4586ad"
-    )));
     assert!(paths.contains(&String::from("index.json")));
     assert!(paths.contains(&String::from("oci-layout")));
+
+    assert_eq!(paths.len(), 8);
 
     Ok(())
 }

--- a/tests/export_test.rs
+++ b/tests/export_test.rs
@@ -1,0 +1,99 @@
+#![cfg(feature = "buildkit")]
+
+use bollard::errors::Error;
+use bollard::models::BuildInfoAux;
+use bollard::Docker;
+
+use futures_util::stream::StreamExt;
+use tokio::runtime::Runtime;
+
+use std::io::Write;
+
+#[macro_use]
+pub mod common;
+use crate::common::*;
+
+async fn export_buildkit_oci_test(mut docker: Docker) -> Result<(), Error> {
+    env_logger::init();
+
+    let dockerfile = String::from(
+        "FROM alpine as builder1
+        RUN touch bollard.txt
+        FROM alpine as builder2
+        RUN --mount=type=bind,from=builder1,target=mnt cp mnt/bollard.txt buildkit-bollard.txt
+        ENTRYPOINT ls buildkit-bollard.txt
+        ",
+    );
+
+    let mut header = tar::Header::new_gnu();
+    header.set_path("Dockerfile").unwrap();
+    header.set_size(dockerfile.len() as u64);
+    header.set_mode(0o755);
+    header.set_cksum();
+    let mut tar = tar::Builder::new(Vec::new());
+    tar.append(&header, dockerfile.as_bytes()).unwrap();
+
+    let uncompressed = tar.into_inner().unwrap();
+    let mut c = flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::default());
+    c.write_all(&uncompressed).unwrap();
+    let compressed = c.finish().unwrap();
+
+    let session_id = "bollard-oci-export-buildkit-example";
+
+    let frontend_opts = bollard::grpc::export::ImageBuildFrontendOptions::builder()
+        .pull(true)
+        .build();
+
+    let dest_path = std::path::Path::new("/tmp/oci-image.tar");
+
+    // cleanup - usually for local testing, the grpc handler will overwrite
+    if dest_path.exists() {
+        std::fs::remove_file(&dest_path);
+    }
+    assert!(!dest_path.exists());
+
+    let output = bollard::grpc::export::ImageExporterOCIOutputBuilder::new(
+        "docker.io/library/bollard-oci-export-buildkit-example:latest",
+    )
+    .annotation("exporter", "Bollard")
+    .dest(&dest_path);
+
+    let load_input =
+        bollard::grpc::export::ImageExporterLoadInput::Upload(bytes::Bytes::from(compressed));
+
+    let res = docker
+        .image_export_oci(session_id, frontend_opts, output, load_input)
+        .await;
+
+    assert!(res.is_ok());
+
+    assert!(dest_path.exists());
+
+    let oci_file = std::fs::File::open(&dest_path)?;
+    let mut oci_archive = tar::Archive::new(oci_file);
+
+    let mut paths = vec![];
+
+    let mut iter = oci_archive.entries()?;
+    while let Some(entry) = iter.next() {
+        let entry = entry?;
+        let path = entry.path()?.display().to_string();
+        paths.push(path);
+    }
+
+    assert!(paths.contains(&String::from("blobs/")));
+    assert!(paths.contains(&String::from("blobs/sha256/")));
+    assert!(paths.contains(&String::from(
+        "blobs/sha256/199d118cabd11758f8769dfc159fafea701b93b09449e3502943f3e1de4586ad"
+    )));
+    assert!(paths.contains(&String::from("index.json")));
+    assert!(paths.contains(&String::from("oci-layout")));
+
+    Ok(())
+}
+
+#[test]
+#[cfg(feature = "buildkit")]
+fn integration_test_export_buildkit_oci() {
+    connect_to_docker_and_run!(export_buildkit_oci_test);
+}


### PR DESCRIPTION
This is some initial work to expose the new functionality provided by buildkit, such as exporting OCI images as tar files. https://docs.docker.com/build/exporters/oci-docker/

Closes #331 
Closes #332 
Closes #333 
Closes #330 
