### PR TITLE
upgrade webpki

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,8 +69,8 @@ time = { version = "0.3", features = ["formatting", "parsing"], optional = true 
 tokio-util = { version = "0.7", features = ["codec"] }
 tower-service = { version = "0.3", optional = true }
 url = "2.2"
-webpki-roots = { version = "0.23", optional = true }
-webpki = { version = "0.22", optional = true }
+webpki-roots = { version = "0.25.2", optional = true }
+webpki = { package = "rustls-webpki", version = "0.101.4", optional = true }
 
 [dev-dependencies]
 flate2 = "1.0"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.65.0-buster
+FROM rust:1.67.0-buster
 
 WORKDIR /usr/src/bollard
 

--- a/examples/build.rs
+++ b/examples/build.rs
@@ -49,6 +49,6 @@ async fn main() {
     let mut image_build_stream = docker.build_image(build_image_options, None, None);
 
     while let Some(msg) = image_build_stream.next().await {
-        println!("Message: {:?}", msg);
+        println!("Message: {msg:?}");
     }
 }

--- a/examples/exec.rs
+++ b/examples/exec.rs
@@ -53,7 +53,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + 'static>> {
         .id;
     if let StartExecResults::Attached { mut output, .. } = docker.start_exec(&exec, None).await? {
         while let Some(Ok(msg)) = output.next().await {
-            print!("{}", msg);
+            print!("{msg}");
         }
     } else {
         unreachable!();

--- a/examples/hoover.rs
+++ b/examples/hoover.rs
@@ -46,7 +46,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + 'static>> {
         }))
         .await?;
 
-    println!("{:?}", prune);
+    println!("{prune:?}");
 
     let prune = docker
         .prune_images(Some(PruneImagesOptions {
@@ -54,13 +54,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error + 'static>> {
         }))
         .await?;
 
-    println!("{:?}", prune);
+    println!("{prune:?}");
 
     let prune = docker
         .prune_volumes(None::<PruneVolumesOptions<String>>)
         .await?;
 
-    println!("{:?}", prune);
+    println!("{prune:?}");
 
     let prune = docker
         .prune_networks(Some(PruneNetworksOptions {
@@ -68,7 +68,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + 'static>> {
         }))
         .await?;
 
-    println!("{:?}", prune);
+    println!("{prune:?}");
 
     Ok(())
 }

--- a/examples/kafka.rs
+++ b/examples/kafka.rs
@@ -162,7 +162,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + 'static>> {
     let mut stream = select(&mut stream1, &mut stream2);
 
     while let Some(msg) = stream.next().await {
-        println!("Message: {:?}", msg);
+        println!("Message: {msg:?}");
     }
 
     Ok(())

--- a/examples/post_dockerfile.rs
+++ b/examples/post_dockerfile.rs
@@ -31,6 +31,6 @@ async fn main() {
     let mut image_build_stream = docker.build_image(image_options, None, Some(body));
 
     while let Some(msg) = image_build_stream.next().await {
-        println!("Message: {:?}", msg);
+        println!("Message: {msg:?}");
     }
 }

