### PR TITLE
fix: missing tty options in StartExecOptions

### DIFF
--- a/src/exec.rs
+++ b/src/exec.rs
@@ -64,6 +64,8 @@ pub struct CreateExecResults {
 pub struct StartExecOptions {
     /// Detach from the command.
     pub detach: bool,
+    /// Allocate a pseudo-TTY.
+    pub tty: bool,
     /// The maximum size for a line of output. The default is 8 * 1024 (roughly 1024 characters).
     pub output_capacity: Option<usize>,
 }


### PR DESCRIPTION
Source: https://docs.docker.com/engine/api/v1.43/#tag/Exec/operation/ExecStart
