### PR TITLE
feat: Add connect_with_defaults

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -157,4 +157,10 @@ pub enum Error {
         #[from]
         err: hyper_util::client::legacy::Error,
     },
+    /// Error emitted when connecting to a URI with an unsupported scheme
+    #[error("URI scheme is not supported: {uri}")]
+    UnsupportedURISchemeError {
+        /// The URI that was attempted to be connected to
+        uri: String,
+    },
 }


### PR DESCRIPTION
Add `connect_with_defaults` function that intelligently selects the best connection method to use based on the `DOCKER_HOST` and `DOCKER_TLS_VERIFY` environment variables. This mimics the logic of the Docker CLI.

Fixes #310 