### PR TITLE
Add 'status' field to ListServicesOptions for enhanced service status retrieval

### DIFF
--- a/src/service.rs
+++ b/src/service.rs
@@ -50,9 +50,7 @@ where
     #[serde(serialize_with = "crate::docker::serialize_as_json")]
     pub filters: HashMap<T, Vec<T>>,
 
-		/// Include service status, with count of running and desired tasks.
-    #[serde(serialize_with = "crate::docker::serialize_as_json")]
-    #[serde(default)]
+    /// Include service status, with count of running and desired tasks.
     pub status: bool,
 }
 

--- a/src/service.rs
+++ b/src/service.rs
@@ -49,6 +49,11 @@ where
     ///  - `name`=`<name>` a services's name
     #[serde(serialize_with = "crate::docker::serialize_as_json")]
     pub filters: HashMap<T, Vec<T>>,
+
+		/// Include service status, with count of running and desired tasks.
+    #[serde(serialize_with = "crate::docker::serialize_as_json")]
+    #[serde(default)]
+    pub status: bool,
 }
 
 /// Parameters used in the [Inspect Service API](Docker::inspect_service())

--- a/src/service.rs
+++ b/src/service.rs
@@ -28,6 +28,7 @@ use std::{collections::HashMap, hash::Hash};
 ///
 /// ListServicesOptions{
 ///     filters,
+///     ..Default::default()
 /// };
 /// ```
 ///


### PR DESCRIPTION
Hi, I have added a `status` field to the ListServicesOptions, which can trigger the return of `ServiceStatus`.

For example, for my Replicated Service, I can get:
```json
"ServiceStatus": {
      "RunningTasks": 3,
      "DesiredTasks": 3,
      "CompletedTasks": 0
}
```