### PR TITLE
Add  buildkit build with remote cache backends

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,10 +42,10 @@ bollard-stubs = { path = "codegen/swagger", version = "=1.44.0-rc.1", default-fe
 bollard-buildkit-proto = { path = "codegen/proto", version = "=0.2.1", optional = true }
 bytes = "1"
 chrono = { version = "0.4", default-features = false, features = ["std", "clock", "serde"], optional = true }
-home = { version = "0.5", optional = true }
 futures-core = "0.3"
 futures-util = "0.3"
 hex = "0.4.2"
+home = { version = "0.5", optional = true }
 http = "1.0"
 hyper = { version = "1", features = ["client", "http1"] }
 hyper-rustls = { version = "0.26", optional = true }

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.70.0-buster
+FROM rust:1.75.0-buster
 
 WORKDIR /usr/src/bollard
 

--- a/examples/build_buildkit_with_cache.rs
+++ b/examples/build_buildkit_with_cache.rs
@@ -1,0 +1,99 @@
+//! Builds a container with a bunch of extra options for testing
+#![allow(unused_variables, unused_mut, unused_imports)]
+
+#[cfg(feature = "buildkit")]
+use bollard::grpc::registry::ImageRegistryOutput;
+use bollard::Docker;
+
+#[cfg(feature = "buildkit")]
+use bollard_buildkit_proto::moby::buildkit::v1::CacheOptionsEntry;
+
+use std::io::Write;
+
+#[tokio::main]
+async fn main() {
+    #[cfg(feature = "buildkit")]
+    {
+        let mut docker = Docker::connect_with_socket_defaults().unwrap();
+
+        let dockerfile = String::from(
+            "FROM localhost:5000/alpine as builder1
+    RUN touch bollard.txt
+    FROM localhost:5000/alpine as builder2
+    RUN --mount=type=bind,from=builder1,target=mnt cp mnt/bollard.txt buildkit-bollard.txt
+    ENTRYPOINT ls buildkit-bollard.txt
+    ",
+        );
+
+        let mut header = tar::Header::new_gnu();
+        header.set_path("Dockerfile").unwrap();
+        header.set_size(dockerfile.len() as u64);
+        header.set_mode(0o755);
+        header.set_cksum();
+        let mut tar = tar::Builder::new(Vec::new());
+        tar.append(&header, dockerfile.as_bytes()).unwrap();
+
+        let uncompressed = tar.into_inner().unwrap();
+        let mut c = flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::default());
+        c.write_all(&uncompressed).unwrap();
+        let compressed = c.finish().unwrap();
+
+        let name = "bollard-buildkit-with-cache-example";
+
+        let registry_addr = if let Ok(addr) = std::env::var("REGISTRY_HTTP_ADDR") {
+            addr
+        } else {
+            panic!("Please set the REGISTRY_HTTP_ADDR environment variable");
+        };
+
+        let mut cache_attrs = std::collections::HashMap::new();
+        cache_attrs.insert(String::from("mode"), String::from("max"));
+        cache_attrs.insert(
+            String::from("ref"),
+            format!("{}/buildkit_with_cache:build-cache", registry_addr),
+        );
+        let cache_from = CacheOptionsEntry {
+            r#type: String::from("registry"),
+            attrs: std::collections::HashMap::clone(&cache_attrs),
+        };
+        let cache_to = CacheOptionsEntry {
+            r#type: String::from("registry"),
+            attrs: cache_attrs,
+        };
+        let frontend_opts = bollard::grpc::build::ImageBuildFrontendOptions::builder()
+            .cachefrom(&cache_from)
+            .cacheto(&cache_to)
+            .pull(true)
+            .build();
+
+        let output =
+            ImageRegistryOutput::builder(&format!("{}/{}:latest", registry_addr, name)).consume();
+
+        // let mut driver = bollard::grpc::driver::moby::Moby::new(&docker);
+        let mut buildkit_builder =
+            bollard::grpc::driver::docker_container::DockerContainerBuilder::new(&docker);
+        buildkit_builder.env("JAEGER_TRACE=localhost:6831");
+        let driver = buildkit_builder.bootstrap().await.unwrap();
+
+        let load_input =
+            bollard::grpc::build::ImageBuildLoadInput::Upload(bytes::Bytes::from(compressed));
+
+        let credentials = bollard::auth::DockerCredentials {
+            username: Some("bollard".to_string()),
+            password: std::env::var("REGISTRY_PASSWORD").ok(),
+            ..Default::default()
+        };
+        let mut creds_hsh = std::collections::HashMap::new();
+        creds_hsh.insert("localhost:5000", credentials);
+
+        bollard::grpc::driver::Image::registry(
+            driver,
+            output,
+            frontend_opts,
+            load_input,
+            Some(creds_hsh),
+        )
+        .await
+        .unwrap();
+    }
+}

