### PR TITLE
chore(deps): Use hyperlocal-next

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,7 +80,7 @@ tokio = { version = "1.7", features = ["fs", "rt-multi-thread", "macros"] }
 yup-hyper-mock = { version = "8.0.0" }
 
 [target.'cfg(unix)'.dependencies]
-hyperlocal = { git = "https://github.com/softprops/hyperlocal", rev = "34dc8579d74f96b68ddbd55582c76019ae18cfdc", version = "0.9.0-alpha" }
+hyperlocal-next = { version = "0.9.0" }
 
 [target.'cfg(unix)'.dev-dependencies]
 termion = "3.0"

--- a/src/docker.rs
+++ b/src/docker.rs
@@ -25,7 +25,7 @@ use hyper_rustls::HttpsConnector;
 use hyper_util::client::legacy::connect::HttpConnector;
 use hyper_util::{client::legacy::Client, rt::TokioExecutor};
 #[cfg(unix)]
-use hyperlocal::UnixConnector;
+use hyperlocal_next::UnixConnector;
 use log::{debug, trace};
 #[cfg(feature = "ssl")]
 use rustls::{crypto::ring::sign::any_supported_type, sign::CertifiedKey, ALL_VERSIONS};


### PR DESCRIPTION
We can't publish to crates.io unless all git dependencies are moved to a crates.io dependency, so let's resolve this with a workaround.