### PR TITLE
Fix `winapi` error

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,7 +86,7 @@ hyperlocal =  { version = "0.8.0" }
 termion = "2.0"
 
 [target.'cfg(windows)'.dependencies]
-winapi = "0.3.9"
+winapi = { version = "0.3.9", features = ["winerror"] }
 
 [package.metadata.docs.rs]
 features = ["ssl"]


### PR DESCRIPTION
I get an error when running on Windows:

```
error[E0432]: unresolved import `winapi::shared::winerror`
```

Repro in this job:  https://github.com/bencherdev/bencher/actions/runs/7432835880/job/20225107491#step:8:443

The fix for this is simple, adding `winerror` as a feature for `winapi`.

Let me know if you would like for me to create a follow on PR to add Windows builds to CI.
