### PR TITLE
Add support for the docker /containers/{}/export API endpoint

### DIFF
--- a/src/container.rs
+++ b/src/container.rs
@@ -2234,6 +2234,35 @@ impl Docker {
 
         self.process_into_body(req)
     }
+
+    /// ---
+    ///
+    /// # Export Container
+    ///
+    /// Get a tarball containing the filesystem contents of a container.
+    ///
+    /// See the [Docker API documentation](https://docs.docker.com/engine/api/v1.40/#operation/ContainerExport)
+    /// for more information.
+    /// # Arguments
+    /// - The `container_name` string referring to an individual container
+    ///
+    /// # Returns
+    ///  - An uncompressed TAR archive
+    pub fn export_container(
+        &self,
+        container_name: &str,
+    ) -> impl Stream<Item = Result<Bytes, Error>> {
+        let url = format!("/containers/{container_name}/export");
+        let req = self.build_request(
+            &url,
+            Builder::new()
+                .method(Method::GET)
+                .header(CONTENT_TYPE, "application/json"),
+            None::<String>,
+            Ok(Full::new(Bytes::new())),
+        );
+        self.process_into_body(req)
+    }
 }
 
 #[cfg(test)]

--- a/tests/container_test.rs
+++ b/tests/container_test.rs
@@ -927,7 +927,9 @@ fn integration_test_resize_container_tty() {
     connect_to_docker_and_run!(resize_container_test);
 }
 
+// note: container exports aren't supported on Windows
 #[test]
+#[cfg(not(windows))]
 fn integration_test_export_container() {
     connect_to_docker_and_run!(export_container_test);
 }


### PR DESCRIPTION
Hello, I noticed that this library has an image export method, but not one to export containers.

Based on Dieff's lovely PR #44, here's one adding that functionality.