### PR TITLE
Reduce serde_with version

### DIFF
--- a/codegen/swagger/Cargo.toml
+++ b/codegen/swagger/Cargo.toml
@@ -18,5 +18,5 @@ serde = { version = "1.0", features = ["derive"] }
 prost = { version = "0.12", optional = true }
 time = { version = "0.3", features = ["formatting", "parsing"], optional = true }
 
-serde_with = {version = "3.0", default-features = false, features = ["std"]}
+serde_with = {version = "2.0", default-features = false, features = ["std"]}
 serde_repr = "0.1"


### PR DESCRIPTION
## Summary
Currently Bollard relies on serde_with for a couple of uses in the swagger crate. It specifies serde_with 3+ but 2+ actually works just fine, at least if `cargo build` is anything to go by. Reducing the minimum version would enable people to use Bollard who can't upgrade to a later version of serde_with / its transitive deps, e.g. serde itself.

## Test Plan
I've tried running `cargo test --all-features --workspace` from the root of the repo on main and I see that not all the tests pass, so I'm not quite sure how to fully test that this works as intended.