### PR TITLE
give stats object name & id fields a default empty string

### DIFF
--- a/src/container.rs
+++ b/src/container.rs
@@ -749,6 +749,10 @@ pub struct StorageStats {
     pub write_size_bytes: Option<u64>,
 }
 
+fn empty_string() -> String {
+    "".to_string()
+}
+
 /// Statistics for the container.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[allow(missing_docs)]
@@ -782,10 +786,11 @@ pub struct Stats {
     pub cpu_stats: CPUStats,
     pub precpu_stats: CPUStats,
     pub storage_stats: StorageStats,
+    #[serde(default = "empty_string")]
     pub name: String,
 
     // Podman incorrectly capitalises the "id" field. See https://github.com/containers/podman/issues/17869
-    #[serde(alias = "Id")]
+    #[serde(alias = "Id", default = "empty_string")]
     pub id: String,
 }
 


### PR DESCRIPTION
This fixes #346 - an issue with the latest Docker `24.0.7` where the `name` and `id` fields in the stats object are omitted for one-shot stats collection. This change seems to be the least disruptive, but may potentially cause problems for folks who rely on getting an Error when `name` or `id` is missing. (Not sure how common that would be.)

Another option would be making `name` and `id` both `Option<String>`s, but that would be a breaking change.

Thoughts?

**UPDATE:**

I've revised this PR description and the associated issue to reflect that the `id` field is also missing from the stats object when collecting one-shot stats.

