### PR TITLE
Add auth provider for private buildkit builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,6 +29,14 @@ jobs:
       - checkout
       - setup_remote_docker
       - run: docker build -t bollard .
+      - run: resources/dockerfiles/bin/run_integration_tests.sh --tests
+  test_buildkit:
+    docker:
+      - image: docker:24.0.5
+    steps:
+      - checkout
+      - setup_remote_docker
+      - run: docker build -t bollard .
       - run: resources/dockerfiles/bin/run_integration_tests.sh --features buildkit --tests
   test_chrono:
     docker:
@@ -86,6 +94,7 @@ workflows:
       - test_ssl
       - test_http
       - test_unix
+      - test_buildkit
       - test_chrono
       - test_time
       - test_doc

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ members = [
 
 [features]
 # Enable Buildkit-enabled docker image building
-buildkit = ["num", "rand", "tokio/fs", "tokio-stream", "tokio-util/io", "tower", "tonic", "tower-service", "bollard-stubs/buildkit", "bollard-buildkit-proto"]
+buildkit = ["chrono", "num", "rand", "tokio/fs", "tokio-stream", "tokio-util/io", "tower", "tonic", "tower-service", "ssl", "bollard-stubs/buildkit", "bollard-buildkit-proto"]
 # Enable tests specifically for the http connector
 test_http = []
 # Enable tests specifically for rustls

--- a/codegen/proto/src/bin/gen.rs
+++ b/codegen/proto/src/bin/gen.rs
@@ -10,6 +10,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 "resources/fsutil/types/wire.proto",
                 "resources/moby/buildkit/v1/control.proto",
                 "resources/moby/buildkit/v1/types/worker.proto",
+                "resources/moby/filesync/v1/auth.proto",
                 "resources/moby/filesync/v1/filesync.proto",
                 "resources/moby/upload/v1/upload.proto",
                 "resources/grpc/health/v1/health.proto",

--- a/codegen/proto/src/generated/moby.filesync.v1.rs
+++ b/codegen/proto/src/generated/moby.filesync.v1.rs
@@ -1,3 +1,598 @@
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct CredentialsRequest {
+    #[prost(string, tag = "1")]
+    pub host: ::prost::alloc::string::String,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct CredentialsResponse {
+    #[prost(string, tag = "1")]
+    pub username: ::prost::alloc::string::String,
+    #[prost(string, tag = "2")]
+    pub secret: ::prost::alloc::string::String,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct FetchTokenRequest {
+    #[prost(string, tag = "1")]
+    pub client_id: ::prost::alloc::string::String,
+    #[prost(string, tag = "2")]
+    pub host: ::prost::alloc::string::String,
+    #[prost(string, tag = "3")]
+    pub realm: ::prost::alloc::string::String,
+    #[prost(string, tag = "4")]
+    pub service: ::prost::alloc::string::String,
+    #[prost(string, repeated, tag = "5")]
+    pub scopes: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct FetchTokenResponse {
+    #[prost(string, tag = "1")]
+    pub token: ::prost::alloc::string::String,
+    /// seconds
+    #[prost(int64, tag = "2")]
+    pub expires_in: i64,
+    /// timestamp
+    #[prost(int64, tag = "3")]
+    pub issued_at: i64,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct GetTokenAuthorityRequest {
+    #[prost(string, tag = "1")]
+    pub host: ::prost::alloc::string::String,
+    #[prost(bytes = "vec", tag = "2")]
+    pub salt: ::prost::alloc::vec::Vec<u8>,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct GetTokenAuthorityResponse {
+    #[prost(bytes = "vec", tag = "1")]
+    pub public_key: ::prost::alloc::vec::Vec<u8>,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct VerifyTokenAuthorityRequest {
+    #[prost(string, tag = "1")]
+    pub host: ::prost::alloc::string::String,
+    #[prost(bytes = "vec", tag = "2")]
+    pub payload: ::prost::alloc::vec::Vec<u8>,
+    #[prost(bytes = "vec", tag = "3")]
+    pub salt: ::prost::alloc::vec::Vec<u8>,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct VerifyTokenAuthorityResponse {
+    #[prost(bytes = "vec", tag = "1")]
+    pub signed: ::prost::alloc::vec::Vec<u8>,
+}
+/// Generated client implementations.
+pub mod auth_client {
+    #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
+    use tonic::codegen::*;
+    use tonic::codegen::http::Uri;
+    #[derive(Debug, Clone)]
+    pub struct AuthClient<T> {
+        inner: tonic::client::Grpc<T>,
+    }
+    impl AuthClient<tonic::transport::Channel> {
+        /// Attempt to create a new client by connecting to a given endpoint.
+        pub async fn connect<D>(dst: D) -> Result<Self, tonic::transport::Error>
+        where
+            D: TryInto<tonic::transport::Endpoint>,
+            D::Error: Into<StdError>,
+        {
+            let conn = tonic::transport::Endpoint::new(dst)?.connect().await?;
+            Ok(Self::new(conn))
+        }
+    }
+    impl<T> AuthClient<T>
+    where
+        T: tonic::client::GrpcService<tonic::body::BoxBody>,
+        T::Error: Into<StdError>,
+        T::ResponseBody: Body<Data = Bytes> + Send + 'static,
+        <T::ResponseBody as Body>::Error: Into<StdError> + Send,
+    {
+        pub fn new(inner: T) -> Self {
+            let inner = tonic::client::Grpc::new(inner);
+            Self { inner }
+        }
+        pub fn with_origin(inner: T, origin: Uri) -> Self {
+            let inner = tonic::client::Grpc::with_origin(inner, origin);
+            Self { inner }
+        }
+        pub fn with_interceptor<F>(
+            inner: T,
+            interceptor: F,
+        ) -> AuthClient<InterceptedService<T, F>>
+        where
+            F: tonic::service::Interceptor,
+            T::ResponseBody: Default,
+            T: tonic::codegen::Service<
+                http::Request<tonic::body::BoxBody>,
+                Response = http::Response<
+                    <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
+                >,
+            >,
+            <T as tonic::codegen::Service<
+                http::Request<tonic::body::BoxBody>,
+            >>::Error: Into<StdError> + Send + Sync,
+        {
+            AuthClient::new(InterceptedService::new(inner, interceptor))
+        }
+        /// Compress requests with the given encoding.
+        ///
+        /// This requires the server to support it otherwise it might respond with an
+        /// error.
+        #[must_use]
+        pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.send_compressed(encoding);
+            self
+        }
+        /// Enable decompressing responses.
+        #[must_use]
+        pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.accept_compressed(encoding);
+            self
+        }
+        /// Limits the maximum size of a decoded message.
+        ///
+        /// Default: `4MB`
+        #[must_use]
+        pub fn max_decoding_message_size(mut self, limit: usize) -> Self {
+            self.inner = self.inner.max_decoding_message_size(limit);
+            self
+        }
+        /// Limits the maximum size of an encoded message.
+        ///
+        /// Default: `usize::MAX`
+        #[must_use]
+        pub fn max_encoding_message_size(mut self, limit: usize) -> Self {
+            self.inner = self.inner.max_encoding_message_size(limit);
+            self
+        }
+        pub async fn credentials(
+            &mut self,
+            request: impl tonic::IntoRequest<super::CredentialsRequest>,
+        ) -> std::result::Result<
+            tonic::Response<super::CredentialsResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/moby.filesync.v1.Auth/Credentials",
+            );
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("moby.filesync.v1.Auth", "Credentials"));
+            self.inner.unary(req, path, codec).await
+        }
+        pub async fn fetch_token(
+            &mut self,
+            request: impl tonic::IntoRequest<super::FetchTokenRequest>,
+        ) -> std::result::Result<
+            tonic::Response<super::FetchTokenResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/moby.filesync.v1.Auth/FetchToken",
+            );
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("moby.filesync.v1.Auth", "FetchToken"));
+            self.inner.unary(req, path, codec).await
+        }
+        pub async fn get_token_authority(
+            &mut self,
+            request: impl tonic::IntoRequest<super::GetTokenAuthorityRequest>,
+        ) -> std::result::Result<
+            tonic::Response<super::GetTokenAuthorityResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/moby.filesync.v1.Auth/GetTokenAuthority",
+            );
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("moby.filesync.v1.Auth", "GetTokenAuthority"));
+            self.inner.unary(req, path, codec).await
+        }
+        pub async fn verify_token_authority(
+            &mut self,
+            request: impl tonic::IntoRequest<super::VerifyTokenAuthorityRequest>,
+        ) -> std::result::Result<
+            tonic::Response<super::VerifyTokenAuthorityResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/moby.filesync.v1.Auth/VerifyTokenAuthority",
+            );
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new("moby.filesync.v1.Auth", "VerifyTokenAuthority"),
+                );
+            self.inner.unary(req, path, codec).await
+        }
+    }
+}
+/// Generated server implementations.
+pub mod auth_server {
+    #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
+    use tonic::codegen::*;
+    /// Generated trait containing gRPC methods that should be implemented for use with AuthServer.
+    #[async_trait]
+    pub trait Auth: Send + Sync + 'static {
+        async fn credentials(
+            &self,
+            request: tonic::Request<super::CredentialsRequest>,
+        ) -> std::result::Result<
+            tonic::Response<super::CredentialsResponse>,
+            tonic::Status,
+        >;
+        async fn fetch_token(
+            &self,
+            request: tonic::Request<super::FetchTokenRequest>,
+        ) -> std::result::Result<
+            tonic::Response<super::FetchTokenResponse>,
+            tonic::Status,
+        >;
+        async fn get_token_authority(
+            &self,
+            request: tonic::Request<super::GetTokenAuthorityRequest>,
+        ) -> std::result::Result<
+            tonic::Response<super::GetTokenAuthorityResponse>,
+            tonic::Status,
+        >;
+        async fn verify_token_authority(
+            &self,
+            request: tonic::Request<super::VerifyTokenAuthorityRequest>,
+        ) -> std::result::Result<
+            tonic::Response<super::VerifyTokenAuthorityResponse>,
+            tonic::Status,
+        >;
+    }
+    #[derive(Debug)]
+    pub struct AuthServer<T: Auth> {
+        inner: _Inner<T>,
+        accept_compression_encodings: EnabledCompressionEncodings,
+        send_compression_encodings: EnabledCompressionEncodings,
+        max_decoding_message_size: Option<usize>,
+        max_encoding_message_size: Option<usize>,
+    }
+    struct _Inner<T>(Arc<T>);
+    impl<T: Auth> AuthServer<T> {
+        pub fn new(inner: T) -> Self {
+            Self::from_arc(Arc::new(inner))
+        }
+        pub fn from_arc(inner: Arc<T>) -> Self {
+            let inner = _Inner(inner);
+            Self {
+                inner,
+                accept_compression_encodings: Default::default(),
+                send_compression_encodings: Default::default(),
+                max_decoding_message_size: None,
+                max_encoding_message_size: None,
+            }
+        }
+        pub fn with_interceptor<F>(
+            inner: T,
+            interceptor: F,
+        ) -> InterceptedService<Self, F>
+        where
+            F: tonic::service::Interceptor,
+        {
+            InterceptedService::new(Self::new(inner), interceptor)
+        }
+        /// Enable decompressing requests with the given encoding.
+        #[must_use]
+        pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.accept_compression_encodings.enable(encoding);
+            self
+        }
+        /// Compress responses with the given encoding, if the client supports it.
+        #[must_use]
+        pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.send_compression_encodings.enable(encoding);
+            self
+        }
+        /// Limits the maximum size of a decoded message.
+        ///
+        /// Default: `4MB`
+        #[must_use]
+        pub fn max_decoding_message_size(mut self, limit: usize) -> Self {
+            self.max_decoding_message_size = Some(limit);
+            self
+        }
+        /// Limits the maximum size of an encoded message.
+        ///
+        /// Default: `usize::MAX`
+        #[must_use]
+        pub fn max_encoding_message_size(mut self, limit: usize) -> Self {
+            self.max_encoding_message_size = Some(limit);
+            self
+        }
+    }
+    impl<T, B> tonic::codegen::Service<http::Request<B>> for AuthServer<T>
+    where
+        T: Auth,
+        B: Body + Send + 'static,
+        B::Error: Into<StdError> + Send + 'static,
+    {
+        type Response = http::Response<tonic::body::BoxBody>;
+        type Error = std::convert::Infallible;
+        type Future = BoxFuture<Self::Response, Self::Error>;
+        fn poll_ready(
+            &mut self,
+            _cx: &mut Context<'_>,
+        ) -> Poll<std::result::Result<(), Self::Error>> {
+            Poll::Ready(Ok(()))
+        }
+        fn call(&mut self, req: http::Request<B>) -> Self::Future {
+            let inner = self.inner.clone();
+            match req.uri().path() {
+                "/moby.filesync.v1.Auth/Credentials" => {
+                    #[allow(non_camel_case_types)]
+                    struct CredentialsSvc<T: Auth>(pub Arc<T>);
+                    impl<T: Auth> tonic::server::UnaryService<super::CredentialsRequest>
+                    for CredentialsSvc<T> {
+                        type Response = super::CredentialsResponse;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::CredentialsRequest>,
+                        ) -> Self::Future {
+                            let inner = Arc::clone(&self.0);
+                            let fut = async move {
+                                <T as Auth>::credentials(&inner, request).await
+                            };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let inner = inner.0;
+                        let method = CredentialsSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/moby.filesync.v1.Auth/FetchToken" => {
+                    #[allow(non_camel_case_types)]
+                    struct FetchTokenSvc<T: Auth>(pub Arc<T>);
+                    impl<T: Auth> tonic::server::UnaryService<super::FetchTokenRequest>
+                    for FetchTokenSvc<T> {
+                        type Response = super::FetchTokenResponse;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::FetchTokenRequest>,
+                        ) -> Self::Future {
+                            let inner = Arc::clone(&self.0);
+                            let fut = async move {
+                                <T as Auth>::fetch_token(&inner, request).await
+                            };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let inner = inner.0;
+                        let method = FetchTokenSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/moby.filesync.v1.Auth/GetTokenAuthority" => {
+                    #[allow(non_camel_case_types)]
+                    struct GetTokenAuthoritySvc<T: Auth>(pub Arc<T>);
+                    impl<
+                        T: Auth,
+                    > tonic::server::UnaryService<super::GetTokenAuthorityRequest>
+                    for GetTokenAuthoritySvc<T> {
+                        type Response = super::GetTokenAuthorityResponse;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::GetTokenAuthorityRequest>,
+                        ) -> Self::Future {
+                            let inner = Arc::clone(&self.0);
+                            let fut = async move {
+                                <T as Auth>::get_token_authority(&inner, request).await
+                            };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let inner = inner.0;
+                        let method = GetTokenAuthoritySvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/moby.filesync.v1.Auth/VerifyTokenAuthority" => {
+                    #[allow(non_camel_case_types)]
+                    struct VerifyTokenAuthoritySvc<T: Auth>(pub Arc<T>);
+                    impl<
+                        T: Auth,
+                    > tonic::server::UnaryService<super::VerifyTokenAuthorityRequest>
+                    for VerifyTokenAuthoritySvc<T> {
+                        type Response = super::VerifyTokenAuthorityResponse;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::VerifyTokenAuthorityRequest>,
+                        ) -> Self::Future {
+                            let inner = Arc::clone(&self.0);
+                            let fut = async move {
+                                <T as Auth>::verify_token_authority(&inner, request).await
+                            };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let inner = inner.0;
+                        let method = VerifyTokenAuthoritySvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                _ => {
+                    Box::pin(async move {
+                        Ok(
+                            http::Response::builder()
+                                .status(200)
+                                .header("grpc-status", "12")
+                                .header("content-type", "application/grpc")
+                                .body(empty_body())
+                                .unwrap(),
+                        )
+                    })
+                }
+            }
+        }
+    }
+    impl<T: Auth> Clone for AuthServer<T> {
+        fn clone(&self) -> Self {
+            let inner = self.inner.clone();
+            Self {
+                inner,
+                accept_compression_encodings: self.accept_compression_encodings,
+                send_compression_encodings: self.send_compression_encodings,
+                max_decoding_message_size: self.max_decoding_message_size,
+                max_encoding_message_size: self.max_encoding_message_size,
+            }
+        }
+    }
+    impl<T: Auth> Clone for _Inner<T> {
+        fn clone(&self) -> Self {
+            Self(Arc::clone(&self.0))
+        }
+    }
+    impl<T: std::fmt::Debug> std::fmt::Debug for _Inner<T> {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "{:?}", self.0)
+        }
+    }
+    impl<T: Auth> tonic::server::NamedService for AuthServer<T> {
+        const NAME: &'static str = "moby.filesync.v1.Auth";
+    }
+}
 /// BytesMessage contains a chunk of byte data
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -83,6 +83,9 @@ pub enum Error {
     /// Error emitted when a session is not provided to the buildkit engine
     #[error("Buildkit requires a unique session")]
     MissingSessionBuildkitError {},
+    /// Error emitted when a session is not provided to the buildkit engine
+    #[error("Buildkit requires a builder version set")]
+    MissingVersionBuildkitError {},
     /// Error emitted when JSON fails to serialize.
     #[error(transparent)]
     JsonSerdeError {

--- a/src/grpc/error.rs
+++ b/src/grpc/error.rs
@@ -39,3 +39,71 @@ pub enum GrpcError {
         err: tonic::metadata::errors::InvalidMetadataValue,
     },
 }
+
+/// Errors related to the Grpc functionality
+#[derive(Debug, thiserror::Error)]
+pub enum GrpcAuthError {
+    /// Error triggered when the registry responds with a status code less than 200 or more than or
+    /// equal to 400
+    #[error("Registry responded with a non-OK status code: {status_code}")]
+    BadRegistryResponse {
+        /// The status code responded by the registry
+        status_code: u16,
+    },
+    /// I/O error during request/response with the registry
+    #[error("I/O failure during GRPC authentication with registry")]
+    IOError {
+        /// The i/o error
+        #[from]
+        err: std::io::Error,
+    },
+    /// Error emitted from the rustls library during communication with the registry
+    #[error("TLS error during GRPC authentication with registry")]
+    RustTlsError {
+        /// The source error from Rustls
+        #[from]
+        err: rustls::Error,
+    },
+    /// Failure to encode query parameters when creating the URL to authenticate with the registry
+    #[error("Failure encoding query parameters for GRPC authentication with registry")]
+    SerdeUrlEncodedError {
+        /// The serde urlencoded error
+        #[from]
+        err: serde_urlencoded::ser::Error,
+    },
+    /// Failure to parse the URL when building the URL to authenticate with the registry
+    #[error("Failure parsing the registry url for GRPC authentication")]
+    UrlParseError {
+        /// The original parse error
+        #[from]
+        err: url::ParseError,
+    },
+    /// Error while building http headers when calling the registry
+    #[error("Invalid HTTP request failure during GRPC authentication with registry")]
+    HTTPError {
+        /// The original http error
+        #[from]
+        err: http::Error,
+    },
+    /// Error emitted by the hyper library during authentication with the registry
+    #[error("Hyper error during GRPC authentication with registry")]
+    HyperError {
+        /// The source hyper error
+        #[from]
+        err: hyper::Error,
+    },
+    /// Error while deserializing the payload emitted by the registry
+    #[error("Serde payload deserializing error during GRPC authentication")]
+    SerdeJsonError {
+        /// The source serde json error
+        #[from]
+        err: serde_json::Error,
+    },
+    /// Error emitted when the URI is deemed invalid by the http protocol
+    #[error("Invalid URI during GRPC authentication with registry")]
+    InvalidUriError {
+        /// The invalid uri error
+        #[from]
+        err: http::uri::InvalidUri,
+    },
+}

--- a/src/grpc/mod.rs
+++ b/src/grpc/mod.rs
@@ -11,11 +11,17 @@ pub mod export;
 /// Internal interfaces to convert types for GRPC communication
 pub(crate) mod io;
 
+use crate::auth::DockerCredentials;
 use crate::health::health_check_response::ServingStatus;
 use crate::health::health_server::Health;
 use crate::health::{HealthCheckRequest, HealthCheckResponse};
+use crate::moby::filesync::v1::auth_server::Auth;
 use crate::moby::filesync::v1::file_send_server::FileSend;
-use crate::moby::filesync::v1::BytesMessage as FileSyncBytesMessage;
+use crate::moby::filesync::v1::{
+    BytesMessage as FileSyncBytesMessage, CredentialsRequest, CredentialsResponse,
+    FetchTokenRequest, FetchTokenResponse, GetTokenAuthorityRequest, GetTokenAuthorityResponse,
+    VerifyTokenAuthorityRequest, VerifyTokenAuthorityResponse,
+};
 use crate::moby::upload::v1::upload_server::{Upload, UploadServer};
 use crate::moby::upload::v1::BytesMessage as UploadBytesMessage;
 
@@ -24,8 +30,10 @@ use std::path::{Path, PathBuf};
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
+use bollard_buildkit_proto::moby::filesync::v1::auth_server::AuthServer;
 use bollard_buildkit_proto::moby::filesync::v1::file_send_server::FileSendServer;
 use futures_core::Stream;
+use hyper::client::HttpConnector;
 use rand::RngCore;
 use tonic::transport::NamedService;
 use tonic::{Code, Request, Response, Status, Streaming};
@@ -34,15 +42,17 @@ use futures_util::{StreamExt, TryFutureExt};
 use tokio::io::AsyncWriteExt;
 
 use http::request::Builder;
-use hyper::{Body, Method};
+use hyper::{Body, Client, Method};
 use std::future::Future;
 use tower::Service;
 
+use self::error::GrpcAuthError;
 use self::io::GrpcTransport;
 
 /// A static dispatch wrapper for GRPC implementations to generated GRPC traits
 #[derive(Debug)]
 pub(crate) enum GrpcServer {
+    Auth(AuthServer<AuthProvider>),
     Upload(UploadServer<UploadProvider>),
     FileSend(FileSendServer<FileSendImpl>),
 }
@@ -53,6 +63,7 @@ impl GrpcServer {
         builder: tonic::transport::server::Router,
     ) -> tonic::transport::server::Router {
         match self {
+            GrpcServer::Auth(auth_server) => builder.add_service(auth_server),
             GrpcServer::Upload(upload_server) => builder.add_service(upload_server),
             GrpcServer::FileSend(file_send_server) => builder.add_service(file_send_server),
         }
@@ -60,6 +71,12 @@ impl GrpcServer {
 
     pub fn names(&self) -> Vec<String> {
         match self {
+            GrpcServer::Auth(_auth_server) => {
+                vec![
+                    format!("/{}/credentials", AuthServer::<AuthProvider>::NAME),
+                    format!("/{}/fetch_token", AuthServer::<AuthProvider>::NAME),
+                ]
+            }
             GrpcServer::Upload(_upload_server) => {
                 vec![format!("/{}/pull", UploadServer::<UploadProvider>::NAME)]
             }
@@ -209,6 +226,249 @@ impl Upload for UploadProvider {
                 "invalid 'urlpath' in uploadprovider request",
             ))
         }
+    }
+}
+
+#[derive(Debug, Default)]
+pub(crate) struct AuthProvider {
+    auth_config_cache: HashMap<String, DockerCredentials>,
+    registry_token: Option<String>,
+}
+
+const DEFAULT_TOKEN_EXPIRATION: i64 = 60;
+const DOCKER_HUB_REGISTRY_HOST: &str = "https://index.docker.io/v1/";
+const DOCKER_HUB_CONFIG_FILE_KEY: &str = "registry-1.docker.io";
+
+enum TokenExpiry {
+    DEFAULT,
+    EXPIRES(i64),
+}
+
+struct TokenOptions {
+    realm: String,
+    service: String,
+    scopes: Vec<String>,
+    username: String,
+    secret: String,
+    fetch_refresh_token: bool,
+}
+
+#[derive(Debug, Deserialize)]
+struct OAuthTokenResponse {
+    access_token: String,
+    refresh_token: String,
+    expires_in: i64,
+    issued_at: chrono::DateTime<chrono::Utc>,
+    scope: String,
+}
+
+impl AuthProvider {
+    pub fn new() -> Self {
+        Self {
+            ..Default::default()
+        }
+    }
+
+    pub(crate) fn set_docker_credentials(
+        &mut self,
+        host: &str,
+        docker_credentials: DockerCredentials,
+    ) {
+        self.auth_config_cache
+            .insert(String::from(host), docker_credentials);
+    }
+
+    fn get_auth_config(&self, mut host: &str) -> Result<DockerCredentials, Status> {
+        if host == DOCKER_HUB_REGISTRY_HOST {
+            host = DOCKER_HUB_CONFIG_FILE_KEY;
+        }
+
+        if let Some(creds) = self.auth_config_cache.get(host) {
+            Ok(DockerCredentials::to_owned(creds))
+        } else {
+            Err(Status::permission_denied(format!(
+                "Could not find credentials for {host}"
+            )))
+        }
+    }
+
+    fn to_token_response(
+        &self,
+        token: &str,
+        issued_at: chrono::DateTime<chrono::Utc>,
+        expires: TokenExpiry,
+    ) -> FetchTokenResponse {
+        let expires = match expires {
+            TokenExpiry::DEFAULT => DEFAULT_TOKEN_EXPIRATION,
+            TokenExpiry::EXPIRES(expiry) => expiry,
+        };
+
+        FetchTokenResponse {
+            token: String::from(token),
+            expires_in: expires,
+            issued_at: issued_at.timestamp(),
+        }
+    }
+
+    fn get_credentials(&self, host: &str) -> Result<CredentialsResponse, Status> {
+        let ac = self.get_auth_config(host)?;
+
+        match ac {
+            DockerCredentials {
+                identitytoken: Some(identitytoken),
+                ..
+            } => Ok(CredentialsResponse {
+                username: String::new(),
+                secret: identitytoken,
+            }),
+            DockerCredentials {
+                username: Some(username),
+                password: Some(password),
+                ..
+            } => Ok(CredentialsResponse {
+                username,
+                secret: password,
+            }),
+            DockerCredentials { .. } => Err(Status::unknown("Invalid DockerCredentials provided")),
+        }
+    }
+
+    fn ssl_client() -> Result<Client<hyper_rustls::HttpsConnector<HttpConnector>>, GrpcAuthError> {
+        let mut root_store = rustls::RootCertStore::empty();
+        for cert in rustls_native_certs::load_native_certs()? {
+            root_store.add(&rustls::Certificate(cert.0))?;
+        }
+
+        let config = rustls::ClientConfig::builder()
+            .with_safe_defaults()
+            .with_root_certificates(root_store)
+            .with_no_client_auth();
+
+        let mut http_connector = HttpConnector::new();
+        http_connector.enforce_http(false);
+
+        let https_connector: hyper_rustls::HttpsConnector<HttpConnector> =
+            hyper_rustls::HttpsConnector::from((http_connector, config));
+
+        let client_builder = Client::builder();
+        let client = client_builder.build(https_connector);
+
+        Ok(client)
+    }
+
+    async fn fetch_token_with_oauth(
+        &self,
+        opts: &TokenOptions,
+    ) -> Result<OAuthTokenResponse, GrpcAuthError> {
+        let mut form = vec![];
+        form.push(("client_id", "bollard-client"));
+        let scopes = opts.scopes.join(" ");
+        if !opts.scopes.is_empty() {
+            form.push(("scope", &scopes));
+        }
+        form.push(("service", &opts.service));
+        if opts.username.is_empty() {
+            form.push(("grant_type", "refresh_token"));
+            form.push(("refresh_token", &opts.secret));
+        } else {
+            form.push(("grant_type", "password"));
+            form.push(("username", &opts.username));
+            form.push(("password", &opts.secret));
+        }
+        if opts.fetch_refresh_token {
+            form.push(("access_type", "offline"));
+        }
+
+        let params = serde_urlencoded::to_string(form)?;
+
+        let client = Self::ssl_client()?;
+
+        let full_uri = format!("{}?{}", opts.realm, &params);
+        let request_uri: hyper::Uri = full_uri.try_into()?;
+        let request = hyper::Request::post(request_uri).body(Body::empty())?;
+
+        let response = client.request(request).await?;
+
+        let status = response.status().as_u16();
+        if status < 200 || status >= 400 {
+            // return custom error
+            return Err(GrpcAuthError::BadRegistryResponse {
+                status_code: status,
+            });
+        }
+
+        let bytes = hyper::body::to_bytes(response.into_body()).await?;
+
+        let oauth_token = serde_json::from_slice::<OAuthTokenResponse>(&bytes)?;
+
+        Ok(oauth_token)
+    }
+}
+
+#[tonic::async_trait]
+impl Auth for AuthProvider {
+    async fn credentials(
+        &self,
+        request: Request<CredentialsRequest>,
+    ) -> Result<Response<CredentialsResponse>, Status> {
+        let host = request.get_ref().host.as_ref();
+
+        Ok(Response::new(self.get_credentials(host)?))
+    }
+
+    async fn fetch_token(
+        &self,
+        request: Request<FetchTokenRequest>,
+    ) -> Result<Response<FetchTokenResponse>, Status> {
+        let FetchTokenRequest {
+            client_id: _,
+            host,
+            realm,
+            service,
+            scopes,
+        } = request.get_ref();
+
+        let creds = self.get_credentials(host)?;
+
+        // check for statically configured bearer token
+        if let Some(token) = self.registry_token.as_ref() {
+            Ok(Response::new(self.to_token_response(
+                token,
+                chrono::Utc::now(),
+                TokenExpiry::DEFAULT,
+            )))
+        } else {
+            let to = TokenOptions {
+                realm: String::clone(realm),
+                service: String::clone(service),
+                scopes: Vec::clone(scopes),
+                username: creds.username,
+                secret: creds.secret,
+                fetch_refresh_token: false,
+            };
+
+            match self.fetch_token_with_oauth(&to).await {
+                Ok(res) => Ok(Response::new(self.to_token_response(
+                    &res.access_token,
+                    res.issued_at,
+                    TokenExpiry::EXPIRES(res.expires_in),
+                ))),
+                Err(e) => Err(Status::from_error(Box::new(e))),
+            }
+        }
+    }
+
+    async fn get_token_authority(
+        &self,
+        _request: Request<GetTokenAuthorityRequest>,
+    ) -> Result<Response<GetTokenAuthorityResponse>, Status> {
+        unimplemented!()
+    }
+    async fn verify_token_authority(
+        &self,
+        _request: Request<VerifyTokenAuthorityRequest>,
+    ) -> Result<Response<VerifyTokenAuthorityResponse>, Status> {
+        unimplemented!()
     }
 }
 


### PR DESCRIPTION
This PR should add the capability to build against private registries with the buildkit build option. 