### PR TITLE
Add `schemars::JsonSchema` behind feature-gate `schemars` to derive JSON-schemas

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ ssl = ["home", "hyper-rustls", "rustls", "rustls-native-certs", "rustls-pemfile"
 ct_logs = ["ssl", "ct-logs"]
 chrono = ["dep:chrono", "bollard-stubs/chrono"]
 time = ["dep:time", "bollard-stubs/time"]
+schemars = ["dep:schemars", "bollard-stubs/schemars"]
 
 [dependencies]
 base64 = "0.21"
@@ -56,6 +57,7 @@ rand = { version = "0.8", optional = true }
 rustls = { version = "0.21", optional = true, features = ["dangerous_configuration"] }
 rustls-native-certs = { version = "0.6.0", optional = true }
 rustls-pemfile = { version = "1.0", optional = true }
+schemars = { version = "0.8", optional = true }
 serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"

--- a/codegen/swagger/Cargo.toml
+++ b/codegen/swagger/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2021"
 
 [features]
 buildkit = ["base64", "bytes", "bollard-buildkit-proto", "prost"]
+schemars = ["dep:schemars"]
 
 [dependencies]
 base64 = { version = "0.21", optional = true }
@@ -17,6 +18,7 @@ chrono = { version = "0.4", default-features = false, features = ["std", "clock"
 serde = { version = "1.0", features = ["derive"] }
 prost = { version = "0.12", optional = true }
 time = { version = "0.3", features = ["formatting", "parsing"], optional = true }
+schemars = { version = "0.8", optional = true }
 
 serde_with = {version = "3.0", default-features = false, features = ["std"]}
 serde_repr = "0.1"

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -3,6 +3,7 @@
 use base64::{engine::general_purpose::STANDARD, Engine};
 
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[allow(missing_docs)]
 /// DockerCredentials credentials and server URI to push images using the [Push Image
 /// API](crate::Docker::push_image()) or the [Build Image

--- a/src/container.rs
+++ b/src/container.rs
@@ -49,6 +49,7 @@ use crate::read::NewlineLogOutputDecoder;
 /// };
 /// ```
 #[derive(Debug, Clone, Default, PartialEq, Serialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct ListContainersOptions<T>
 where
     T: Into<String> + Eq + Hash + Serialize,
@@ -92,6 +93,7 @@ where
 /// };
 /// ```
 #[derive(Debug, Clone, Default, PartialEq, Serialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct CreateContainerOptions<T>
 where
     T: Into<String> + Serialize,
@@ -107,6 +109,7 @@ where
 
 /// This container's networking configuration.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[serde(rename_all = "PascalCase")]
 #[allow(missing_docs)]
 pub struct NetworkingConfig<T: Into<String> + Hash + Eq> {
@@ -115,6 +118,7 @@ pub struct NetworkingConfig<T: Into<String> + Hash + Eq> {
 
 /// Container to create.
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct Config<T>
 where
     T: Into<String> + Eq + Hash,
@@ -300,6 +304,7 @@ impl From<ContainerConfig> for Config<String> {
 ///     t: 30,
 /// };
 #[derive(Debug, Copy, Clone, Default, PartialEq, Serialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct StopContainerOptions {
     /// Number of seconds to wait before killing the container
     pub t: i64,
@@ -317,6 +322,7 @@ pub struct StopContainerOptions {
 /// };
 /// ```
 #[derive(Debug, Clone, Default, PartialEq, Serialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[serde(rename_all = "camelCase")]
 pub struct StartContainerOptions<T>
 where
@@ -342,6 +348,7 @@ where
 /// };
 /// ```
 #[derive(Debug, Copy, Clone, Default, PartialEq, Serialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct RemoveContainerOptions {
     /// Remove the volumes associated with the container.
     pub v: bool,
@@ -363,6 +370,7 @@ pub struct RemoveContainerOptions {
 /// };
 /// ```
 #[derive(Debug, Clone, Default, PartialEq, Serialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct WaitContainerOptions<T>
 where
     T: Into<String> + Serialize,
@@ -403,6 +411,7 @@ impl fmt::Debug for AttachContainerResults {
 /// };
 /// ```
 #[derive(Debug, Copy, Clone, Default, PartialEq, Serialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct AttachContainerOptions<T>
 where
     T: Into<String> + Serialize + Default,
@@ -438,6 +447,7 @@ where
 /// };
 /// ```
 #[derive(Debug, Copy, Clone, Default, PartialEq, Serialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct ResizeContainerTtyOptions {
     /// Width of the TTY session in characters
     #[serde(rename = "w")]
@@ -459,6 +469,7 @@ pub struct ResizeContainerTtyOptions {
 /// };
 /// ```
 #[derive(Debug, Copy, Clone, Default, PartialEq, Serialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct RestartContainerOptions {
     /// Number of seconds to wait before killing the container.
     pub t: isize,
@@ -476,6 +487,7 @@ pub struct RestartContainerOptions {
 /// };
 /// ```
 #[derive(Debug, Copy, Clone, Default, PartialEq, Serialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct InspectContainerOptions {
     /// Return the size of container as fields `SizeRw` and `SizeRootFs`
     pub size: bool,
@@ -493,6 +505,7 @@ pub struct InspectContainerOptions {
 /// };
 /// ```
 #[derive(Debug, Clone, Default, PartialEq, Serialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct TopOptions<T>
 where
     T: Into<String> + Serialize,
@@ -520,6 +533,7 @@ fn is_zero(val: &i64) -> bool {
 /// };
 /// ```
 #[derive(Debug, Clone, Default, PartialEq, Serialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct LogsOptions<T>
 where
     T: Into<String> + Serialize,
@@ -601,6 +615,7 @@ impl LogOutput {
 /// };
 /// ```
 #[derive(Debug, Copy, Clone, Default, PartialEq, Serialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct StatsOptions {
     /// Stream the output. If false, the stats will be output once and then it will disconnect.
     pub stream: bool,
@@ -611,6 +626,7 @@ pub struct StatsOptions {
 
 /// Granular memory statistics for the container.
 #[derive(Debug, Copy, Clone, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[allow(missing_docs)]
 #[serde(untagged)]
 pub enum MemoryStatsStats {
@@ -622,6 +638,7 @@ pub enum MemoryStatsStats {
 ///
 /// Exposed in the docker library [here](https://github.com/moby/moby/blob/40d9e2aff130b42ba0f83d5238b9b53184c8ab3b/daemon/daemon_unix.go#L1436).
 #[derive(Debug, Copy, Clone, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[allow(missing_docs)]
 #[serde(deny_unknown_fields)]
 pub struct MemoryStatsStatsV1 {
@@ -665,6 +682,7 @@ pub struct MemoryStatsStatsV1 {
 ///
 /// Exposed in the docker library [here](https://github.com/moby/moby/blob/40d9e2aff130b42ba0f83d5238b9b53184c8ab3b/daemon/daemon_unix.go#L1542).
 #[derive(Debug, Copy, Clone, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[allow(missing_docs)]
 #[serde(deny_unknown_fields)]
 pub struct MemoryStatsStatsV2 {
@@ -703,6 +721,7 @@ pub struct MemoryStatsStatsV2 {
 
 /// General memory statistics for the container.
 #[derive(Debug, Copy, Clone, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[allow(missing_docs)]
 pub struct MemoryStats {
     pub stats: Option<MemoryStatsStats>,
@@ -719,6 +738,7 @@ pub struct MemoryStats {
 
 /// Process ID statistics for the container.
 #[derive(Debug, Copy, Clone, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[allow(missing_docs)]
 pub struct PidsStats {
     pub current: Option<u64>,
@@ -727,6 +747,7 @@ pub struct PidsStats {
 
 /// I/O statistics for the container.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[allow(missing_docs)]
 pub struct BlkioStats {
     pub io_service_bytes_recursive: Option<Vec<BlkioStatsEntry>>,
@@ -741,6 +762,7 @@ pub struct BlkioStats {
 
 /// File I/O statistics for the container.
 #[derive(Debug, Copy, Clone, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[allow(missing_docs)]
 pub struct StorageStats {
     pub read_count_normalized: Option<u64>,
@@ -755,6 +777,7 @@ fn empty_string() -> String {
 
 /// Statistics for the container.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[allow(missing_docs)]
 pub struct Stats {
     #[cfg(feature = "time")]
@@ -762,20 +785,26 @@ pub struct Stats {
         deserialize_with = "crate::docker::deserialize_rfc3339",
         serialize_with = "crate::docker::serialize_rfc3339"
     )]
+    #[cfg_attr(feature = "schemars", schemars(with = "Rfc3339"))]
     pub read: time::OffsetDateTime,
     #[cfg(feature = "time")]
     #[serde(
         deserialize_with = "crate::docker::deserialize_rfc3339",
         serialize_with = "crate::docker::serialize_rfc3339"
     )]
+    #[cfg_attr(feature = "schemars", schemars(with = "Rfc3339"))]
     pub preread: time::OffsetDateTime,
     #[cfg(all(feature = "chrono", not(feature = "time")))]
+    #[cfg_attr(feature = "schemars", schemars(with = "Rfc3339"))]
     pub read: chrono::DateTime<chrono::Utc>,
     #[cfg(all(feature = "chrono", not(feature = "time")))]
+    #[cfg_attr(feature = "schemars", schemars(with = "Rfc3339"))]
     pub preread: chrono::DateTime<chrono::Utc>,
     #[cfg(not(any(feature = "chrono", feature = "time")))]
+    #[cfg_attr(feature = "schemars", schemars(with = "Rfc3339"))]
     pub read: String,
     #[cfg(not(any(feature = "chrono", feature = "time")))]
+    #[cfg_attr(feature = "schemars", schemars(with = "Rfc3339"))]
     pub preread: String,
     pub num_procs: u32,
     pub pids_stats: PidsStats,
@@ -796,6 +825,7 @@ pub struct Stats {
 
 /// Network statistics for the container.
 #[derive(Debug, Copy, Clone, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[allow(missing_docs)]
 pub struct NetworkStats {
     pub rx_dropped: u64,
@@ -810,6 +840,7 @@ pub struct NetworkStats {
 
 /// CPU usage statistics for the container.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[allow(missing_docs)]
 pub struct CPUUsage {
     pub percpu_usage: Option<Vec<u64>>,
@@ -820,6 +851,7 @@ pub struct CPUUsage {
 
 /// CPU throttling statistics.
 #[derive(Debug, Copy, Clone, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[allow(missing_docs)]
 pub struct ThrottlingData {
     pub periods: u64,
@@ -829,6 +861,7 @@ pub struct ThrottlingData {
 
 /// General CPU statistics for the container.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[allow(missing_docs)]
 pub struct CPUStats {
     pub cpu_usage: CPUUsage,
@@ -838,6 +871,7 @@ pub struct CPUStats {
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[allow(missing_docs)]
 pub struct BlkioStatsEntry {
     pub major: u64,
@@ -858,6 +892,7 @@ pub struct BlkioStatsEntry {
 /// };
 /// ```
 #[derive(Debug, Clone, Default, PartialEq, Serialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct KillContainerOptions<T>
 where
     T: Into<String> + Serialize,
@@ -881,6 +916,7 @@ where
 /// };
 /// ```
 #[derive(Debug, Clone, Default, PartialEq, Serialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[serde(rename_all = "PascalCase")]
 pub struct UpdateContainerOptions<T>
 where
@@ -1065,6 +1101,7 @@ where
 /// };
 /// ```
 #[derive(Debug, Clone, Default, PartialEq, Serialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct RenameContainerOptions<T>
 where
     T: Into<String> + Serialize,
@@ -1090,6 +1127,7 @@ where
 /// };
 /// ```
 #[derive(Debug, Clone, Default, PartialEq, Serialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct PruneContainersOptions<T>
 where
     T: Into<String> + Eq + Hash + Serialize,
@@ -1119,6 +1157,7 @@ where
 /// };
 /// ```
 #[derive(Debug, Clone, Default, PartialEq, Serialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[serde(rename_all = "camelCase")]
 pub struct UploadToContainerOptions<T>
 where
@@ -1144,6 +1183,7 @@ where
 /// };
 /// ```
 #[derive(Debug, Clone, Default, PartialEq, Serialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct DownloadFromContainerOptions<T>
 where
     T: Into<String> + Serialize,

--- a/src/docker.rs
+++ b/src/docker.rs
@@ -284,6 +284,7 @@ impl Clone for Docker {
 
 /// Internal model: Docker Server JSON payload when an error is emitted
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 struct DockerServerErrorMessage {
     message: String,
 }

--- a/src/exec.rs
+++ b/src/exec.rs
@@ -21,6 +21,7 @@ use tokio_util::codec::FramedRead;
 
 /// Exec configuration used in the [Create Exec API](Docker::create_exec())
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[serde(rename_all = "PascalCase")]
 pub struct CreateExecOptions<T>
 where
@@ -52,6 +53,7 @@ where
 
 /// Result type for the [Create Exec API](Docker::create_exec())
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[serde(rename_all = "PascalCase")]
 #[allow(missing_docs)]
 pub struct CreateExecResults {
@@ -60,6 +62,7 @@ pub struct CreateExecResults {
 
 /// Exec configuration used in the [Create Exec API](Docker::create_exec())
 #[derive(Debug, Clone, Copy, Default, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[serde(rename_all = "PascalCase")]
 pub struct StartExecOptions {
     /// Detach from the command.
@@ -91,6 +94,7 @@ impl Debug for StartExecResults {
 
 /// Resize configuration used in the [Resize Exec API](Docker::resize_exec())
 #[derive(Debug, Clone, Copy, Default, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[serde(rename_all = "PascalCase")]
 pub struct ResizeExecOptions {
     /// Height of the TTY session in characters

--- a/src/grpc/mod.rs
+++ b/src/grpc/mod.rs
@@ -254,10 +254,12 @@ struct TokenOptions {
 }
 
 #[derive(Debug, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 struct OAuthTokenResponse {
     access_token: String,
     refresh_token: String,
     expires_in: i64,
+    #[cfg_attr(feature = "schemars", schemars(with = "crate::models::Rfc3339"))]
     issued_at: chrono::DateTime<chrono::Utc>,
     scope: String,
 }

--- a/src/image.rs
+++ b/src/image.rs
@@ -46,6 +46,7 @@ use std::hash::Hash;
 /// };
 /// ```
 #[derive(Debug, Clone, Default, PartialEq, Serialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[serde(rename_all = "camelCase")]
 pub struct CreateImageOptions<'a, T>
 where
@@ -102,6 +103,7 @@ where
 /// ```
 ///
 #[derive(Debug, Clone, Default, PartialEq, Serialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct ListImagesOptions<T>
 where
     T: Into<String> + Eq + Hash + Serialize,
@@ -146,6 +148,7 @@ where
 /// ```
 ///
 #[derive(Debug, Clone, Default, PartialEq, Serialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct PruneImagesOptions<T>
 where
     T: Into<String> + Eq + Hash + Serialize,
@@ -190,6 +193,7 @@ where
 /// };
 /// ```
 #[derive(Debug, Clone, Default, PartialEq, Serialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct SearchImagesOptions<T>
 where
     T: Into<String> + Eq + Hash + Serialize,
@@ -220,6 +224,7 @@ where
 /// };
 /// ```
 #[derive(Debug, Copy, Clone, Default, PartialEq, Serialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct RemoveImageOptions {
     /// Remove the image even if it is being used by stopped containers or has other tags.
     pub force: bool,
@@ -249,6 +254,7 @@ pub struct RemoveImageOptions {
 /// };
 /// ```
 #[derive(Debug, Clone, Default, PartialEq, Serialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct TagImageOptions<T>
 where
     T: Into<String> + Serialize,
@@ -279,6 +285,7 @@ where
 /// };
 /// ```
 #[derive(Debug, Clone, Default, PartialEq, Serialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct PushImageOptions<T>
 where
     T: Into<String> + Serialize,
@@ -309,6 +316,7 @@ where
 /// };
 /// ```
 #[derive(Debug, Clone, Default, PartialEq, Serialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct CommitContainerOptions<T>
 where
     T: Into<String> + Serialize,
@@ -351,6 +359,7 @@ where
 /// };
 /// ```
 #[derive(Debug, Clone, Default, PartialEq, Serialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct BuildImageOptions<T>
 where
     T: Into<String> + Eq + Hash + Serialize,
@@ -423,6 +432,7 @@ where
 #[cfg(feature = "buildkit")]
 /// Buildkit Image Output configuration: <https://docs.docker.com/build/exporters/oci-docker/>
 #[derive(Debug, Clone, Default, PartialEq, Serialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct ImageBuildOutput<T>
 where
     T: Into<String> + Eq + Hash + Serialize,
@@ -437,6 +447,7 @@ where
 
 /// Builder Version to use
 #[derive(Clone, Copy, Debug, PartialEq, Serialize_repr)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[repr(u8)]
 #[derive(Default)]
 pub enum BuilderVersion {
@@ -466,6 +477,7 @@ enum ImageBuildBuildkitEither {
 /// };
 /// ```
 #[derive(Debug, Copy, Clone, Default, PartialEq, Serialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct ImportImageOptions {
     /// Suppress progress details during load.
     pub quiet: bool,
@@ -1470,7 +1482,7 @@ mod tests {
     async fn test_build_image_with_error() {
         let mut connector = HostToReplyConnector::default();
         connector.m.insert(
-            String::from("http://127.0.0.1"), 
+            String::from("http://127.0.0.1"),
             "HTTP/1.1 200 OK\r\nServer:mock1\r\nContent-Type:application/json\r\n\r\n{\"stream\":\"Step 1/2 : FROM alpine\"}\n{\"stream\":\"\n\"}\n{\"status\":\"Pulling from library/alpine\",\"id\":\"latest\"}\n{\"status\":\"Digest: sha256:bc41182d7ef5ffc53a40b044e725193bc10142a1243f395ee852a8d9730fc2ad\"}\n{\"status\":\"Status: Image is up to date for alpine:latest\"}\n{\"stream\":\" --- 9c6f07244728\\n\"}\n{\"stream\":\"Step 2/2 : RUN cmd.exe /C copy nul bollard.txt\"}\n{\"stream\":\"\\n\"}\n{\"stream\":\" --- Running in d615794caf91\\n\"}\n{\"stream\":\"/bin/sh: cmd.exe: not found\\n\"}\n{\"errorDetail\":{\"code\":127,\"message\":\"The command '/bin/sh -c cmd.exe /C copy nul bollard.txt' returned a non-zero code: 127\"},\"error\":\"The command '/bin/sh -c cmd.exe /C copy nul bollard.txt' returned a non-zero code: 127\"}".to_string());
         let docker =
             Docker::connect_with_mock(connector, "127.0.0.1".to_string(), 5, API_DEFAULT_VERSION)

--- a/src/network.rs
+++ b/src/network.rs
@@ -15,6 +15,7 @@ use crate::models::*;
 
 /// Network configuration used in the [Create Network API](Docker::create_network())
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[serde(rename_all = "PascalCase")]
 pub struct CreateNetworkOptions<T>
 where
@@ -69,6 +70,7 @@ where
 /// };
 /// ```
 #[derive(Debug, Clone, Default, PartialEq, Serialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct InspectNetworkOptions<T>
 where
     T: Into<String> + Serialize,
@@ -105,6 +107,7 @@ where
 /// };
 /// ```
 #[derive(Debug, Clone, Default, PartialEq, Serialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct ListNetworksOptions<T>
 where
     T: Into<String> + Eq + Hash + Serialize,
@@ -122,6 +125,7 @@ where
 
 /// Network configuration used in the [Connect Network API](Docker::connect_network())
 #[derive(Debug, Clone, Default, PartialEq, Serialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[serde(rename_all = "PascalCase")]
 pub struct ConnectNetworkOptions<T>
 where
@@ -135,6 +139,7 @@ where
 
 /// Network configuration used in the [Disconnect Network API](Docker::disconnect_network())
 #[derive(Debug, Clone, Default, PartialEq, Serialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[serde(rename_all = "PascalCase")]
 pub struct DisconnectNetworkOptions<T>
 where
@@ -172,6 +177,7 @@ where
 /// };
 /// ```
 #[derive(Debug, Clone, Default, PartialEq, Serialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct PruneNetworksOptions<T>
 where
     T: Into<String> + Eq + Hash + Serialize,

--- a/src/secret.rs
+++ b/src/secret.rs
@@ -33,6 +33,7 @@ use std::{collections::HashMap, hash::Hash};
 /// let options: ListSecretsOptions<&str> = Default::default();
 /// ```
 #[derive(Debug, Clone, Default, PartialEq, Serialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct ListSecretsOptions<T>
 where
     T: Into<String> + Eq + Hash + Serialize,
@@ -59,6 +60,7 @@ where
 /// };
 /// ```
 #[derive(Debug, Copy, Clone, Default, PartialEq, Serialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct UpdateSecretOptions {
     /// The version number of the secret object being updated. This is required to avoid conflicting writes. This version number should be the value as currently set on the secret before the update.
     pub version: u64,

--- a/src/service.rs
+++ b/src/service.rs
@@ -36,6 +36,7 @@ use std::{collections::HashMap, hash::Hash};
 /// let options: ListServicesOptions<&str> = Default::default();
 /// ```
 #[derive(Debug, Clone, Default, PartialEq, Serialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct ListServicesOptions<T>
 where
     T: Into<String> + Eq + Hash + Serialize,
@@ -61,6 +62,7 @@ where
 /// };
 /// ```
 #[derive(Debug, Copy, Clone, Default, PartialEq, Serialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[serde(rename_all = "camelCase")]
 pub struct InspectServiceOptions {
     /// Fill empty fields with default values.
@@ -80,6 +82,7 @@ pub struct InspectServiceOptions {
 /// };
 /// ```
 #[derive(Debug, Copy, Clone, Default, PartialEq, Serialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[serde(rename_all = "camelCase")]
 pub struct UpdateServiceOptions {
     /// The version number of the service object being updated. This is required to avoid conflicting writes. This version number should be the value as currently set on the service before the update.

--- a/src/system.rs
+++ b/src/system.rs
@@ -15,6 +15,7 @@ use crate::models::*;
 
 /// Response of Engine API: GET \"/version\"
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[allow(missing_docs)]
 pub struct Version {
     #[serde(rename = "Platform")]
@@ -81,6 +82,7 @@ pub struct Version {
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[allow(missing_docs)]
 pub struct VersionComponents {
     /// Name of the component
@@ -115,6 +117,7 @@ pub struct VersionComponents {
 /// # }
 /// ```
 #[derive(Debug, Default, Clone, PartialEq, Serialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct EventsOptions<T>
 where
     T: Into<String> + Eq + Hash + Serialize,
@@ -122,24 +125,30 @@ where
     /// Show events created since this timestamp then stream new events.
     #[cfg(all(feature = "chrono", not(feature = "time")))]
     #[serde(serialize_with = "crate::docker::serialize_as_timestamp")]
+    #[cfg_attr(feature = "schemars", schemars(with = "Option<Rfc3339>"))]
     pub since: Option<chrono::DateTime<chrono::Utc>>,
     /// Show events created until this timestamp then stop streaming.
     #[cfg(all(feature = "chrono", not(feature = "time")))]
     #[serde(serialize_with = "crate::docker::serialize_as_timestamp")]
+    #[cfg_attr(feature = "schemars", schemars(with = "Option<Rfc3339>"))]
     pub until: Option<chrono::DateTime<chrono::Utc>>,
     /// Show events created since this timestamp then stream new events.
     #[cfg(feature = "time")]
     #[serde(serialize_with = "crate::docker::serialize_as_timestamp")]
+    #[cfg_attr(feature = "schemars", schemars(with = "Option<Rfc3339>"))]
     pub since: Option<time::OffsetDateTime>,
     /// Show events created until this timestamp then stop streaming.
     #[cfg(feature = "time")]
     #[serde(serialize_with = "crate::docker::serialize_as_timestamp")]
+    #[cfg_attr(feature = "schemars", schemars(with = "Option<Rfc3339>"))]
     pub until: Option<time::OffsetDateTime>,
     /// Show events created since this timestamp then stream new events.
     #[cfg(not(any(feature = "time", feature = "chrono")))]
+    #[cfg_attr(feature = "schemars", schemars(with = "Option<Rfc3339>"))]
     pub since: Option<String>,
     /// Show events created until this timestamp then stop streaming.
     #[cfg(not(any(feature = "time", feature = "chrono")))]
+    #[cfg_attr(feature = "schemars", schemars(with = "Option<Rfc3339>"))]
     pub until: Option<String>,
     /// A JSON encoded value of filters (a `map[string][]string`) to process on the event list. Available filters:
     ///  - `config=<string>` config name or ID

--- a/src/volume.rs
+++ b/src/volume.rs
@@ -14,6 +14,7 @@ use crate::models::*;
 
 /// Parameters used in the [List Volume API](Docker::list_volumes())
 #[derive(Debug, Clone, Default, PartialEq, Serialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct ListVolumesOptions<T>
 where
     T: Into<String> + Eq + Hash + Serialize,
@@ -30,6 +31,7 @@ where
 /// Volume configuration used in the [Create Volume
 /// API](Docker::create_volume())
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[serde(rename_all = "PascalCase")]
 pub struct CreateVolumeOptions<T>
 where
@@ -48,6 +50,7 @@ where
 
 /// Parameters used in the [Remove Volume API](super::Docker::remove_volume())
 #[derive(Debug, Clone, Copy, Default, PartialEq, Serialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[serde(rename_all = "camelCase")]
 pub struct RemoveVolumeOptions {
     /// Force the removal of the volume.
@@ -80,6 +83,7 @@ pub struct RemoveVolumeOptions {
 /// };
 /// ```
 #[derive(Debug, Clone, Default, PartialEq, Serialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct PruneVolumesOptions<T>
 where
     T: Into<String> + Eq + Hash + Serialize,


### PR DESCRIPTION
Outside the crate `schemars`, the trait `JsonSchema` can only implemented on owned types due to the orphan rule. So if `JsonSchema` is required to be implemented for a type in an API, e.g. `aide`, those types have to be basically copied and `#[derive(JsonSchema)]` as well as some serde-remote/wrapper-magic applied. This PR avoids all of this by optionally deriving `JsonSchema` if used with feature `schemars`.