--- a/examples/top.rs
+++ b/examples/top.rs
@@ -47,12 +47,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error + 'static>> {
     ))) = futures.next().await
     {
         if let Some(p) = p.get(0) {
-            print!("{}", name);
+            print!("{name}");
             for mut v in p.iter().cloned() {
                 if v.len() > 30 {
                     v.truncate(30);
                 }
-                print!("\t{}", v);
+                print!("\t{v}");
             }
             println!();
         }

--- a/src/container.rs
+++ b/src/container.rs
@@ -1281,7 +1281,7 @@ impl Docker {
     where
         T: Into<String> + Serialize,
     {
-        let url = format!("/containers/{}/start", container_name);
+        let url = format!("/containers/{container_name}/start");
 
         let req = self.build_request(
             &url,
@@ -1326,7 +1326,7 @@ impl Docker {
         container_name: &str,
         options: Option<StopContainerOptions>,
     ) -> Result<(), Error> {
-        let url = format!("/containers/{}/stop", container_name);
+        let url = format!("/containers/{container_name}/stop");
 
         let req = self.build_request(
             &url,
@@ -1375,7 +1375,7 @@ impl Docker {
         container_name: &str,
         options: Option<RemoveContainerOptions>,
     ) -> Result<(), Error> {
-        let url = format!("/containers/{}", container_name);
+        let url = format!("/containers/{container_name}");
 
         let req = self.build_request(
             &url,
@@ -1426,7 +1426,7 @@ impl Docker {
     where
         T: Into<String> + Serialize,
     {
-        let url = format!("/containers/{}/wait", container_name);
+        let url = format!("/containers/{container_name}/wait");
 
         let req = self.build_request(
             &url,
@@ -1497,7 +1497,7 @@ impl Docker {
     where
         T: Into<String> + Serialize + Default,
     {
-        let url = format!("/containers/{}/attach", container_name);
+        let url = format!("/containers/{container_name}/attach");
 
         let req = self.build_request(
             &url,
@@ -1549,7 +1549,7 @@ impl Docker {
         container_name: &str,
         options: ResizeContainerTtyOptions,
     ) -> Result<(), Error> {
-        let url = format!("/containers/{}/resize", container_name);
+        let url = format!("/containers/{container_name}/resize");
 
         let req = self.build_request(
             &url,
@@ -1595,7 +1595,7 @@ impl Docker {
         container_name: &str,
         options: Option<RestartContainerOptions>,
     ) -> Result<(), Error> {
-        let url = format!("/containers/{}/restart", container_name);
+        let url = format!("/containers/{container_name}/restart");
 
         let req = self.build_request(
             &url,
@@ -1640,7 +1640,7 @@ impl Docker {
         container_name: &str,
         options: Option<InspectContainerOptions>,
     ) -> Result<ContainerInspectResponse, Error> {
-        let url = format!("/containers/{}/json", container_name);
+        let url = format!("/containers/{container_name}/json");
 
         let req = self.build_request(
             &url,
@@ -1688,7 +1688,7 @@ impl Docker {
     where
         T: Into<String> + Serialize,
     {
-        let url = format!("/containers/{}/top", container_name);
+        let url = format!("/containers/{container_name}/top");
 
         let req = self.build_request(
             &url,
@@ -1741,7 +1741,7 @@ impl Docker {
     where
         T: Into<String> + Serialize,
     {
-        let url = format!("/containers/{}/logs", container_name);
+        let url = format!("/containers/{container_name}/logs");
 
         let req = self.build_request(
             &url,
@@ -1780,7 +1780,7 @@ impl Docker {
         &self,
         container_name: &str,
     ) -> Result<Option<Vec<FilesystemChange>>, Error> {
-        let url = format!("/containers/{}/changes", container_name);
+        let url = format!("/containers/{container_name}/changes");
 
         let req = self.build_request(
             &url,
@@ -1828,7 +1828,7 @@ impl Docker {
         container_name: &str,
         options: Option<StatsOptions>,
     ) -> impl Stream<Item = Result<Stats, Error>> {
-        let url = format!("/containers/{}/stats", container_name);
+        let url = format!("/containers/{container_name}/stats");
 
         let req = self.build_request(
             &url,
@@ -1877,7 +1877,7 @@ impl Docker {
     where
         T: Into<String> + Serialize,
     {
-        let url = format!("/containers/{}/kill", container_name);
+        let url = format!("/containers/{container_name}/kill");
 
         let req = self.build_request(
             &url,
@@ -1929,7 +1929,7 @@ impl Docker {
     where
         T: Into<String> + Eq + Hash + Serialize,
     {
-        let url = format!("/containers/{}/update", container_name);
+        let url = format!("/containers/{container_name}/update");
 
         let req = self.build_request(
             &url,
@@ -1978,7 +1978,7 @@ impl Docker {
     where
         T: Into<String> + Serialize,
     {
-        let url = format!("/containers/{}/rename", container_name);
+        let url = format!("/containers/{container_name}/rename");
 
         let req = self.build_request(
             &url,
@@ -2013,7 +2013,7 @@ impl Docker {
     /// docker.pause_container("postgres");
     /// ```
     pub async fn pause_container(&self, container_name: &str) -> Result<(), Error> {
-        let url = format!("/containers/{}/pause", container_name);
+        let url = format!("/containers/{container_name}/pause");
 
         let req = self.build_request(
             &url,
@@ -2048,7 +2048,7 @@ impl Docker {
     /// docker.unpause_container("postgres");
     /// ```
     pub async fn unpause_container(&self, container_name: &str) -> Result<(), Error> {
-        let url = format!("/containers/{}/unpause", container_name);
+        let url = format!("/containers/{container_name}/unpause");
 
         let req = self.build_request(
             &url,
@@ -2156,7 +2156,7 @@ impl Docker {
     where
         T: Into<String> + Serialize,
     {
-        let url = format!("/containers/{}/archive", container_name);
+        let url = format!("/containers/{container_name}/archive");
 
         let req = self.build_request(
             &url,
@@ -2206,7 +2206,7 @@ impl Docker {
     where
         T: Into<String> + Serialize,
     {
-        let url = format!("/containers/{}/archive", container_name);
+        let url = format!("/containers/{container_name}/archive");
 
         let req = self.build_request(
             &url,

--- a/src/docker.rs
+++ b/src/docker.rs
@@ -457,7 +457,7 @@ impl Docker {
                 .map_err(|err| NoNativeCertsError { err })?;
         }
 
-        root_store.add_server_trust_anchors(webpki_roots::TLS_SERVER_ROOTS.0.iter().map(|ta| {
+        root_store.add_server_trust_anchors(webpki_roots::TLS_SERVER_ROOTS.iter().map(|ta| {
             rustls::OwnedTrustAnchor::from_subject_spki_name_constraints(
                 ta.subject,
                 ta.spki,

--- a/src/docker.rs
+++ b/src/docker.rs
@@ -186,7 +186,7 @@ where
     S: serde::Serializer,
 {
     s.serialize_str(
-        &serde_json::to_string(t).map_err(|e| serde::ser::Error::custom(format!("{}", e)))?,
+        &serde_json::to_string(t).map_err(|e| serde::ser::Error::custom(format!("{e}")))?,
     )
 }
 

--- a/src/exec.rs
+++ b/src/exec.rs
@@ -141,7 +141,7 @@ impl Docker {
     where
         T: Into<String> + Serialize,
     {
-        let url = format!("/containers/{}/exec", container_name);
+        let url = format!("/containers/{container_name}/exec");
 
         let req = self.build_request(
             &url,
@@ -194,7 +194,7 @@ impl Docker {
         exec_id: &str,
         config: Option<StartExecOptions>,
     ) -> Result<StartExecResults, Error> {
-        let url = format!("/exec/{}/start", exec_id);
+        let url = format!("/exec/{exec_id}/start");
 
         match config {
             Some(StartExecOptions { detach: true, .. }) => {
@@ -278,7 +278,7 @@ impl Docker {
     /// };
     /// ```
     pub async fn inspect_exec(&self, exec_id: &str) -> Result<ExecInspectResponse, Error> {
-        let url = format!("/exec/{}/json", exec_id);
+        let url = format!("/exec/{exec_id}/json");
 
         let req = self.build_request(
             &url,
@@ -329,7 +329,7 @@ impl Docker {
         exec_id: &str,
         options: ResizeExecOptions,
     ) -> Result<(), Error> {
-        let url = format!("/exec/{}/resize", exec_id);
+        let url = format!("/exec/{exec_id}/resize");
 
         let req = self.build_request(
             &url,

--- a/src/image.rs
+++ b/src/image.rs
@@ -611,7 +611,7 @@ impl Docker {
     /// docker.inspect_image("hello-world");
     /// ```
     pub async fn inspect_image(&self, image_name: &str) -> Result<ImageInspect, Error> {
-        let url = format!("/images/{}/json", image_name);
+        let url = format!("/images/{image_name}/json");
 
         let req = self.build_request(
             &url,
@@ -698,7 +698,7 @@ impl Docker {
     /// docker.image_history("hello-world");
     /// ```
     pub async fn image_history(&self, image_name: &str) -> Result<Vec<HistoryResponseItem>, Error> {
-        let url = format!("/images/{}/history", image_name);
+        let url = format!("/images/{image_name}/history");
 
         let req = self.build_request(
             &url,
@@ -803,7 +803,7 @@ impl Docker {
         options: Option<RemoveImageOptions>,
         credentials: Option<DockerCredentials>,
     ) -> Result<Vec<ImageDeleteResponseItem>, Error> {
-        let url = format!("/images/{}", image_name);
+        let url = format!("/images/{image_name}");
 
         match serde_json::to_string(&credentials.unwrap_or_else(|| DockerCredentials {
             ..Default::default()
@@ -862,7 +862,7 @@ impl Docker {
     where
         T: Into<String> + Serialize,
     {
-        let url = format!("/images/{}/tag", image_name);
+        let url = format!("/images/{image_name}/tag");
 
         let req = self.build_request(
             &url,
@@ -922,7 +922,7 @@ impl Docker {
     where
         T: Into<String> + Serialize,
     {
-        let url = format!("/images/{}/push", image_name);
+        let url = format!("/images/{image_name}/push");
 
         match serde_json::to_string(&credentials.unwrap_or_else(|| DockerCredentials {
             ..Default::default()
@@ -1210,7 +1210,7 @@ impl Docker {
     /// # Returns
     ///  - An uncompressed TAR archive
     pub fn export_image(&self, image_name: &str) -> impl Stream<Item = Result<Bytes, Error>> {
-        let url = format!("/images/{}/get", image_name);
+        let url = format!("/images/{image_name}/get");
         let req = self.build_request(
             &url,
             Builder::new()

--- a/src/network.rs
+++ b/src/network.rs
@@ -259,7 +259,7 @@ impl Docker {
     /// docker.remove_network("my_network_name");
     /// ```
     pub async fn remove_network(&self, network_name: &str) -> Result<(), Error> {
-        let url = format!("/networks/{}", network_name);
+        let url = format!("/networks/{network_name}");
 
         let req = self.build_request(
             &url,
@@ -309,7 +309,7 @@ impl Docker {
     where
         T: Into<String> + Serialize,
     {
-        let url = format!("/networks/{}", network_name);
+        let url = format!("/networks/{network_name}");
 
         let req = self.build_request(
             &url,
@@ -417,7 +417,7 @@ impl Docker {
     where
         T: Into<String> + Eq + Hash + Serialize,
     {
-        let url = format!("/networks/{}/connect", network_name);
+        let url = format!("/networks/{network_name}/connect");
 
         let req = self.build_request(
             &url,
@@ -466,7 +466,7 @@ impl Docker {
     where
         T: Into<String> + Serialize,
     {
-        let url = format!("/networks/{}/disconnect", network_name);
+        let url = format!("/networks/{network_name}/disconnect");
 
         let req = self.build_request(
             &url,

--- a/src/secret.rs
+++ b/src/secret.rs
@@ -188,7 +188,7 @@ impl Docker {
     /// docker.inspect_secret("secret-name");
     /// ```
     pub async fn inspect_secret(&self, secret_id: &str) -> Result<Secret, Error> {
-        let url = format!("/secrets/{}", secret_id);
+        let url = format!("/secrets/{secret_id}");
 
         let req = self.build_request(
             &url,
@@ -224,7 +224,7 @@ impl Docker {
     /// docker.delete_secret("secret-name");
     /// ```
     pub async fn delete_secret(&self, secret_id: &str) -> Result<(), Error> {
-        let url = format!("/secrets/{}", secret_id);
+        let url = format!("/secrets/{secret_id}");
 
         let req = self.build_request(
             &url,
@@ -281,7 +281,7 @@ impl Docker {
         secret_spec: SecretSpec,
         options: UpdateSecretOptions,
     ) -> Result<(), Error> {
-        let url = format!("/secrets/{}/update", secret_id);
+        let url = format!("/secrets/{secret_id}/update");
 
         let req = self.build_request(
             &url,

--- a/src/service.rs
+++ b/src/service.rs
@@ -281,7 +281,7 @@ impl Docker {
         service_name: &str,
         options: Option<InspectServiceOptions>,
     ) -> Result<Service, Error> {
-        let url = format!("/services/{}", service_name);
+        let url = format!("/services/{service_name}");
 
         let req = self.build_request(
             &url,
@@ -316,7 +316,7 @@ impl Docker {
     /// docker.delete_service("my-service");
     /// ```
     pub async fn delete_service(&self, service_name: &str) -> Result<(), Error> {
-        let url = format!("/services/{}", service_name);
+        let url = format!("/services/{service_name}");
 
         let req = self.build_request(
             &url,
@@ -395,7 +395,7 @@ impl Docker {
         options: UpdateServiceOptions,
         credentials: Option<DockerCredentials>,
     ) -> Result<ServiceUpdateResponse, Error> {
-        let url = format!("/services/{}/update", service_name);
+        let url = format!("/services/{service_name}/update");
 
         match serde_json::to_string(&credentials.unwrap_or_else(|| DockerCredentials {
             ..Default::default()

--- a/src/volume.rs
+++ b/src/volume.rs
@@ -214,7 +214,7 @@ impl Docker {
     /// docker.inspect_volume("my_volume_name");
     /// ```
     pub async fn inspect_volume(&self, volume_name: &str) -> Result<Volume, Error> {
-        let url = format!("/volumes/{}", volume_name);
+        let url = format!("/volumes/{volume_name}");
 
         let req = self.build_request(
             &url,
@@ -261,7 +261,7 @@ impl Docker {
         volume_name: &str,
         options: Option<RemoveVolumeOptions>,
     ) -> Result<(), Error> {
-        let url = format!("/volumes/{}", volume_name);
+        let url = format!("/volumes/{volume_name}");
 
         let req = self.build_request(
             &url,

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -61,7 +61,7 @@ where
 {
     rt.block_on(future)
         .map_err(|e| {
-            println!("{:?}", e);
+            println!("{e:?}");
             e
         })
         .unwrap();

--- a/tests/container_test.rs
+++ b/tests/container_test.rs
@@ -208,7 +208,7 @@ async fn logs_test(docker: Docker) -> Result<(), Error> {
 
     let value = vec.get(1).unwrap();
 
-    assert_eq!(format!("{}", value), "Hello from Docker!\n".to_string());
+    assert_eq!(format!("{value}"), "Hello from Docker!\n".to_string());
 
     let _ = &docker
         .remove_container("integration_test_logs", None::<RemoveContainerOptions>)
@@ -299,7 +299,7 @@ async fn attach_container_test(docker: Docker) -> Result<(), Error> {
         .await?;
 
     input
-        .write_all(format!("echo {}\n", unique_string).as_bytes())
+        .write_all(format!("echo {unique_string}\n").as_bytes())
         .await?;
     input.write_all("exit\n".as_bytes()).await?;
 
@@ -622,7 +622,7 @@ async fn archive_container_test(docker: Docker) -> Result<(), Error> {
         .map(|file| file.unwrap())
         .filter(|file| {
             let path = file.header().path().unwrap();
-            println!("{:?}", path);
+            println!("{path:?}");
             if path
                 == std::path::Path::new(if cfg!(windows) {
                     "Logs/readme.txt"

--- a/tests/system_test.rs
+++ b/tests/system_test.rs
@@ -62,7 +62,7 @@ async fn events_test(docker: Docker) -> Result<(), Error> {
     assert!(vec
         .iter()
         .map(|value| {
-            println!("{:?}", value);
+            println!("{value:?}");
             value
         })
         .any(|value| matches!(value, Results::EventsResults(EventMessage { typ: _, .. }))));


### PR DESCRIPTION
These upgrades are needed to fix:
- https://rustsec.org/advisories/RUSTSEC-2023-0052.html
- https://rustsec.org/advisories/RUSTSEC-2023-0053.html

Note that `webpki` is unmaintained, and `rustls-webpki` is the new maintained fork.