--- a/examples/export_oci_image.rs
+++ b/examples/export_oci_image.rs
@@ -12,9 +12,9 @@ async fn main() {
         let mut docker = Docker::connect_with_socket_defaults().unwrap();
 
         let dockerfile = String::from(
-            "FROM alpine as builder1
+            "FROM localhost:5000/alpine as builder1
             RUN touch bollard.txt
-            FROM alpine as builder2
+            FROM localhost:5000/alpine as builder2
             RUN --mount=type=bind,from=builder1,target=mnt cp mnt/bollard.txt buildkit-bollard.txt
             ENTRYPOINT ls buildkit-bollard.txt
             ",
@@ -35,26 +35,39 @@ async fn main() {
 
         let session_id = "bollard-oci-export-buildkit-example";
 
-        let frontend_opts = bollard::grpc::export::ImageBuildFrontendOptions::builder()
+        let frontend_opts = bollard::grpc::build::ImageBuildFrontendOptions::builder()
             .pull(true)
             .build();
 
-        let output = bollard::grpc::export::ImageExporterOCIOutputBuilder::new(
+        let output = bollard::grpc::export::ImageExporterOutput::builder(
             "docker.io/library/bollard-oci-export-buildkit-example:latest",
         )
         .annotation("exporter", "Bollard")
         .dest(std::path::Path::new("/tmp/oci-image.tar"));
 
-        let buildkit_builder =
-            DockerContainerBuilder::new("bollard_buildkit_export_oci_image", &docker, session_id);
+        let mut buildkit_builder = DockerContainerBuilder::new(&docker);
+        buildkit_builder.env("JAEGER_TRACE=localhost:6831");
         let driver = buildkit_builder.bootstrap().await.unwrap();
 
         let load_input =
-            bollard::grpc::export::ImageExporterLoadInput::Upload(bytes::Bytes::from(compressed));
+            bollard::grpc::build::ImageBuildLoadInput::Upload(bytes::Bytes::from(compressed));
 
-        docker
-            .image_export_oci(driver, session_id, frontend_opts, output, load_input, None)
-            .await
-            .unwrap();
+        let credentials = bollard::auth::DockerCredentials {
+            username: Some("bollard".to_string()),
+            password: std::env::var("REGISTRY_PASSWORD").ok(),
+            ..Default::default()
+        };
+        let mut creds_hsh = std::collections::HashMap::new();
+        creds_hsh.insert("localhost:5000", credentials);
+
+        bollard::grpc::driver::Export::export(
+            driver,
+            bollard::grpc::driver::ImageExporterEnum::OCI(output),
+            frontend_opts,
+            load_input,
+            Some(creds_hsh),
+        )
+        .await
+        .unwrap();
     }
 }

--- a/examples/top.rs
+++ b/examples/top.rs
@@ -46,7 +46,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + 'static>> {
         },
     ))) = futures.next().await
     {
-        if let Some(p) = p.get(0) {
+        if let Some(p) = p.first() {
             print!("{name}");
             for mut v in p.iter().cloned() {
                 if v.len() > 30 {

--- a/src/grpc/build.rs
+++ b/src/grpc/build.rs
@@ -1,0 +1,455 @@
+pub use bollard_buildkit_proto::fsutil;
+pub use bollard_buildkit_proto::health;
+pub use bollard_buildkit_proto::moby;
+use bollard_buildkit_proto::moby::buildkit::v1::CacheOptionsEntry;
+
+use std::collections::HashMap;
+use std::net::IpAddr;
+use std::path::Path;
+
+use bytes::Bytes;
+
+/// Parameters available for passing frontend options to buildkit when initiating a Solve GRPC
+/// request, f.e. used in associated methods within the [GRPC module](module@crate::grpc)
+///
+/// ## Examples
+///
+/// ```rust
+/// use bollard::grpc::build::ImageBuildFrontendOptions;
+///
+/// ImageBuildFrontendOptions::builder().pull(true).build();
+///
+/// ```
+///
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct ImageBuildFrontendOptions {
+    //pub(crate) cgroupparent: Option<String>,
+    //pub(crate) multiplatform: bool,
+    //pub(crate) attests: HashMap<String, String>,
+    pub(crate) cacheto: Vec<CacheOptionsEntry>,
+    pub(crate) cachefrom: Vec<CacheOptionsEntry>,
+    pub(crate) image_resolve_mode: bool,
+    pub(crate) target: Option<String>,
+    pub(crate) nocache: bool,
+    pub(crate) buildargs: HashMap<String, String>,
+    pub(crate) labels: HashMap<String, String>,
+    pub(crate) platforms: Vec<ImageBuildPlatform>,
+    pub(crate) force_network_mode: ImageBuildNetworkMode,
+    pub(crate) extrahosts: Vec<ImageBuildHostIp>,
+    pub(crate) shmsize: u64,
+    //pub(crate) ulimit: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+/// A list of hostnames/IP mappings to add to the container's `/etc/hosts` file.
+pub struct ImageBuildHostIp {
+    /// The hosname mapping component of a hostname/IP mapping
+    pub host: String,
+    /// The IP mapping component of a hostname/IP mapping
+    pub ip: IpAddr,
+}
+
+impl ToString for ImageBuildHostIp {
+    fn to_string(&self) -> String {
+        format!("{}={}", self.host, self.ip)
+    }
+}
+
+#[derive(Default, Debug, Clone, PartialEq)]
+#[non_exhaustive]
+/// Network mode to use for this container. Supported standard values are: `bridge`, `host`,
+/// `none`, and `container:<name|id>`. Any other value is taken as a custom network's name to which
+/// this container should connect to.
+pub enum ImageBuildNetworkMode {
+    /// Bridge mode networking
+    #[default]
+    Bridge,
+    /// Host mode networking
+    Host,
+    /// No networking mode
+    None,
+    /// Container mode networking, with container name as `name`
+    Container(String),
+}
+
+impl ToString for ImageBuildNetworkMode {
+    fn to_string(&self) -> String {
+        match self {
+            ImageBuildNetworkMode::Bridge => String::from("default"),
+            ImageBuildNetworkMode::Host => String::from("host"),
+            ImageBuildNetworkMode::None => String::from("none"),
+            ImageBuildNetworkMode::Container(name) => format!("container:{name}"),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default, PartialEq)]
+/// Describes the platform which the image in the manifest runs on, as defined in the [OCI Image Index Specification](https://github.com/opencontainers/image-spec/blob/v1.0.1/image-index.md).
+pub struct ImageBuildPlatform {
+    /// The CPU architecture, for example `amd64` or `ppc64`.
+    pub architecture: String,
+    /// The operating system, for example `linux` or `windows`.
+    pub os: String,
+    /// Optional field specifying a variant of the CPU, for example `v7` to specify ARMv7 when architecture is `arm`.
+    pub variant: Option<String>,
+}
+
+impl ToString for ImageBuildPlatform {
+    fn to_string(&self) -> String {
+        let prefix = Path::new(&self.architecture).join(Path::new(&self.os));
+        if let Some(variant) = &self.variant {
+            prefix.join(Path::new(&variant))
+        } else {
+            prefix
+        }
+        .display()
+        .to_string()
+    }
+}
+
+#[derive(Default, Debug, Copy, Clone, PartialEq)]
+#[non_exhaustive]
+/// Compression type for the exported image tar file
+pub enum ImageBuildOutputCompression {
+    /// Emit the tar file uncompressed
+    Uncompressed,
+    /// Emit the tar file GZIP compressed
+    #[default]
+    Gzip,
+    /// Emit the tar file as a stargz snapshot
+    Estargz,
+    /// Emit the tar file with lossless Zstandard compression
+    Zstd,
+}
+
+impl ToString for ImageBuildOutputCompression {
+    fn to_string(&self) -> String {
+        match self {
+            ImageBuildOutputCompression::Uncompressed => "uncompressed",
+            ImageBuildOutputCompression::Gzip => "gzip",
+            ImageBuildOutputCompression::Estargz => "estargz",
+            ImageBuildOutputCompression::Zstd => "zstd",
+        }
+        .to_string()
+    }
+}
+
+pub(crate) struct ImageBuildFrontendOptionsIngest {
+    pub cache_to: Vec<CacheOptionsEntry>,
+    pub cache_from: Vec<CacheOptionsEntry>,
+    pub frontend_attrs: HashMap<String, String>,
+}
+
+impl ImageBuildFrontendOptions {
+    /// Construct a builder for the `ImageBuildFrontendOptions`
+    pub fn builder() -> ImageBuildFrontendOptionsBuilder {
+        ImageBuildFrontendOptionsBuilder::new()
+    }
+
+    pub(crate) fn consume(self) -> ImageBuildFrontendOptionsIngest {
+        let mut attrs = HashMap::new();
+
+        if self.image_resolve_mode {
+            attrs.insert(String::from("image-resolve-mode"), String::from("pull"));
+        } else {
+            attrs.insert(String::from("image-resolve-mode"), String::from("default"));
+        }
+
+        if let Some(target) = self.target {
+            attrs.insert(String::from("target"), target);
+        }
+
+        if self.nocache {
+            attrs.insert(String::from("no-cache"), String::new());
+        }
+
+        if !self.buildargs.is_empty() {
+            for (key, value) in self.buildargs {
+                attrs.insert(format!("build-arg:{}", key), value);
+            }
+        }
+
+        if !self.labels.is_empty() {
+            for (key, value) in self.labels {
+                attrs.insert(format!("label:{}", key), value);
+            }
+        }
+
+        if !self.platforms.is_empty() {
+            attrs.insert(
+                String::from("platform"),
+                self.platforms
+                    .iter()
+                    .map(|v| v.to_string())
+                    .collect::<Vec<_>>()
+                    .join(","),
+            );
+        }
+
+        match self.force_network_mode {
+            ImageBuildNetworkMode::Host => {
+                attrs.insert(String::from("force-network-mode"), String::from("host"));
+            }
+            ImageBuildNetworkMode::None => {
+                attrs.insert(String::from("force-network-mode"), String::from("none"));
+            }
+            _ => (),
+        }
+
+        if !self.extrahosts.is_empty() {
+            attrs.insert(
+                String::from("add-hosts"),
+                self.extrahosts
+                    .iter()
+                    .map(|v| v.to_string())
+                    .collect::<Vec<_>>()
+                    .join(","),
+            );
+        }
+
+        if self.shmsize > 0 {
+            attrs.insert(String::from("shm-size"), self.shmsize.to_string());
+        }
+
+        ImageBuildFrontendOptionsIngest {
+            cache_to: self.cacheto,
+            cache_from: self.cachefrom,
+            frontend_attrs: attrs,
+        }
+    }
+}
+
+/// Builder for the associated [`ImageBuildFrontendOptions`](ImageBuildFrontendOptions) type
+///
+/// ## Examples
+///
+/// ```rust
+/// use bollard::grpc::build::ImageBuildFrontendOptionsBuilder;
+///
+/// ImageBuildFrontendOptionsBuilder::new().pull(true).build();
+///
+/// ```
+///
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct ImageBuildFrontendOptionsBuilder {
+    inner: ImageBuildFrontendOptions,
+}
+
+impl ImageBuildFrontendOptionsBuilder {
+    /// Construct a new builder
+    pub fn new() -> Self {
+        Self {
+            inner: ImageBuildFrontendOptions {
+                ..Default::default()
+            },
+        }
+    }
+
+    /// Image to add towards for build cache resolution.
+    pub fn cacheto(mut self, value: &CacheOptionsEntry) -> Self {
+        self.inner.cacheto.push(value.to_owned());
+        self
+    }
+
+    /// Image to pull towards for build cache resolution.
+    pub fn cachefrom(mut self, value: &CacheOptionsEntry) -> Self {
+        self.inner.cachefrom.push(value.to_owned());
+        self
+    }
+
+    /// Attempt to pull the image even if an older image exists locally.
+    pub fn pull(mut self, pull: bool) -> Self {
+        self.inner.image_resolve_mode = pull;
+        self
+    }
+
+    /// A name and optional tag to apply to the image in the `name:tag` format. If you omit the tag
+    /// the default `latest` value is assumed. You can provide several `t` parameters.
+    pub fn target(mut self, target: &str) -> Self {
+        self.inner.target = Some(String::from(target));
+        self
+    }
+
+    /// Do not use the cache when building the image.
+    pub fn nocache(mut self, nocache: bool) -> Self {
+        self.inner.nocache = nocache;
+        self
+    }
+
+    /// Add string pair for build-time variables. Users pass these values at build-time.
+    /// Docker uses the buildargs as the environment context for commands run via the `Dockerfile`
+    /// RUN instruction, or for variable expansion in other `Dockerfile` instructions.
+    pub fn buildarg(mut self, key: &str, value: &str) -> Self {
+        self.inner
+            .buildargs
+            .insert(String::from(key), String::from(value));
+        self
+    }
+
+    /// Append arbitrary key/value label to set on the image.
+    pub fn label(mut self, key: &str, value: &str) -> Self {
+        self.inner
+            .labels
+            .insert(String::from(key), String::from(value));
+        self
+    }
+
+    /// Platform in the format [`ImageBuildPlatform`](ImageBuildPlatform)
+    pub fn platforms(mut self, value: &ImageBuildPlatform) -> Self {
+        self.inner.platforms.push(value.to_owned());
+        self
+    }
+
+    /// Sets the networking mode for the run commands during build. Supported standard values are:
+    /// `bridge`, `host`, `none`, and `container:<name|id>`.
+    pub fn force_network_mode(mut self, value: &ImageBuildNetworkMode) -> Self {
+        self.inner.force_network_mode = value.to_owned();
+        self
+    }
+
+    /// Extra hosts to add to `/etc/hosts`.
+    pub fn extrahost(mut self, value: &ImageBuildHostIp) -> Self {
+        self.inner.extrahosts.push(value.to_owned());
+        self
+    }
+
+    /// Size of `/dev/shm` in bytes. The size must be greater than 0. If omitted the system uses 64MB.
+    pub fn shmsize(mut self, value: u64) -> Self {
+        self.inner.shmsize = value;
+        self
+    }
+
+    /// Consume the builder and emit an [`ImageBuildFrontendOptions`](ImageBuildFrontendOptions)
+    pub fn build(self) -> ImageBuildFrontendOptions {
+        self.inner
+    }
+}
+
+#[derive(Debug, PartialEq)]
+#[non_exhaustive]
+/// Dockerfile seed implementation to export OCI images as part of the
+/// [`image_export_oci`][crate::Docker::image_export_oci] Docker/buildkit functionality.
+///
+/// Accepts a compressed Dockerfile as Bytes
+///
+/// ## Examples
+///
+/// ```rust
+///     # use std::io::Write;
+///
+///     let dockerfile = String::from(
+///         "FROM alpine as builder1
+///         RUN touch bollard.txt
+///         FROM alpine as builder2
+///         RUN --mount=type=bind,from=builder1,target=mnt cp mnt/bollard.txt buildkit-bollard.txt
+///         ENTRYPOINT ls buildkit-bollard.txt
+///         ",
+///     );
+///     let mut header = tar::Header::new_gnu();
+///     header.set_path("Dockerfile").unwrap();
+///     # header.set_size(dockerfile.len() as u64);
+///     # header.set_mode(0o755);
+///     # header.set_cksum();
+///     let mut tar = tar::Builder::new(Vec::new());
+///     tar.append(&header, dockerfile.as_bytes()).unwrap();
+///     let uncompressed = tar.into_inner().unwrap();
+///     let mut c = flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::default());
+///     c.write_all(&uncompressed).unwrap();
+///     let compressed = c.finish().unwrap();
+///
+///     bollard::grpc::build::ImageBuildLoadInput::Upload(bytes::Bytes::from(compressed));
+///
+/// ```
+///
+pub enum ImageBuildLoadInput {
+    /// Seed the exporter with a tarball containing the Dockerfile to build
+    Upload(Bytes),
+}
+
+// impl super::super::Docker {
+//     /// TODO
+//     pub async fn image_build_buildkit(
+//         &mut self,
+//         driver: impl Driver,
+//         name: &str,
+//         frontend_opts: ImageBuildFrontendOptions,
+//         load_input: ImageBuildLoadInput,
+//         credentials: Option<HashMap<&str, DockerCredentials>>,
+//     ) -> Result<(), GrpcError> {
+//         let session_id = crate::grpc::new_id();
+
+//         let payload = match load_input {
+//             ImageBuildLoadInput::Upload(bytes) => bytes,
+//         };
+
+//         let mut upload_provider = super::UploadProvider::new();
+//         let context = upload_provider.add(payload.to_vec());
+
+//         let ImageBuildFrontendOptionsIngest {
+//             cache_to,
+//             cache_from,
+//             mut frontend_attrs,
+//         } = frontend_opts.consume();
+
+//         frontend_attrs.insert(String::from("context"), context);
+
+//         let mut auth_provider = super::AuthProvider::new();
+//         if let Some(creds) = credentials {
+//             for (host, docker_credentials) in creds {
+//                 auth_provider.set_docker_credentials(host, docker_credentials);
+//             }
+//         }
+//         let auth = moby::filesync::v1::auth_server::AuthServer::new(auth_provider);
+
+//         let upload = moby::upload::v1::upload_server::UploadServer::new(upload_provider);
+//         let filesend = moby::filesync::v1::file_send_server::FileSendServer::new(
+//             super::FileSendImpl::new(Path::new("/tmp/foo")),
+//         );
+
+//         let services: Vec<super::GrpcServer> = vec![
+//             super::GrpcServer::Auth(auth),
+//             super::GrpcServer::FileSend(filesend),
+//             super::GrpcServer::Upload(upload),
+//         ];
+
+//         let tear_down_handler = driver.get_tear_down_handler();
+//         let mut control_client = driver.grpc_handle(&session_id, services).await?;
+
+//         let id = super::new_id();
+
+//         let mut exporter_attrs = HashMap::new();
+//         exporter_attrs.insert(String::from("type"), String::from("image"));
+//         exporter_attrs.insert(String::from("name"), String::from(name));
+
+//         let solve_request = moby::buildkit::v1::SolveRequest {
+//             r#ref: String::from(id),
+//             cache: Some(CacheOptions {
+//                 export_ref_deprecated: String::new(),
+//                 import_refs_deprecated: Vec::new(),
+//                 export_attrs_deprecated: HashMap::new(),
+//                 exports: cache_to,
+//                 imports: cache_from,
+//             }),
+//             definition: None,
+//             entitlements: vec![],
+//             exporter: String::from("docker"),
+//             exporter_attrs,
+//             frontend: String::from("dockerfile.v0"),
+//             frontend_attrs,
+//             frontend_inputs: HashMap::new(),
+//             session: String::from(session_id),
+//         };
+
+//         debug!("sending solve request: {:#?}", solve_request);
+//         let res = control_client.solve(solve_request).await;
+//         debug!("solve res: {:#?}", res);
+
+//         // clean up
+
+//         tear_down_handler.tear_down().await?;
+//         // tear_down?;
+//         res?;
+
+//         Ok(())
+//     }
+// }

--- a/src/grpc/driver/moby.rs
+++ b/src/grpc/driver/moby.rs
@@ -1,18 +1,26 @@
 #![cfg(feature = "buildkit")]
 
+use std::collections::HashMap;
+use std::pin::Pin;
+
 use bollard_buildkit_proto::{health, moby::buildkit::v1::control_client::ControlClient};
 use bytes::Bytes;
 use http::{request::Builder, Method};
 use http_body_util::Full;
 use log::error;
 use log::trace;
+use tonic::codegen::InterceptedService;
 use tonic::transport::{Channel, Endpoint};
 
+use crate::auth::DockerCredentials;
+use crate::grpc::build::{ImageBuildFrontendOptions, ImageBuildLoadInput};
 use crate::{
     grpc::error::GrpcError,
     grpc::{io::GrpcTransport, GrpcClient, GrpcServer, HealthServerImpl},
     Docker,
 };
+
+use super::{Driver, DriverInterceptor};
 
 /// The Moby driver handles a GRPC connection with an upgraded `/session` and `/grpc` endpoints in
 /// Docker itself.
@@ -22,11 +30,20 @@ pub struct Moby {
 }
 
 impl Moby {
+    /// TODO
+    pub fn new(docker: &Docker) -> Self {
+        Self {
+            docker: Docker::clone(docker),
+        }
+    }
+}
+
+impl Driver for Moby {
     async fn grpc_handle(
-        &mut self,
+        self,
         session_id: &str,
         services: Vec<GrpcServer>,
-    ) -> Result<ControlClient<Channel>, GrpcError> {
+    ) -> Result<ControlClient<InterceptedService<Channel, DriverInterceptor>>, GrpcError> {
         let grpc_client = GrpcClient {
             client: self.docker.clone(),
             session_id: String::from(session_id),
@@ -36,12 +53,19 @@ impl Moby {
             .connect_with_connector(grpc_client)
             .await?;
 
-        let control_client = ControlClient::new(channel);
+        let metadata_grpc_method: Vec<String> = services.iter().flat_map(|s| s.names()).collect();
+
+        let joined_methods = &metadata_grpc_method.join(",");
+
+        let interceptor = DriverInterceptor {
+            session_id: String::from(session_id),
+            metadata_grpc_method,
+        };
+        let control_client = ControlClient::with_interceptor(channel, interceptor);
 
         let url = "/session";
 
         let opt: Option<serde_json::Value> = None;
-        let metadata_grpc_method: Vec<String> = services.iter().flat_map(|s| s.names()).collect();
 
         let req = self.docker.build_request(
             url,
@@ -50,10 +74,7 @@ impl Moby {
                 .header("Connection", "Upgrade")
                 .header("Upgrade", "h2c")
                 .header("X-Docker-Expose-Session-Uuid", session_id)
-                .header(
-                    "X-Docker-Expose-Session-Grpc-Method",
-                    metadata_grpc_method.join(","),
-                ),
+                .header("X-Docker-Expose-Session-Grpc-Method", joined_methods),
             opt,
             Ok(Full::new(Bytes::new())),
         );
@@ -89,5 +110,41 @@ impl Moby {
         });
 
         Ok(control_client)
+    }
+
+    fn get_tear_down_handler(&self) -> Box<dyn super::DriverTearDownHandler> {
+        Box::new(MobyTearDownHandler {})
+    }
+}
+
+struct MobyTearDownHandler {}
+
+impl super::DriverTearDownHandler for MobyTearDownHandler {
+    fn tear_down(&self) -> Pin<Box<dyn futures_core::Future<Output = Result<(), GrpcError>>>> {
+        Box::pin(futures_util::future::ok(()))
+    }
+}
+
+impl super::Build for Moby {
+    async fn docker_build(
+        self,
+        name: &str,
+        frontend_opts: ImageBuildFrontendOptions,
+        load_input: ImageBuildLoadInput,
+        credentials: Option<HashMap<&str, DockerCredentials>>,
+    ) -> Result<(), GrpcError> {
+        let mut exporter_attrs = HashMap::new();
+        exporter_attrs.insert(String::from("type"), String::from("docker"));
+        exporter_attrs.insert(String::from("name"), String::from(name));
+        super::solve(
+            self,
+            "moby",
+            exporter_attrs,
+            None,
+            frontend_opts,
+            load_input,
+            credentials,
+        )
+        .await
     }
 }

--- a/src/grpc/driver/mod.rs
+++ b/src/grpc/driver/mod.rs
@@ -1,6 +1,204 @@
+use std::{collections::HashMap, path::PathBuf};
+
+use bollard_buildkit_proto::moby::{
+    buildkit::v1::{control_client::ControlClient, CacheOptions, SolveRequest},
+    filesync::v1::{auth_server::AuthServer, file_send_server::FileSendServer},
+    upload::v1::upload_server::UploadServer,
+};
+use log::debug;
+// use tonic::service::Interceptor;
+use tonic::{
+    codegen::InterceptedService, metadata::MetadataValue, service::Interceptor, transport::Channel,
+};
+
+use crate::{auth::DockerCredentials, grpc::build::ImageBuildFrontendOptionsIngest};
+
+use super::{
+    build::{ImageBuildFrontendOptions, ImageBuildLoadInput},
+    error::GrpcError,
+    export::ImageExporterRequest,
+    registry::ImageRegistryOutput,
+    GrpcServer,
+};
+
 /// The Docker Container driver opens a GRPC connection by instantiating a Buildkit container over
 /// the traditional docker socket, and communicating over a docker execution Stdin/Stdout pipe.
 pub mod docker_container;
 /// The Moby driver opens a bi-directional GRPC connection by upgrading HTTP `/session` and `/grpc`
 /// endpoints over the traditional docker socket.
 pub mod moby;
+
+/// TODO
+pub trait Driver {
+    /// TODO
+    async fn grpc_handle(
+        self,
+        session_id: &str,
+        services: Vec<GrpcServer>,
+    ) -> Result<ControlClient<InterceptedService<Channel, DriverInterceptor>>, GrpcError>;
+    /// TODO
+    fn get_tear_down_handler(&self) -> Box<dyn DriverTearDownHandler>;
+}
+
+/// TODO
+pub trait DriverTearDownHandler {
+    /// TODO
+    fn tear_down<'a>(
+        &'a self,
+    ) -> std::pin::Pin<Box<dyn futures_core::Future<Output = Result<(), GrpcError>> + 'a>>;
+}
+
+/// TODO
+#[derive(Debug, Clone)]
+pub struct DriverInterceptor {
+    session_id: String,
+    metadata_grpc_method: Vec<String>,
+}
+
+impl Interceptor for DriverInterceptor {
+    fn call(&mut self, mut req: tonic::Request<()>) -> Result<tonic::Request<()>, tonic::Status> {
+        let metadata = req.metadata_mut();
+
+        metadata.insert(
+            "x-docker-expose-session-uuid",
+            self.session_id
+                .parse()
+                .map_err(|_| tonic::Status::invalid_argument("invalid 'session_id' argument"))?,
+        );
+
+        debug!("grpc-method: {:?}", self.metadata_grpc_method.join(","));
+        for metadata_grpc_method_value in &self.metadata_grpc_method {
+            let metadata_value = metadata_grpc_method_value
+                .parse::<MetadataValue<tonic::metadata::Ascii>>()
+                .map_err(|_| tonic::Status::invalid_argument("invalid grpc method name"))?;
+            metadata.append("x-docker-expose-session-grpc-method", metadata_value);
+        }
+
+        Ok(req)
+    }
+}
+
+/// TODO
+#[derive(Debug, Clone)]
+pub enum ImageExporterEnum {
+    /// TODO
+    OCI(ImageExporterRequest),
+    /// TODO
+    Docker(ImageExporterRequest),
+}
+
+/// TODO
+pub trait Export {
+    /// TODO
+    async fn export(
+        self,
+        exporter_request: ImageExporterEnum,
+        frontend_opts: ImageBuildFrontendOptions,
+        load_input: ImageBuildLoadInput,
+        credentials: Option<HashMap<&str, DockerCredentials>>,
+    ) -> Result<(), GrpcError>;
+}
+
+/// TODO
+pub trait Build {
+    /// TODO
+    async fn docker_build(
+        self,
+        name: &str,
+        frontend_opts: ImageBuildFrontendOptions,
+        load_input: ImageBuildLoadInput,
+        credentials: Option<HashMap<&str, DockerCredentials>>,
+    ) -> Result<(), GrpcError>;
+}
+
+/// TODO
+pub trait Image {
+    /// TODO
+    async fn registry(
+        self,
+        output: ImageRegistryOutput,
+        frontend_opts: ImageBuildFrontendOptions,
+        load_input: ImageBuildLoadInput,
+        credentials: Option<HashMap<&str, DockerCredentials>>,
+    ) -> Result<(), GrpcError>;
+}
+
+pub(crate) async fn solve(
+    driver: impl Driver,
+    exporter: &str,
+    exporter_attrs: HashMap<String, String>,
+    path: Option<PathBuf>,
+    frontend_opts: ImageBuildFrontendOptions,
+    load_input: ImageBuildLoadInput,
+    credentials: Option<HashMap<&str, DockerCredentials>>,
+) -> Result<(), GrpcError> {
+    let session_id = crate::grpc::new_id();
+
+    let ImageBuildLoadInput::Upload(payload) = load_input;
+
+    let mut upload_provider = super::UploadProvider::new();
+    let context = upload_provider.add(payload.to_vec());
+
+    let ImageBuildFrontendOptionsIngest {
+        cache_to,
+        cache_from,
+        mut frontend_attrs,
+    } = frontend_opts.consume();
+
+    frontend_attrs.insert(String::from("context"), context);
+
+    let mut auth_provider = super::AuthProvider::new();
+    if let Some(creds) = credentials {
+        for (host, docker_credentials) in creds {
+            auth_provider.set_docker_credentials(host, docker_credentials);
+        }
+    }
+    let auth = AuthServer::new(auth_provider);
+
+    let upload = UploadServer::new(upload_provider);
+    let mut services: Vec<GrpcServer> = vec![
+        super::GrpcServer::Auth(auth),
+        super::GrpcServer::Upload(upload),
+    ];
+    if let Some(path) = path {
+        let filesend = FileSendServer::new(super::FileSendImpl::new(path.as_path()));
+
+        services.push(super::GrpcServer::FileSend(filesend));
+    }
+
+    let tear_down_handler = driver.get_tear_down_handler();
+    let mut control_client = driver.grpc_handle(&session_id, services).await?;
+
+    let id = super::new_id();
+
+    let solve_request = SolveRequest {
+        r#ref: id,
+        cache: Some(CacheOptions {
+            export_ref_deprecated: String::new(),
+            import_refs_deprecated: Vec::new(),
+            export_attrs_deprecated: HashMap::new(),
+            exports: cache_to,
+            imports: cache_from,
+        }),
+        definition: None,
+        entitlements: vec![],
+        exporter: String::from(exporter),
+        exporter_attrs,
+        frontend: String::from("dockerfile.v0"),
+        frontend_attrs,
+        frontend_inputs: HashMap::new(),
+        session: session_id,
+    };
+
+    debug!("sending solve request: {:#?}", solve_request);
+    let res = control_client.solve(solve_request).await;
+    debug!("solve res: {:#?}", res);
+
+    // clean up
+
+    tear_down_handler.tear_down().await?;
+    // tear_down?;
+    res?;
+
+    Ok(())
+}

--- a/src/grpc/export.rs
+++ b/src/grpc/export.rs
@@ -4,295 +4,10 @@ pub use bollard_buildkit_proto::fsutil;
 pub use bollard_buildkit_proto::health;
 pub use bollard_buildkit_proto::moby;
 
-use bytes::Bytes;
-use log::debug;
-use log::trace;
-
 use std::collections::HashMap;
-use std::net::IpAddr;
 use std::path::Path;
 
-use super::error::GrpcError;
-use crate::auth::DockerCredentials;
-use crate::container::KillContainerOptions;
-
-use super::driver::docker_container::DockerContainer;
-
-/// Parameters available for passing frontend options to buildkit when initiating a Solve GRPC
-/// request, f.e. used in associated methods within the [GRPC module](module@crate::grpc)
-///
-/// ## Examples
-///
-/// ```rust
-/// use bollard::grpc::export::ImageBuildFrontendOptions;
-///
-/// ImageBuildFrontendOptions::builder().pull(true).build();
-///
-/// ```
-///
-#[derive(Debug, Clone, Default, PartialEq)]
-pub struct ImageBuildFrontendOptions {
-    //pub(crate) cgroupparent: Option<String>,
-    //pub(crate) multiplatform: bool,
-    //pub(crate) attests: HashMap<String, String>,
-    pub(crate) cachefrom: Vec<String>,
-    pub(crate) image_resolve_mode: bool,
-    pub(crate) target: Option<String>,
-    pub(crate) nocache: bool,
-    pub(crate) buildargs: HashMap<String, String>,
-    pub(crate) labels: HashMap<String, String>,
-    pub(crate) platforms: Vec<ImageBuildPlatform>,
-    pub(crate) force_network_mode: ImageBuildNetworkMode,
-    pub(crate) extrahosts: Vec<ImageBuildHostIp>,
-    pub(crate) shmsize: u64,
-    //pub(crate) ulimit: Vec<String>,
-}
-
-#[derive(Debug, Clone, PartialEq)]
-/// A list of hostnames/IP mappings to add to the container's `/etc/hosts` file.
-pub struct ImageBuildHostIp {
-    /// The hosname mapping component of a hostname/IP mapping
-    pub host: String,
-    /// The IP mapping component of a hostname/IP mapping
-    pub ip: IpAddr,
-}
-
-impl ToString for ImageBuildHostIp {
-    fn to_string(&self) -> String {
-        format!("{}={}", self.host, self.ip)
-    }
-}
-
-#[derive(Default, Debug, Clone, PartialEq)]
-#[non_exhaustive]
-/// Network mode to use for this container. Supported standard values are: `bridge`, `host`,
-/// `none`, and `container:<name|id>`. Any other value is taken as a custom network's name to which
-/// this container should connect to.
-pub enum ImageBuildNetworkMode {
-    /// Bridge mode networking
-    #[default]
-    Bridge,
-    /// Host mode networking
-    Host,
-    /// No networking mode
-    None,
-    /// Container mode networking, with container name as `name`
-    Container(String),
-}
-
-impl ToString for ImageBuildNetworkMode {
-    fn to_string(&self) -> String {
-        match self {
-            ImageBuildNetworkMode::Bridge => String::from("default"),
-            ImageBuildNetworkMode::Host => String::from("host"),
-            ImageBuildNetworkMode::None => String::from("none"),
-            ImageBuildNetworkMode::Container(name) => format!("container:{name}"),
-        }
-    }
-}
-
-#[derive(Debug, Clone, Default, PartialEq)]
-/// Describes the platform which the image in the manifest runs on, as defined in the [OCI Image Index Specification](https://github.com/opencontainers/image-spec/blob/v1.0.1/image-index.md).
-pub struct ImageBuildPlatform {
-    /// The CPU architecture, for example `amd64` or `ppc64`.
-    pub architecture: String,
-    /// The operating system, for example `linux` or `windows`.
-    pub os: String,
-    /// Optional field specifying a variant of the CPU, for example `v7` to specify ARMv7 when architecture is `arm`.
-    pub variant: Option<String>,
-}
-
-impl ToString for ImageBuildPlatform {
-    fn to_string(&self) -> String {
-        let prefix = Path::new(&self.architecture).join(Path::new(&self.os));
-        if let Some(variant) = &self.variant {
-            prefix.join(Path::new(&variant))
-        } else {
-            prefix
-        }
-        .display()
-        .to_string()
-    }
-}
-
-impl ImageBuildFrontendOptions {
-    /// Construct a builder for the `ImageBuildFrontendOptions`
-    pub fn builder() -> ImageBuildFrontendOptionsBuilder {
-        ImageBuildFrontendOptionsBuilder::new()
-    }
-
-    pub(crate) fn into_map(self) -> HashMap<String, String> {
-        let mut attrs = HashMap::new();
-
-        if self.image_resolve_mode {
-            attrs.insert(String::from("image-resolve-mode"), String::from("pull"));
-        } else {
-            attrs.insert(String::from("image-resolve-mode"), String::from("default"));
-        }
-
-        if let Some(target) = self.target {
-            attrs.insert(String::from("target"), target);
-        }
-
-        if self.nocache {
-            attrs.insert(String::from("no-cache"), String::new());
-        }
-
-        if !self.buildargs.is_empty() {
-            for (key, value) in self.buildargs {
-                attrs.insert(format!("build-arg:{}", key), value);
-            }
-        }
-
-        if !self.labels.is_empty() {
-            for (key, value) in self.labels {
-                attrs.insert(format!("label:{}", key), value);
-            }
-        }
-
-        if !self.platforms.is_empty() {
-            attrs.insert(
-                String::from("platform"),
-                self.platforms
-                    .iter()
-                    .map(|v| v.to_string())
-                    .collect::<Vec<_>>()
-                    .join(","),
-            );
-        }
-
-        match self.force_network_mode {
-            ImageBuildNetworkMode::Host => {
-                attrs.insert(String::from("force-network-mode"), String::from("host"));
-            }
-            ImageBuildNetworkMode::None => {
-                attrs.insert(String::from("force-network-mode"), String::from("none"));
-            }
-            _ => (),
-        }
-
-        if !self.extrahosts.is_empty() {
-            attrs.insert(
-                String::from("add-hosts"),
-                self.extrahosts
-                    .iter()
-                    .map(|v| v.to_string())
-                    .collect::<Vec<_>>()
-                    .join(","),
-            );
-        }
-
-        if self.shmsize > 0 {
-            attrs.insert(String::from("shm-size"), self.shmsize.to_string());
-        }
-
-        if !self.cachefrom.is_empty() {
-            attrs.insert(String::from("cache-from"), self.cachefrom.join(","));
-        }
-
-        attrs
-    }
-}
-
-/// Builder for the associated [`ImageBuildFrontendOptions`](ImageBuildFrontendOptions) type
-///
-/// ## Examples
-///
-/// ```rust
-/// use bollard::grpc::export::ImageBuildFrontendOptionsBuilder;
-///
-/// ImageBuildFrontendOptionsBuilder::new().pull(true).build();
-///
-/// ```
-///
-#[derive(Debug, Clone, Default, PartialEq)]
-pub struct ImageBuildFrontendOptionsBuilder {
-    inner: ImageBuildFrontendOptions,
-}
-
-impl ImageBuildFrontendOptionsBuilder {
-    /// Construct a new builder
-    pub fn new() -> Self {
-        Self {
-            inner: ImageBuildFrontendOptions {
-                ..Default::default()
-            },
-        }
-    }
-
-    /// Image to add towards for build cache resolution.
-    pub fn cachefrom(mut self, value: &str) -> Self {
-        self.inner.cachefrom.push(value.to_owned());
-        self
-    }
-
-    /// Attempt to pull the image even if an older image exists locally.
-    pub fn pull(mut self, pull: bool) -> Self {
-        self.inner.image_resolve_mode = pull;
-        self
-    }
-
-    /// A name and optional tag to apply to the image in the `name:tag` format. If you omit the tag
-    /// the default `latest` value is assumed. You can provide several `t` parameters.
-    pub fn target(mut self, target: &str) -> Self {
-        self.inner.target = Some(String::from(target));
-        self
-    }
-
-    /// Do not use the cache when building the image.
-    pub fn nocache(mut self, nocache: bool) -> Self {
-        self.inner.nocache = nocache;
-        self
-    }
-
-    /// Add string pair for build-time variables. Users pass these values at build-time.
-    /// Docker uses the buildargs as the environment context for commands run via the `Dockerfile`
-    /// RUN instruction, or for variable expansion in other `Dockerfile` instructions.
-    pub fn buildarg(mut self, key: &str, value: &str) -> Self {
-        self.inner
-            .buildargs
-            .insert(String::from(key), String::from(value));
-        self
-    }
-
-    /// Append arbitrary key/value label to set on the image.
-    pub fn label(mut self, key: &str, value: &str) -> Self {
-        self.inner
-            .labels
-            .insert(String::from(key), String::from(value));
-        self
-    }
-
-    /// Platform in the format [`ImageBuildPlatform`](ImageBuildPlatform)
-    pub fn platforms(mut self, value: &ImageBuildPlatform) -> Self {
-        self.inner.platforms.push(value.to_owned());
-        self
-    }
-
-    /// Sets the networking mode for the run commands during build. Supported standard values are:
-    /// `bridge`, `host`, `none`, and `container:<name|id>`.
-    pub fn force_network_mode(mut self, value: &ImageBuildNetworkMode) -> Self {
-        self.inner.force_network_mode = value.to_owned();
-        self
-    }
-
-    /// Extra hosts to add to `/etc/hosts`.
-    pub fn extrahost(mut self, value: &ImageBuildHostIp) -> Self {
-        self.inner.extrahosts.push(value.to_owned());
-        self
-    }
-
-    /// Size of `/dev/shm` in bytes. The size must be greater than 0. If omitted the system uses 64MB.
-    pub fn shmsize(mut self, value: u64) -> Self {
-        self.inner.shmsize = value;
-        self
-    }
-
-    /// Consume the builder and emit an [`ImageBuildFrontendOptions`](ImageBuildFrontendOptions)
-    pub fn build(self) -> ImageBuildFrontendOptions {
-        self.inner
-    }
-}
+use super::build::ImageBuildOutputCompression;
 
 /// Parameters available for passing exporter output options to buildkit when exporting images
 /// using a Solve GRPC request, f.e. used in associated [GRPC export methods](module@crate::grpc::export)
@@ -300,16 +15,16 @@ impl ImageBuildFrontendOptionsBuilder {
 /// ## Examples
 ///
 /// ```rust
-/// use bollard::grpc::export::ImageBuildFrontendOptions;
+/// use bollard::grpc::build::ImageBuildFrontendOptions;
 ///
 /// let frontend_options = ImageBuildFrontendOptions::builder().pull(true).build();
 ///
 /// ```
 ///
 #[derive(Debug, Clone, Default, PartialEq)]
-pub struct ImageExporterOCIOutput {
+pub struct ImageExporterOutput {
     pub(crate) name: String,
-    pub(crate) compression: ImageExporterOCIOutputCompression,
+    pub(crate) compression: ImageBuildOutputCompression,
     pub(crate) compression_level: Option<u8>,
     pub(crate) force_compression: bool,
     pub(crate) oci_mediatypes: bool,
@@ -351,27 +66,25 @@ impl ToString for ImageExporterOCIOutputCompression {
 /// ## Examples
 ///
 /// ```rust
-/// use bollard::grpc::export::ImageExporterOCIOutput;
+/// use bollard::grpc::export::ImageExporterOutput;
 /// use std::path::Path;
 ///
-/// ImageExporterOCIOutput::builder("docker.io/library/my-image:latest")
+/// ImageExporterOutput::builder("docker.io/library/my-image:latest")
 ///     .dest(&Path::new("/tmp/oci.tar"));
 ///
 /// ```
 ///
 #[derive(Debug, Clone, Default, PartialEq)]
-#[cfg(feature = "buildkit")]
-pub struct ImageExporterOCIRequest {
-    output: ImageExporterOCIOutput,
-    path: std::path::PathBuf,
+pub struct ImageExporterRequest {
+    pub(crate) output: ImageExporterOutput,
+    pub(crate) path: std::path::PathBuf,
 }
 
-#[cfg(feature = "buildkit")]
-impl ImageExporterOCIOutput {
+impl ImageExporterOutput {
     /// Constructs a [`ImageExporterOCIOutputBuilder`], the `name` parameter denotes the output
     /// image target, e.g. "docker.io/library/my-image:latest".
-    pub fn builder(name: &str) -> ImageExporterOCIOutputBuilder {
-        ImageExporterOCIOutputBuilder::new(name)
+    pub fn builder(name: &str) -> ImageExporterOutputBuilder {
+        ImageExporterOutputBuilder::new(name)
     }
 
     fn new(name: &str) -> Self {
@@ -417,24 +130,24 @@ impl ImageExporterOCIOutput {
 /// ## Examples
 ///
 /// ```rust
-/// use bollard::grpc::export::ImageExporterOCIOutputBuilder;
+/// use bollard::grpc::export::ImageExporterOutputBuilder;
 /// use std::path::Path;
 ///
-/// ImageExporterOCIOutputBuilder::new("docker.io/library/my-image:latest")
+/// ImageExporterOutputBuilder::new("docker.io/library/my-image:latest")
 ///     .dest(&Path::new("/tmp/oci.tar"));
 ///
 /// ```
 ///
 #[derive(Debug, Clone, Default, PartialEq)]
-pub struct ImageExporterOCIOutputBuilder {
-    inner: ImageExporterOCIOutput,
+pub struct ImageExporterOutputBuilder {
+    inner: ImageExporterOutput,
 }
 
-impl ImageExporterOCIOutputBuilder {
+impl ImageExporterOutputBuilder {
     /// Constructs the builder given an image name, e.g. "docker.io/library/my-image:latest"
     pub fn new(name: &str) -> Self {
         Self {
-            inner: ImageExporterOCIOutput {
+            inner: ImageExporterOutput {
                 name: String::from(name),
                 ..Default::default()
             },
@@ -443,7 +156,7 @@ impl ImageExporterOCIOutputBuilder {
 
     /// Compression type, see [buildkit compression
     /// docs](https://docs.docker.com/build/exporters/#compression)
-    pub fn compression(mut self, compression: &ImageExporterOCIOutputCompression) -> Self {
+    pub fn compression(mut self, compression: &ImageBuildOutputCompression) -> Self {
         self.inner.compression = compression.to_owned();
         self
     }
@@ -482,212 +195,172 @@ impl ImageExporterOCIOutputBuilder {
 
     /// Consume this builder to create an [`ImageExporterOCIOutput`] for the
     /// [`image_export_oci`](crate::Docker::image_export_oci) method
-    pub fn dest(self, path: &Path) -> ImageExporterOCIRequest {
-        ImageExporterOCIRequest {
+    pub fn dest(self, path: &Path) -> ImageExporterRequest {
+        ImageExporterRequest {
             output: self.inner,
             path: path.to_owned(),
         }
     }
 }
 
-#[derive(Debug, PartialEq)]
-#[non_exhaustive]
-/// Dockerfile seed implementation to export OCI images as part of the
-/// [`image_export_oci`][crate::Docker::image_export_oci] Docker/buildkit functionality.
-///
-/// Accepts a compressed Dockerfile as Bytes
-///
-/// ## Examples
-///
-/// ```rust
-///     # use std::io::Write;
-///
-///     let dockerfile = String::from(
-///         "FROM alpine as builder1
-///         RUN touch bollard.txt
-///         FROM alpine as builder2
-///         RUN --mount=type=bind,from=builder1,target=mnt cp mnt/bollard.txt buildkit-bollard.txt
-///         ENTRYPOINT ls buildkit-bollard.txt
-///         ",
-///     );
-///     let mut header = tar::Header::new_gnu();
-///     header.set_path("Dockerfile").unwrap();
-///     # header.set_size(dockerfile.len() as u64);
-///     # header.set_mode(0o755);
-///     # header.set_cksum();
-///     let mut tar = tar::Builder::new(Vec::new());
-///     tar.append(&header, dockerfile.as_bytes()).unwrap();
-///     let uncompressed = tar.into_inner().unwrap();
-///     let mut c = flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::default());
-///     c.write_all(&uncompressed).unwrap();
-///     let compressed = c.finish().unwrap();
-///
-///     bollard::grpc::export::ImageExporterLoadInput::Upload(bytes::Bytes::from(compressed));
-///
-/// ```
-///
-pub enum ImageExporterLoadInput {
-    /// Seed the exporter with a tarball containing the Dockerfile to build
-    Upload(Bytes),
-}
+// impl<'a> super::super::Docker {
+//     ///
+//     /// Export build result as [OCI image
+//     /// layout](https://github.com/opencontainers/image-spec/blob/main/image-layout.md) tarball,
+//     /// see [buildkit documentation on OCI
+//     /// exporters](https://docs.docker.com/build/exporters/oci-docker/).
+//     ///
+//     /// <div class="warning">
+//     ///  Warning: Buildkit features in Bollard are currently in Developer Preview and are intended strictly for feedback purposes only.
+//     /// </div>
+//     ///
+//     /// # Arguments
+//     ///
+//     ///  - An owned instance of a [`DockerContainer`](crate::grpc::driver::docker_container::DockerContainer) is
+//     ///  needed to create a grpc conncection with buildkit.
+//     ///  - The `session_id` represents a unique id to identify the grpc connection.
+//     ///  - An owned instance of a [`ImageBuildFrontendOptions`], to parameterise the buildkit
+//     ///  frontend Solve request options.
+//     ///  - An owned instance of a [`ImageExporterOCIRequest`], to parameterise the export specific
+//     ///  buildkit options
+//     ///  - An owned instance of a [`ImageExporterLoadInput`], to upload the Dockerfile that should
+//     ///  be exported.
+//     ///  - An optional hashmap of registry hosts to [credentials](crate::auth::DockerCredentials) to
+//     ///  authenticate with, if using private images.
+//     ///
+//     /// ## Examples
+//     ///
+//     /// ```rust
+//     /// # use bollard::grpc::driver::docker_container::DockerContainerBuilder;
+//     /// # use bollard::grpc::export::ImageExporterLoadInput;
+//     /// # use bollard::grpc::export::ImageExporterOCIOutputBuilder;
+//     /// # use bollard::grpc::export::ImageBuildFrontendOptions;
+//     /// # use bollard::Docker;
+//     /// # use std::io::Write;
+//     ///
+//     /// # let mut docker = Docker::connect_with_socket_defaults().unwrap();
+//     ///
+//     /// let dockerfile = String::from(
+//     ///     "FROM alpine as builder1
+//     ///     RUN touch bollard.txt
+//     ///     FROM alpine as builder2
+//     ///     RUN --mount=type=bind,from=builder1,target=mnt cp mnt/bollard.txt buildkit-bollard.txt
+//     ///     ENTRYPOINT ls buildkit-bollard.txt
+//     ///     ",
+//     /// );
+//     ///
+//     /// let mut header = tar::Header::new_gnu();
+//     /// header.set_path("Dockerfile").unwrap();
+//     /// # header.set_size(dockerfile.len() as u64);
+//     /// # header.set_mode(0o755);
+//     /// # header.set_cksum();
+//     /// let mut tar = tar::Builder::new(Vec::new());
+//     /// tar.append(&header, dockerfile.as_bytes()).unwrap();
+//     ///
+//     /// let uncompressed = tar.into_inner().unwrap();
+//     /// let mut c = flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::default());
+//     /// c.write_all(&uncompressed).unwrap();
+//     /// let compressed = c.finish().unwrap();
+//     ///
+//     /// let session_id = "bollard-oci-export-buildkit-example";
+//     ///
+//     /// let frontend_opts = ImageBuildFrontendOptions::builder()
+//     ///     .pull(true)
+//     ///     .build();
+//     ///
+//     /// let output = ImageExporterOCIOutputBuilder::new(
+//     ///     "docker.io/library/bollard-oci-export-buildkit-example:latest",
+//     /// )
+//     /// .annotation("exporter", "Bollard")
+//     /// .dest(&std::path::Path::new("/tmp/oci-image.tar"));
+//     ///
+//     /// let buildkit_builder =
+//     ///     DockerContainerBuilder::new("bollard_buildkit_export_oci_image", &docker, session_id);
+//     ///
+//     /// let load_input =
+//     ///     ImageExporterLoadInput::Upload(bytes::Bytes::from(compressed));
+//     ///
+//     /// async move {
+//     ///     let driver = buildkit_builder.bootstrap().await.unwrap();
+//     ///     docker
+//     ///         .image_export_oci(driver, session_id, frontend_opts, output, load_input, None)
+//     ///         .await
+//     ///         .unwrap();
+//     /// };
+//     /// ```
+//     ///
+//     pub async fn image_export_oci(
+//         &mut self,
+//         driver: DockerContainer,
+//         session_id: &str,
+//         frontend_opts: ImageBuildFrontendOptions,
+//         exporter_request: ImageExporterRequest,
+//         load_input: ImageBuildLoadInput,
+//         credentials: Option<HashMap<&str, DockerCredentials>>,
+//     ) -> Result<(), GrpcError> {
+//         let buildkit_name = String::from(driver.name());
 
-impl<'a> super::super::Docker {
-    ///
-    /// Export build result as [OCI image
-    /// layout](https://github.com/opencontainers/image-spec/blob/main/image-layout.md) tarball,
-    /// see [buildkit documentation on OCI
-    /// exporters](https://docs.docker.com/build/exporters/oci-docker/).
-    ///
-    /// <div class="warning">
-    ///  Warning: Buildkit features in Bollard are currently in Developer Preview and are intended strictly for feedback purposes only.
-    /// </div>
-    ///
-    /// # Arguments
-    ///
-    ///  - An owned instance of a [`DockerContainer`](crate::grpc::driver::docker_container::DockerContainer) is
-    ///  needed to create a grpc conncection with buildkit.
-    ///  - The `session_id` represents a unique id to identify the grpc connection.
-    ///  - An owned instance of a [`ImageBuildFrontendOptions`], to parameterise the buildkit
-    ///  frontend Solve request options.
-    ///  - An owned instance of a [`ImageExporterOCIRequest`], to parameterise the export specific
-    ///  buildkit options
-    ///  - An owned instance of a [`ImageExporterLoadInput`], to upload the Dockerfile that should
-    ///  be exported.
-    ///  - An optional hashmap of registry hosts to [credentials](crate::auth::DockerCredentials) to
-    ///  authenticate with, if using private images.
-    ///
-    /// ## Examples
-    ///
-    /// ```rust
-    /// # use bollard::grpc::driver::docker_container::DockerContainerBuilder;
-    /// # use bollard::grpc::export::ImageExporterLoadInput;
-    /// # use bollard::grpc::export::ImageExporterOCIOutputBuilder;
-    /// # use bollard::grpc::export::ImageBuildFrontendOptions;
-    /// # use bollard::Docker;
-    /// # use std::io::Write;
-    ///
-    /// # let mut docker = Docker::connect_with_socket_defaults().unwrap();
-    ///
-    /// let dockerfile = String::from(
-    ///     "FROM alpine as builder1
-    ///     RUN touch bollard.txt
-    ///     FROM alpine as builder2
-    ///     RUN --mount=type=bind,from=builder1,target=mnt cp mnt/bollard.txt buildkit-bollard.txt
-    ///     ENTRYPOINT ls buildkit-bollard.txt
-    ///     ",
-    /// );
-    ///
-    /// let mut header = tar::Header::new_gnu();
-    /// header.set_path("Dockerfile").unwrap();
-    /// # header.set_size(dockerfile.len() as u64);
-    /// # header.set_mode(0o755);
-    /// # header.set_cksum();
-    /// let mut tar = tar::Builder::new(Vec::new());
-    /// tar.append(&header, dockerfile.as_bytes()).unwrap();
-    ///
-    /// let uncompressed = tar.into_inner().unwrap();
-    /// let mut c = flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::default());
-    /// c.write_all(&uncompressed).unwrap();
-    /// let compressed = c.finish().unwrap();
-    ///
-    /// let session_id = "bollard-oci-export-buildkit-example";
-    ///
-    /// let frontend_opts = ImageBuildFrontendOptions::builder()
-    ///     .pull(true)
-    ///     .build();
-    ///
-    /// let output = ImageExporterOCIOutputBuilder::new(
-    ///     "docker.io/library/bollard-oci-export-buildkit-example:latest",
-    /// )
-    /// .annotation("exporter", "Bollard")
-    /// .dest(&std::path::Path::new("/tmp/oci-image.tar"));
-    ///
-    /// let buildkit_builder =
-    ///     DockerContainerBuilder::new("bollard_buildkit_export_oci_image", &docker, session_id);
-    ///
-    /// let load_input =
-    ///     ImageExporterLoadInput::Upload(bytes::Bytes::from(compressed));
-    ///
-    /// async move {
-    ///     let driver = buildkit_builder.bootstrap().await.unwrap();
-    ///     docker
-    ///         .image_export_oci(driver, session_id, frontend_opts, output, load_input, None)
-    ///         .await
-    ///         .unwrap();
-    /// };
-    /// ```
-    ///
-    pub async fn image_export_oci(
-        &mut self,
-        driver: DockerContainer,
-        session_id: &str,
-        frontend_opts: ImageBuildFrontendOptions,
-        exporter_request: ImageExporterOCIRequest,
-        load_input: ImageExporterLoadInput,
-        credentials: Option<HashMap<&str, DockerCredentials>>,
-    ) -> Result<(), GrpcError> {
-        let buildkit_name = String::from(driver.name());
+// let ImageExporterLoadInput::Upload(bytes) = load_input;
 
-        let ImageExporterLoadInput::Upload(bytes) = load_input;
+// let mut upload_provider = super::UploadProvider::new();
+// let context = upload_provider.add(bytes.to_vec());
 
-        let mut upload_provider = super::UploadProvider::new();
-        let context = upload_provider.add(bytes.to_vec());
+// let mut frontend_attrs = frontend_opts.into_map();
+// frontend_attrs.insert(String::from("context"), context);
+// let exporter_attrs = exporter_request.output.into_map();
 
-        let mut frontend_attrs = frontend_opts.into_map();
-        frontend_attrs.insert(String::from("context"), context);
-        let exporter_attrs = exporter_request.output.into_map();
+//         let mut auth_provider = super::AuthProvider::new();
+//         if let Some(creds) = credentials {
+//             for (host, docker_credentials) in creds {
+//                 auth_provider.set_docker_credentials(host, docker_credentials);
+//             }
+//         }
+//         let auth = moby::filesync::v1::auth_server::AuthServer::new(auth_provider);
 
-        let mut auth_provider = super::AuthProvider::new();
-        if let Some(creds) = credentials {
-            for (host, docker_credentials) in creds {
-                auth_provider.set_docker_credentials(host, docker_credentials);
-            }
-        }
-        let auth = moby::filesync::v1::auth_server::AuthServer::new(auth_provider);
+//         let filesend = moby::filesync::v1::file_send_server::FileSendServer::new(
+//             super::FileSendImpl::new(exporter_request.path.as_path()),
+//         );
 
-        let filesend = moby::filesync::v1::file_send_server::FileSendServer::new(
-            super::FileSendImpl::new(exporter_request.path.as_path()),
-        );
+//         let upload = moby::upload::v1::upload_server::UploadServer::new(upload_provider);
 
-        let upload = moby::upload::v1::upload_server::UploadServer::new(upload_provider);
+//         let services: Vec<super::GrpcServer> = vec![
+//             super::GrpcServer::Auth(auth),
+//             super::GrpcServer::FileSend(filesend),
+//             super::GrpcServer::Upload(upload),
+//         ];
 
-        let services: Vec<super::GrpcServer> = vec![
-            super::GrpcServer::Auth(auth),
-            super::GrpcServer::FileSend(filesend),
-            super::GrpcServer::Upload(upload),
-        ];
+//         let mut control_client =
+//             crate::grpc::driver::Driver::grpc_handle(driver, session_id, services).await?;
 
-        let mut control_client = driver.grpc_handle(session_id, services).await?;
+//         let id = super::new_id();
 
-        let id = super::new_id();
+// let solve_request = moby::buildkit::v1::SolveRequest {
+//     r#ref: id,
+//     cache: None,
+//     definition: None,
+//     entitlements: vec![],
+//     exporter: String::from("oci"),
+//     exporter_attrs,
+//     frontend: String::from("dockerfile.v0"),
+//     frontend_attrs,
+//     frontend_inputs: HashMap::new(),
+//     session: String::from(session_id),
+// };
 
-        let solve_request = moby::buildkit::v1::SolveRequest {
-            r#ref: id,
-            cache: None,
-            definition: None,
-            entitlements: vec![],
-            exporter: String::from("oci"),
-            exporter_attrs,
-            frontend: String::from("dockerfile.v0"),
-            frontend_attrs,
-            frontend_inputs: HashMap::new(),
-            session: String::from(session_id),
-        };
+//         debug!("sending solve request: {:#?}", solve_request);
+//         let res = control_client.solve(solve_request).await;
+//         debug!("solve res: {:#?}", res);
 
-        debug!("sending solve request: {:#?}", solve_request);
-        let res = control_client.solve(solve_request).await;
-        debug!("solve res: {:#?}", res);
+//         // clean up
+//         let kill = self
+//             .kill_container(&buildkit_name, None::<KillContainerOptions<String>>)
+//             .await;
 
-        // clean up
-        let kill = self
-            .kill_container(&buildkit_name, None::<KillContainerOptions<String>>)
-            .await;
+//         trace!("kill res: {:#?}", kill);
 
-        trace!("kill res: {:#?}", kill);
+//         res?;
+//         kill?;
 
-        res?;
-        kill?;
-
-        Ok(())
-    }
-}
+//         Ok(())
+//     }
+// }

--- a/src/grpc/mod.rs
+++ b/src/grpc/mod.rs
@@ -2,6 +2,8 @@
 #![cfg(feature = "buildkit")]
 #![allow(dead_code)]
 
+/// End-user buildkit build functions
+pub mod build;
 /// A package of GRPC buildkit connection implementations
 pub mod driver;
 /// Errors for the GRPC modules
@@ -10,6 +12,8 @@ pub mod error;
 pub mod export;
 /// Internal interfaces to convert types for GRPC communication
 pub(crate) mod io;
+/// End-user buildkit registry functions
+pub mod registry;
 
 use crate::auth::DockerCredentials;
 use crate::health::health_check_response::ServingStatus;
@@ -58,13 +62,17 @@ use self::io::GrpcTransport;
 
 /// A static dispatch wrapper for GRPC implementations to generated GRPC traits
 #[derive(Debug)]
-pub(crate) enum GrpcServer {
+pub enum GrpcServer {
+    /// TODO
     Auth(AuthServer<AuthProvider>),
+    /// TODO
     Upload(UploadServer<UploadProvider>),
+    /// TODO
     FileSend(FileSendServer<FileSendImpl>),
 }
 
 impl GrpcServer {
+    /// TODO
     pub fn append(
         self,
         builder: tonic::transport::server::Router,
@@ -76,6 +84,7 @@ impl GrpcServer {
         }
     }
 
+    /// TODO
     pub fn names(&self) -> Vec<String> {
         match self {
             GrpcServer::Auth(_auth_server) => {
@@ -147,12 +156,14 @@ impl Health for HealthServerImpl {
     }
 }
 
+/// TODO
 #[derive(Clone, Debug)]
-pub(crate) struct FileSendImpl {
+pub struct FileSendImpl {
     pub(crate) dest: PathBuf,
 }
 
 impl FileSendImpl {
+    /// TODO
     pub fn new(dest: &Path) -> Self {
         Self {
             dest: dest.to_owned(),
@@ -188,18 +199,21 @@ impl FileSend for FileSendImpl {
     }
 }
 
-#[derive(Debug)]
-pub(crate) struct UploadProvider {
+/// TODO
+#[derive(Default, Debug)]
+pub struct UploadProvider {
     pub(crate) store: HashMap<String, Vec<u8>>,
 }
 
 impl UploadProvider {
+    /// TODO
     pub fn new() -> Self {
         Self {
             store: HashMap::new(),
         }
     }
 
+    /// TODO
     pub fn add(&mut self, reader: Vec<u8>) -> String {
         let id = new_id();
         let key = format!("http://buildkit-session/{}", id);
@@ -238,10 +252,12 @@ impl Upload for UploadProvider {
     }
 }
 
+/// TODO
 #[derive(Debug, Default)]
-pub(crate) struct AuthProvider {
+pub struct AuthProvider {
     auth_config_cache: HashMap<String, DockerCredentials>,
     registry_token: Option<String>,
+    token_seeds: HashMap<String, Bytes>,
 }
 
 const DEFAULT_TOKEN_EXPIRATION: i64 = 60;
@@ -272,6 +288,7 @@ struct OAuthTokenResponse {
 }
 
 impl AuthProvider {
+    /// TODO
     pub fn new() -> Self {
         Self {
             ..Default::default()
@@ -482,7 +499,7 @@ impl Auth for AuthProvider {
         &self,
         _request: Request<GetTokenAuthorityRequest>,
     ) -> Result<Response<GetTokenAuthorityResponse>, Status> {
-        unimplemented!()
+        return Err(Status::unavailable("client-side authentication disabled"));
     }
 
     #[allow(clippy::diverging_sub_expression)]
@@ -490,7 +507,7 @@ impl Auth for AuthProvider {
         &self,
         _request: Request<VerifyTokenAuthorityRequest>,
     ) -> Result<Response<VerifyTokenAuthorityResponse>, Status> {
-        unimplemented!()
+        return Err(Status::unavailable("client-side authentication disabled"));
     }
 }
 

--- a/src/grpc/registry.rs
+++ b/src/grpc/registry.rs
@@ -1,0 +1,196 @@
+use std::collections::HashMap;
+
+use super::build::ImageBuildOutputCompression;
+
+/// TODO
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct ImageRegistryOutput {
+    pub(crate) name: String,
+    pub(crate) push: bool,
+    pub(crate) push_by_digest: bool,
+    pub(crate) insecure_registry: bool,
+    pub(crate) dangling_name_prefix: String,
+    pub(crate) name_canonical: bool,
+    pub(crate) compression: ImageBuildOutputCompression,
+    pub(crate) compression_level: Option<u8>,
+    pub(crate) force_compression: bool,
+    pub(crate) oci_mediatypes: bool,
+    pub(crate) unpack: bool,
+    pub(crate) store: bool,
+    pub(crate) annotation: HashMap<String, String>,
+}
+
+impl ImageRegistryOutput {
+    /// TODO
+    pub fn builder(name: &str) -> ImageRegistryOutputBuilder {
+        ImageRegistryOutputBuilder::new(name)
+    }
+
+    fn new(name: &str) -> Self {
+        Self {
+            name: String::from(name),
+            ..Default::default()
+        }
+    }
+
+    pub(crate) fn into_map(self) -> HashMap<String, String> {
+        let mut attrs = HashMap::new();
+
+        attrs.insert(String::from("name"), self.name);
+
+        attrs.insert(String::from("push"), self.push.to_string());
+
+        attrs.insert(
+            String::from("push-by-digest"),
+            self.push_by_digest.to_string(),
+        );
+
+        attrs.insert(
+            String::from("registry.insecure"),
+            self.insecure_registry.to_string(),
+        );
+
+        attrs.insert(
+            String::from("dangling_name_prefix"),
+            self.dangling_name_prefix,
+        );
+
+        attrs.insert(
+            String::from("name_canonical"),
+            self.name_canonical.to_string(),
+        );
+
+        attrs.insert(String::from("compression"), self.compression.to_string());
+
+        if let Some(compression_level) = self.compression_level {
+            attrs.insert(
+                String::from("compression-level"),
+                compression_level.to_string(),
+            );
+        }
+
+        attrs.insert(
+            String::from("force-compression"),
+            self.force_compression.to_string(),
+        );
+
+        attrs.insert(
+            String::from("oci-mediatypes"),
+            self.oci_mediatypes.to_string(),
+        );
+
+        attrs.insert(String::from("unpack"), self.unpack.to_string());
+
+        attrs.insert(String::from("store"), self.store.to_string());
+
+        for (key, value) in self.annotation {
+            attrs.insert(format!("annotation.{}", key), value);
+        }
+
+        attrs
+    }
+}
+
+/// TODO
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct ImageRegistryOutputBuilder {
+    inner: ImageRegistryOutput,
+}
+
+impl ImageRegistryOutputBuilder {
+    /// TODO
+    pub fn new(name: &str) -> Self {
+        Self {
+            inner: ImageRegistryOutput {
+                name: String::from(name),
+                ..Default::default()
+            },
+        }
+    }
+
+    /// TODO
+    pub fn push(mut self, push: bool) -> Self {
+        self.inner.push = push;
+        self
+    }
+
+    /// TODO
+    pub fn push_by_digest(mut self, push_by_digest: bool) -> Self {
+        self.inner.push_by_digest = push_by_digest;
+        self
+    }
+
+    /// TODO
+    pub fn insecure_registry(mut self, insecure_registry: bool) -> Self {
+        self.inner.insecure_registry = insecure_registry;
+        self
+    }
+
+    /// TODO
+    pub fn dangling_name_prefix(mut self, dangling_name_prefix: &str) -> Self {
+        self.inner.dangling_name_prefix = String::from(dangling_name_prefix);
+        self
+    }
+
+    /// TODO
+    pub fn name_canonical(mut self, name_canonical: bool) -> Self {
+        self.inner.name_canonical = name_canonical;
+        self
+    }
+
+    /// Compression type, see [buildkit compression
+    /// docs](https://docs.docker.com/build/exporters/#compression)
+    pub fn compression(mut self, compression: &ImageBuildOutputCompression) -> Self {
+        self.inner.compression = compression.to_owned();
+        self
+    }
+
+    /// Compression level, see [buildkit compression
+    /// docs](https://docs.docker.com/build/exporters/#compression)
+    pub fn compression_level(mut self, compression_level: u8) -> Self {
+        self.inner.compression_level = Some(compression_level);
+        self
+    }
+
+    /// Forcefully apply compression, see [buildkit compression
+    /// docs](https://docs.docker.com/build/exporters/#compression)
+    pub fn force_compression(mut self, force_compression: bool) -> Self {
+        self.inner.force_compression = force_compression;
+        self
+    }
+
+    /// Use OCI media types in exporter manifests. Defaults to `true` for `type=oci`, and `false`
+    /// for `type=docker`. See [buildkit OCI media types
+    /// docs](https://docs.docker.com/build/exporters/#oci-media-types)
+    pub fn oci_mediatypes(mut self, oci_mediatypes: bool) -> Self {
+        self.inner.oci_mediatypes = oci_mediatypes;
+        self
+    }
+
+    /// TODO
+    pub fn unpack(mut self, unpack: bool) -> Self {
+        self.inner.unpack = unpack;
+        self
+    }
+
+    /// TODO
+    pub fn store(mut self, store: bool) -> Self {
+        self.inner.store = store;
+        self
+    }
+
+    /// Attach an annotation with the respective `key` and `value` to the built image, see
+    /// [buildkit annotations
+    /// docs](https://docs.docker.com/build/exporters/oci-docker/#annotations)
+    pub fn annotation(mut self, key: &str, value: &str) -> Self {
+        self.inner
+            .annotation
+            .insert(String::from(key), String::from(value));
+        self
+    }
+
+    /// TODO
+    pub fn consume(self) -> ImageRegistryOutput {
+        self.inner
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -261,11 +261,15 @@
     missing_copy_implementations,
     trivial_casts,
     trivial_numeric_casts,
-    unstable_features,
+    //unstable_features,
     unused_import_braces,
     unused_qualifications
 )]
-#![allow(clippy::upper_case_acronyms, clippy::derive_partial_eq_without_eq)]
+#![allow(
+    clippy::upper_case_acronyms,
+    clippy::derive_partial_eq_without_eq,
+    async_fn_in_trait
+)]
 #![warn(rust_2018_idioms)]
 
 // declare modules

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -289,7 +289,7 @@ pub async fn create_image_hello_world(docker: &Docker) -> Result<(), Error> {
         .await?;
 
     assert_eq!(
-        result.get(0).unwrap().id.as_ref().unwrap(),
+        result.first().unwrap().id.as_ref().unwrap(),
         if cfg!(windows) { "nanoserver" } else { "linux" }
     );
 

--- a/tests/container_test.rs
+++ b/tests/container_test.rs
@@ -254,7 +254,7 @@ async fn stats_test(docker: Docker) -> Result<(), Error> {
         .try_collect::<Vec<_>>()
         .await?;
 
-    let value = vec.get(0);
+    let value = vec.first();
 
     assert_eq!(value.unwrap().name, "/integration_test_stats".to_string());
     kill_container(&docker, "integration_test_stats")

--- a/tests/image_test.rs
+++ b/tests/image_test.rs
@@ -284,7 +284,7 @@ async fn commit_container_test(docker: Docker) -> Result<(), Error> {
         .try_collect::<Vec<_>>()
         .await?;
 
-    let first = vec.get(0).unwrap();
+    let first = vec.first().unwrap();
     if let Some(error) = &first.error {
         println!("{}", error.message.as_ref().unwrap());
     }
@@ -402,7 +402,7 @@ RUN touch bollard.txt
         .try_collect::<Vec<_>>()
         .await?;
 
-    let first = vec.get(0).unwrap();
+    let first = vec.first().unwrap();
     if let Some(error) = &first.error {
         println!("{}", error.message.as_ref().unwrap());
     }
@@ -520,7 +520,7 @@ ENTRYPOINT ls buildkit-bollard.txt
         .try_collect::<Vec<_>>()
         .await?;
 
-    let first = vec.get(0).unwrap();
+    let first = vec.first().unwrap();
     if let Some(error) = &first.error {
         println!("{}", error.message.as_ref().unwrap());
     }
@@ -584,6 +584,127 @@ ENTRYPOINT ls buildkit-bollard.txt
     assert!(build.is_err());
     let err = build.as_ref().unwrap_err();
     assert!(matches!(err, Error::MissingSessionBuildkitError {}));
+
+    Ok(())
+}
+
+#[cfg(feature = "buildkit")]
+async fn build_buildkit_image_inline_driver_test(docker: Docker) -> Result<(), Error> {
+    let dockerfile = String::from(
+        "FROM localhost:5000/alpine as builder1
+RUN touch bollard.txt
+FROM localhost:5000/alpine as builder2
+RUN --mount=type=bind,from=builder1,target=mnt cp mnt/bollard.txt buildkit-bollard.txt
+ENTRYPOINT ls buildkit-bollard.txt
+",
+    );
+    let mut header = tar::Header::new_gnu();
+    header.set_path("Dockerfile").unwrap();
+    header.set_size(dockerfile.len() as u64);
+    header.set_mode(0o755);
+    header.set_cksum();
+    let mut tar = tar::Builder::new(Vec::new());
+    tar.append(&header, dockerfile.as_bytes()).unwrap();
+
+    let uncompressed = tar.into_inner().unwrap();
+    let mut c = flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::default());
+    c.write_all(&uncompressed).unwrap();
+    let compressed = c.finish().unwrap();
+
+    let name = "integration_test_build_buildkit_image_inline_driver";
+
+    let credentials = bollard::auth::DockerCredentials {
+        username: Some("bollard".to_string()),
+        password: std::env::var("REGISTRY_PASSWORD").ok(),
+        ..Default::default()
+    };
+    let mut creds_hsh = std::collections::HashMap::new();
+    creds_hsh.insert("localhost:5000".to_string(), credentials);
+
+    let cache_attrs = std::collections::HashMap::new();
+    let cache_from = bollard_buildkit_proto::moby::buildkit::v1::CacheOptionsEntry {
+        r#type: String::from("inline"),
+        attrs: std::collections::HashMap::clone(&cache_attrs),
+    };
+    let cache_to = bollard_buildkit_proto::moby::buildkit::v1::CacheOptionsEntry {
+        r#type: String::from("inline"),
+        attrs: cache_attrs,
+    };
+    let frontend_opts = bollard::grpc::build::ImageBuildFrontendOptions::builder()
+        .cachefrom(&cache_from)
+        .cacheto(&cache_to)
+        .pull(true)
+        .build();
+
+    let driver = bollard::grpc::driver::moby::Moby::new(&docker);
+
+    let load_input =
+        bollard::grpc::build::ImageBuildLoadInput::Upload(bytes::Bytes::from(compressed));
+
+    let credentials = bollard::auth::DockerCredentials {
+        username: Some("bollard".to_string()),
+        password: std::env::var("REGISTRY_PASSWORD").ok(),
+        ..Default::default()
+    };
+    let mut creds_hsh = std::collections::HashMap::new();
+    creds_hsh.insert("localhost:5000", credentials);
+
+    let res = bollard::grpc::driver::Build::docker_build(
+        driver,
+        name,
+        frontend_opts,
+        load_input,
+        Some(creds_hsh),
+    )
+    .await;
+
+    assert!(res.is_ok());
+
+    let _ = &docker
+        .create_container(
+            Some(CreateContainerOptions {
+                name: "integration_test_build_buildkit_image_inline_driver",
+                platform: None,
+            }),
+            Config {
+                image: Some("integration_test_build_buildkit_image_inline_driver"),
+                cmd: Some(vec!["ls", "/buildkit-bollard.txt"]),
+                ..Default::default()
+            },
+        )
+        .await?;
+
+    let _ = &docker
+        .start_container(
+            "integration_test_build_buildkit_image_inline_driver",
+            None::<StartContainerOptions<String>>,
+        )
+        .await?;
+
+    let vec = &docker
+        .wait_container(
+            "integration_test_build_buildkit_image_inline_driver",
+            None::<WaitContainerOptions<String>>,
+        )
+        .try_collect::<Vec<_>>()
+        .await?;
+
+    let first = vec.first().unwrap();
+    if let Some(error) = &first.error {
+        println!("{}", error.message.as_ref().unwrap());
+    }
+    assert_eq!(first.status_code, 0);
+    let _ = &docker
+        .remove_container("integration_test_build_buildkit_image_inline_driver", None)
+        .await?;
+
+    let _ = &docker
+        .remove_image(
+            "integration_test_build_buildkit_image_inline_driver",
+            None::<RemoveImageOptions>,
+            None,
+        )
+        .await?;
 
     Ok(())
 }
@@ -825,6 +946,12 @@ fn integration_test_build_buildkit_image() {
 #[cfg(feature = "buildkit")]
 fn integration_test_buildkit_image_missing_session_test() {
     connect_to_docker_and_run!(buildkit_image_missing_session_test);
+}
+
+#[test]
+#[cfg(feature = "buildkit")]
+fn integration_test_build_buildkit_inline_driver() {
+    connect_to_docker_and_run!(build_buildkit_image_inline_driver_test);
 }
 
 #[test]

--- a/tests/network_test.rs
+++ b/tests/network_test.rs
@@ -102,7 +102,7 @@ async fn list_networks_test(docker: Docker) -> Result<(), Error> {
         }))
         .await?;
 
-    let v = results.get(0).unwrap();
+    let v = results.first().unwrap();
 
     assert!(v
         .ipam


### PR DESCRIPTION
This should open the door to adding the `cache-from` and `cache-to` options to allow [remote cache backends](https://docs.docker.com/build/cache/backends/).

This is currently blocked on a nightly feature ([async in trait](https://rust-lang.github.io/rfcs/3185-static-async-fn-in-trait.html)), which should stabilize in the upcoming release in ~mid-November~ [end December](https://releases.rs/docs/1.75.0/).