### PR TITLE
Add repository field to codegen crates

### DIFF
--- a/codegen/proto/Cargo.toml
+++ b/codegen/proto/Cargo.toml
@@ -4,6 +4,7 @@ description = "Protobuf definitions to interact with buildkit using Bollard"
 version = "0.3.0"
 authors = [ "Bollard contributors" ]
 license = "Apache-2.0"
+repository = "https://github.com/fussybeaver/bollard"
 edition = "2021"
 
 [features]

--- a/codegen/swagger/Cargo.toml
+++ b/codegen/swagger/Cargo.toml
@@ -4,6 +4,7 @@ version = "1.44.0-rc.2"
 authors = [ "Bollard contributors" ]
 description = "Stubs used for the Bollard rust async Docker client API"
 license = "Apache-2.0"
+repository = "https://github.com/fussybeaver/bollard"
 edition = "2021"
 
 [features]


### PR DESCRIPTION
Hi! While scraping crates.io I've found these crates to be missing the `repository` field, making it harder for users and automated tools to find the git repository. This fixes it.