### PR TITLE
fix: Don't populate X-Registry-* headers when credentials are not set

### DIFF
--- a/src/auth.rs
+++ b/src/auth.rs
@@ -1,8 +1,8 @@
 //! Credentials management, for access to the Docker Hub or a custom Registry.
 
-use std::collections::HashMap;
 use base64::{engine::general_purpose::STANDARD, Engine};
 use serde_derive::{Deserialize, Serialize};
+use std::collections::HashMap;
 
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 #[allow(missing_docs)]

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -1,5 +1,6 @@
 //! Credentials management, for access to the Docker Hub or a custom Registry.
 
+use std::collections::HashMap;
 use base64::{engine::general_purpose::STANDARD, Engine};
 use serde_derive::{Deserialize, Serialize};
 
@@ -16,6 +17,13 @@ pub struct DockerCredentials {
     pub serveraddress: Option<String>,
     pub identitytoken: Option<String>,
     pub registrytoken: Option<String>,
+}
+
+pub(crate) enum DockerCredentialsHeader {
+    /// Credentials of a single registry sent as an X-Registry-Auth header
+    Auth(DockerCredentials),
+    /// Credentials of multiple registries sent as an X-Registry-Config header
+    Config(HashMap<String, DockerCredentials>),
 }
 
 pub(crate) fn base64_url_encode(payload: &str) -> String {

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -21,9 +21,9 @@ pub struct DockerCredentials {
 
 pub(crate) enum DockerCredentialsHeader {
     /// Credentials of a single registry sent as an X-Registry-Auth header
-    Auth(DockerCredentials),
+    Auth(Option<DockerCredentials>),
     /// Credentials of multiple registries sent as an X-Registry-Config header
-    Config(HashMap<String, DockerCredentials>),
+    Config(Option<HashMap<String, DockerCredentials>>),
 }
 
 pub(crate) fn base64_url_encode(payload: &str) -> String {

--- a/src/docker.rs
+++ b/src/docker.rs
@@ -1215,21 +1215,28 @@ impl Docker {
         mut builder: Builder,
         query: Option<O>,
         payload: Result<BodyType, Error>,
-        credentials: Option<DockerCredentialsHeader>,
+        credentials: DockerCredentialsHeader,
     ) -> Result<Request<BodyType>, Error>
     where
         O: Serialize,
     {
         match credentials {
-            Some(DockerCredentialsHeader::Config(config)) => {
-                let ser_cred = serde_json::to_string(&config)?;
-                builder = builder.header("X-Registry-Config", base64_url_encode(&ser_cred))
+            DockerCredentialsHeader::Config(config) => {
+                let value = match config {
+                    Some(config) => base64_url_encode(&serde_json::to_string(&config)?),
+                    None => "".into(),
+                };
+
+                builder = builder.header("X-Registry-Config", value)
             }
-            Some(DockerCredentialsHeader::Auth(auth)) => {
-                let ser_cred = serde_json::to_string(&auth)?;
-                builder = builder.header("X-Registry-Auth", base64_url_encode(&ser_cred))
+            DockerCredentialsHeader::Auth(auth) => {
+                let value = match auth {
+                    Some(config) => base64_url_encode(&serde_json::to_string(&config)?),
+                    None => "".into(),
+                };
+
+                builder = builder.header("X-Registry-Auth", value)
             }
-            None => {}
         }
 
         self.build_request(path, builder, query, payload)

--- a/src/docker.rs
+++ b/src/docker.rs
@@ -49,9 +49,9 @@ use crate::uri::Uri;
 #[cfg(windows)]
 use hyper_named_pipe::NamedPipeConnector;
 
+use crate::auth::{base64_url_encode, DockerCredentialsHeader};
 use serde::de::DeserializeOwned;
 use serde::ser::Serialize;
-use crate::auth::{base64_url_encode, DockerCredentialsHeader};
 
 /// The default `DOCKER_SOCKET` address that we will try to connect to.
 #[cfg(unix)]

--- a/src/image.rs
+++ b/src/image.rs
@@ -592,7 +592,7 @@ impl Docker {
                 Some(body) => body,
                 None => Bytes::new(),
             }))),
-            credentials.map(DockerCredentialsHeader::Auth),
+            DockerCredentialsHeader::Auth(credentials),
         );
 
         self.process_into_stream(req).boxed().map(|res| {
@@ -676,7 +676,7 @@ impl Docker {
             Builder::new().method(Method::GET),
             None::<String>,
             Ok(BodyType::Left(Full::new(Bytes::new()))),
-            credentials.map(DockerCredentialsHeader::Auth),
+            DockerCredentialsHeader::Auth(credentials),
         );
 
         self.process_into_value(req).await
@@ -869,7 +869,7 @@ impl Docker {
             Builder::new().method(Method::DELETE),
             options,
             Ok(BodyType::Left(Full::new(Bytes::new()))),
-            credentials.map(DockerCredentialsHeader::Auth),
+            DockerCredentialsHeader::Auth(credentials),
         );
         self.process_into_value(req).await
     }
@@ -982,7 +982,7 @@ impl Docker {
                 .header(CONTENT_TYPE, "application/json"),
             options,
             Ok(BodyType::Left(Full::new(Bytes::new()))),
-            credentials.map(DockerCredentialsHeader::Auth),
+            DockerCredentialsHeader::Auth(credentials),
         );
 
         self.process_into_stream(req).boxed().map(|res| {
@@ -1178,7 +1178,7 @@ impl Docker {
                         .header(CONTENT_TYPE, "application/x-tar"),
                     Some(options),
                     Ok(BodyType::Left(Full::new(tar.unwrap_or_default()))),
-                    creds.map(DockerCredentialsHeader::Config),
+                    DockerCredentialsHeader::Config(creds),
                 );
 
                 self.process_into_stream(req).boxed()
@@ -1352,7 +1352,7 @@ impl Docker {
                 .header(CONTENT_TYPE, "application/json"),
             Some(options),
             Ok(BodyType::Left(Full::new(root_fs))),
-            credentials.map(DockerCredentialsHeader::Config),
+            DockerCredentialsHeader::Config(credentials),
         );
 
         self.process_into_stream(req).boxed().map(|res| {
@@ -1437,7 +1437,7 @@ impl Docker {
                 .header(CONTENT_TYPE, "application/json"),
             Some(options),
             Ok(body_stream(root_fs)),
-            credentials.map(DockerCredentialsHeader::Config),
+            DockerCredentialsHeader::Config(credentials),
         );
 
         self.process_into_stream(req).boxed().map(|res| {

--- a/src/image.rs
+++ b/src/image.rs
@@ -1,9 +1,11 @@
 //! Image API: creating, manipulating and pushing docker images
 use bytes::Bytes;
 use futures_core::Stream;
+use futures_util::stream::StreamExt;
 #[cfg(feature = "buildkit")]
 use futures_util::future::{Either, FutureExt};
-use futures_util::{stream, stream::StreamExt};
+#[cfg(feature = "buildkit")]
+use futures_util::stream;
 use http::header::CONTENT_TYPE;
 use http::request::Builder;
 use http_body_util::Full;
@@ -12,7 +14,7 @@ use serde::Serialize;
 use serde_repr::*;
 
 use super::Docker;
-use crate::auth::{base64_url_encode, DockerCredentials};
+use crate::auth::{DockerCredentials, DockerCredentialsHeader};
 use crate::container::Config;
 use crate::docker::{body_stream, BodyType};
 use crate::errors::Error;
@@ -453,7 +455,7 @@ pub enum BuilderVersion {
 enum ImageBuildBuildkitEither {
     #[allow(dead_code)]
     Left(Option<HashMap<String, DockerCredentials>>),
-    Right(Result<String, serde_json::Error>),
+    Right(Option<HashMap<String, DockerCredentials>>),
 }
 
 /// Parameters to the [Import Image API](Docker::import_image())
@@ -582,35 +584,30 @@ impl Docker {
     {
         let url = "/images/create";
 
-        match serde_json::to_string(&credentials.unwrap_or_else(|| DockerCredentials {
-            ..Default::default()
-        })) {
-            Ok(ser_cred) => {
-                let req = self.build_request(
-                    url,
-                    Builder::new()
-                        .method(Method::POST)
-                        .header("X-Registry-Auth", base64_url_encode(&ser_cred)),
-                    options,
-                    Ok(BodyType::Left(Full::new(match root_fs {
-                        Some(body) => body,
-                        None => Bytes::new(),
-                    }))),
-                );
-                self.process_into_stream(req).boxed()
-            }
-            Err(e) => stream::once(async move { Err(Error::from(e)) }).boxed(),
-        }
-        .map(|res| {
-            if let Ok(CreateImageInfo {
-                error: Some(error), ..
-            }) = res
-            {
-                Err(Error::DockerStreamError { error })
-            } else {
-                res
-            }
-        })
+        let req = self.build_request_with_registry_auth(
+            url,
+            Builder::new()
+                .method(Method::POST),
+            options,
+            Ok(BodyType::Left(Full::new(match root_fs {
+                Some(body) => body,
+                None => Bytes::new(),
+            }))),
+            credentials.map(|c| DockerCredentialsHeader::Auth(c)),
+        );
+
+        self.process_into_stream(req)
+            .boxed()
+            .map(|res| {
+                if let Ok(CreateImageInfo {
+                    error: Some(error), ..
+                }) = res
+                {
+                    Err(Error::DockerStreamError { error })
+                } else {
+                    res
+                }
+            })
     }
 
     /// ---
@@ -677,19 +674,13 @@ impl Docker {
     ) -> Result<DistributionInspect, Error> {
         let url = format!("/distribution/{image_name}/json");
 
-        // base64 encode docker credential json to add X-Registry-Auth header to request
-        let creds = &credentials.unwrap_or_else(|| DockerCredentials {
-            ..Default::default()
-        });
-        let creds = serde_json::to_string(creds)?;
-        let creds = base64_url_encode(&creds);
-        let req = self.build_request(
+        let req = self.build_request_with_registry_auth(
             &url,
             Builder::new()
-                .method(Method::GET)
-                .header("X-Registry-Auth", creds),
+                .method(Method::GET),
             None::<String>,
             Ok(BodyType::Left(Full::new(Bytes::new()))),
+            credentials.map(|c| DockerCredentialsHeader::Auth(c)),
         );
 
         self.process_into_value(req).await
@@ -877,22 +868,15 @@ impl Docker {
     ) -> Result<Vec<ImageDeleteResponseItem>, Error> {
         let url = format!("/images/{image_name}");
 
-        match serde_json::to_string(&credentials.unwrap_or_else(|| DockerCredentials {
-            ..Default::default()
-        })) {
-            Ok(ser_cred) => {
-                let req = self.build_request(
-                    &url,
-                    Builder::new()
-                        .method(Method::DELETE)
-                        .header("X-Registry-Auth", base64_url_encode(&ser_cred)),
-                    options,
-                    Ok(BodyType::Left(Full::new(Bytes::new()))),
-                );
-                self.process_into_value(req).await
-            }
-            Err(e) => Err(e.into()),
-        }
+        let req = self.build_request_with_registry_auth(
+            &url,
+            Builder::new()
+                .method(Method::DELETE),
+            options,
+            Ok(BodyType::Left(Full::new(Bytes::new()))),
+            credentials.map(|c| DockerCredentialsHeader::Auth(c)),
+        );
+        self.process_into_value(req).await
     }
 
     /// ---
@@ -996,34 +980,28 @@ impl Docker {
     {
         let url = format!("/images/{image_name}/push");
 
-        match serde_json::to_string(&credentials.unwrap_or_else(|| DockerCredentials {
-            ..Default::default()
-        })) {
-            Ok(ser_cred) => {
-                let req = self.build_request(
-                    &url,
-                    Builder::new()
-                        .method(Method::POST)
-                        .header(CONTENT_TYPE, "application/json")
-                        .header("X-Registry-Auth", base64_url_encode(&ser_cred)),
-                    options,
-                    Ok(BodyType::Left(Full::new(Bytes::new()))),
-                );
+        let req = self.build_request_with_registry_auth(
+            &url,
+            Builder::new()
+                .method(Method::POST)
+                .header(CONTENT_TYPE, "application/json"),
+            options,
+            Ok(BodyType::Left(Full::new(Bytes::new()))),
+            credentials.map(|c| DockerCredentialsHeader::Auth(c)),
+        );
 
-                self.process_into_stream(req).boxed()
-            }
-            Err(e) => stream::once(async move { Err(e.into()) }).boxed(),
-        }
-        .map(|res| {
-            if let Ok(PushImageInfo {
-                error: Some(error), ..
-            }) = res
-            {
-                Err(Error::DockerStreamError { error })
-            } else {
-                res
-            }
-        })
+        self.process_into_stream(req)
+            .boxed()
+            .map(|res| {
+                if let Ok(PushImageInfo {
+                    error: Some(error), ..
+                }) = res
+                {
+                    Err(Error::DockerStreamError { error })
+                } else {
+                    res
+                }
+            })
     }
 
     /// ---
@@ -1148,9 +1126,7 @@ impl Docker {
             if cfg!(feature = "buildkit") && options.version == BuilderVersion::BuilderBuildKit {
                 ImageBuildBuildkitEither::Left(credentials)
             } else {
-                ImageBuildBuildkitEither::Right(serde_json::to_string(
-                    &credentials.unwrap_or_default(),
-                ))
+                ImageBuildBuildkitEither::Right(credentials)
             },
             &options,
         ) {
@@ -1201,21 +1177,18 @@ impl Docker {
             (ImageBuildBuildkitEither::Left(_), _) => unimplemented!(
                 "a buildkit enabled build without the 'buildkit' feature should not be possible"
             ),
-            (ImageBuildBuildkitEither::Right(Ok(ser_cred)), _) => {
-                let req = self.build_request(
+            (ImageBuildBuildkitEither::Right(creds), _) => {
+                let req = self.build_request_with_registry_auth(
                     url,
                     Builder::new()
                         .method(Method::POST)
-                        .header(CONTENT_TYPE, "application/x-tar")
-                        .header("X-Registry-Config", base64_url_encode(&ser_cred)),
+                        .header(CONTENT_TYPE, "application/x-tar"),
                     Some(options),
                     Ok(BodyType::Left(Full::new(tar.unwrap_or_default()))),
+                    creds.map(|c| DockerCredentialsHeader::Config(c)),
                 );
 
                 self.process_into_stream(req).boxed()
-            }
-            (ImageBuildBuildkitEither::Right(Err(e)), _) => {
-                stream::once(async move { Err(e.into()) }).boxed()
             }
         }
         .map(|res| {
@@ -1379,31 +1352,28 @@ impl Docker {
         root_fs: Bytes,
         credentials: Option<HashMap<String, DockerCredentials>>,
     ) -> impl Stream<Item = Result<BuildInfo, Error>> {
-        match serde_json::to_string(&credentials.unwrap_or_default()) {
-            Ok(ser_cred) => {
-                let req = self.build_request(
-                    "/images/load",
-                    Builder::new()
-                        .method(Method::POST)
-                        .header(CONTENT_TYPE, "application/json")
-                        .header("X-Registry-Config", base64_url_encode(&ser_cred)),
-                    Some(options),
-                    Ok(BodyType::Left(Full::new(root_fs))),
-                );
-                self.process_into_stream(req).boxed()
-            }
-            Err(e) => stream::once(async move { Err(e.into()) }).boxed(),
-        }
-        .map(|res| {
-            if let Ok(BuildInfo {
-                error: Some(error), ..
-            }) = res
-            {
-                Err(Error::DockerStreamError { error })
-            } else {
-                res
-            }
-        })
+        let req = self.build_request_with_registry_auth(
+            "/images/load",
+            Builder::new()
+                .method(Method::POST)
+                .header(CONTENT_TYPE, "application/json"),
+            Some(options),
+            Ok(BodyType::Left(Full::new(root_fs))),
+            credentials.map(|c| DockerCredentialsHeader::Config(c)),
+        );
+
+        self.process_into_stream(req)
+            .boxed()
+            .map(|res| {
+                if let Ok(BuildInfo {
+                    error: Some(error), ..
+                }) = res
+                {
+                    Err(Error::DockerStreamError { error })
+                } else {
+                    res
+                }
+            })
     }
 
     /// ---
@@ -1469,31 +1439,28 @@ impl Docker {
         root_fs: impl Stream<Item = Bytes> + Send + 'static,
         credentials: Option<HashMap<String, DockerCredentials>>,
     ) -> impl Stream<Item = Result<BuildInfo, Error>> {
-        match serde_json::to_string(&credentials.unwrap_or_default()) {
-            Ok(ser_cred) => {
-                let req = self.build_request(
-                    "/images/load",
-                    Builder::new()
-                        .method(Method::POST)
-                        .header(CONTENT_TYPE, "application/json")
-                        .header("X-Registry-Config", base64_url_encode(&ser_cred)),
-                    Some(options),
-                    Ok(body_stream(root_fs)),
-                );
-                self.process_into_stream(req).boxed()
-            }
-            Err(e) => stream::once(async move { Err(e.into()) }).boxed(),
-        }
-        .map(|res| {
-            if let Ok(BuildInfo {
-                error: Some(error), ..
-            }) = res
-            {
-                Err(Error::DockerStreamError { error })
-            } else {
-                res
-            }
-        })
+        let req = self.build_request_with_registry_auth(
+            "/images/load",
+            Builder::new()
+                .method(Method::POST)
+                .header(CONTENT_TYPE, "application/json"),
+            Some(options),
+            Ok(body_stream(root_fs)),
+            credentials.map(|c| DockerCredentialsHeader::Config(c)),
+        );
+
+        self.process_into_stream(req)
+            .boxed()
+            .map(|res| {
+                if let Ok(BuildInfo {
+                    error: Some(error), ..
+                }) = res
+                {
+                    Err(Error::DockerStreamError { error })
+                } else {
+                    res
+                }
+            })
     }
 }
 

--- a/src/image.rs
+++ b/src/image.rs
@@ -1,11 +1,11 @@
 //! Image API: creating, manipulating and pushing docker images
 use bytes::Bytes;
 use futures_core::Stream;
-use futures_util::stream::StreamExt;
 #[cfg(feature = "buildkit")]
 use futures_util::future::{Either, FutureExt};
 #[cfg(feature = "buildkit")]
 use futures_util::stream;
+use futures_util::stream::StreamExt;
 use http::header::CONTENT_TYPE;
 use http::request::Builder;
 use http_body_util::Full;
@@ -586,28 +586,25 @@ impl Docker {
 
         let req = self.build_request_with_registry_auth(
             url,
-            Builder::new()
-                .method(Method::POST),
+            Builder::new().method(Method::POST),
             options,
             Ok(BodyType::Left(Full::new(match root_fs {
                 Some(body) => body,
                 None => Bytes::new(),
             }))),
-            credentials.map(|c| DockerCredentialsHeader::Auth(c)),
+            credentials.map(DockerCredentialsHeader::Auth),
         );
 
-        self.process_into_stream(req)
-            .boxed()
-            .map(|res| {
-                if let Ok(CreateImageInfo {
-                    error: Some(error), ..
-                }) = res
-                {
-                    Err(Error::DockerStreamError { error })
-                } else {
-                    res
-                }
-            })
+        self.process_into_stream(req).boxed().map(|res| {
+            if let Ok(CreateImageInfo {
+                error: Some(error), ..
+            }) = res
+            {
+                Err(Error::DockerStreamError { error })
+            } else {
+                res
+            }
+        })
     }
 
     /// ---
@@ -676,11 +673,10 @@ impl Docker {
 
         let req = self.build_request_with_registry_auth(
             &url,
-            Builder::new()
-                .method(Method::GET),
+            Builder::new().method(Method::GET),
             None::<String>,
             Ok(BodyType::Left(Full::new(Bytes::new()))),
-            credentials.map(|c| DockerCredentialsHeader::Auth(c)),
+            credentials.map(DockerCredentialsHeader::Auth),
         );
 
         self.process_into_value(req).await
@@ -870,11 +866,10 @@ impl Docker {
 
         let req = self.build_request_with_registry_auth(
             &url,
-            Builder::new()
-                .method(Method::DELETE),
+            Builder::new().method(Method::DELETE),
             options,
             Ok(BodyType::Left(Full::new(Bytes::new()))),
-            credentials.map(|c| DockerCredentialsHeader::Auth(c)),
+            credentials.map(DockerCredentialsHeader::Auth),
         );
         self.process_into_value(req).await
     }
@@ -987,21 +982,19 @@ impl Docker {
                 .header(CONTENT_TYPE, "application/json"),
             options,
             Ok(BodyType::Left(Full::new(Bytes::new()))),
-            credentials.map(|c| DockerCredentialsHeader::Auth(c)),
+            credentials.map(DockerCredentialsHeader::Auth),
         );
 
-        self.process_into_stream(req)
-            .boxed()
-            .map(|res| {
-                if let Ok(PushImageInfo {
-                    error: Some(error), ..
-                }) = res
-                {
-                    Err(Error::DockerStreamError { error })
-                } else {
-                    res
-                }
-            })
+        self.process_into_stream(req).boxed().map(|res| {
+            if let Ok(PushImageInfo {
+                error: Some(error), ..
+            }) = res
+            {
+                Err(Error::DockerStreamError { error })
+            } else {
+                res
+            }
+        })
     }
 
     /// ---
@@ -1185,7 +1178,7 @@ impl Docker {
                         .header(CONTENT_TYPE, "application/x-tar"),
                     Some(options),
                     Ok(BodyType::Left(Full::new(tar.unwrap_or_default()))),
-                    creds.map(|c| DockerCredentialsHeader::Config(c)),
+                    creds.map(DockerCredentialsHeader::Config),
                 );
 
                 self.process_into_stream(req).boxed()
@@ -1359,21 +1352,19 @@ impl Docker {
                 .header(CONTENT_TYPE, "application/json"),
             Some(options),
             Ok(BodyType::Left(Full::new(root_fs))),
-            credentials.map(|c| DockerCredentialsHeader::Config(c)),
+            credentials.map(DockerCredentialsHeader::Config),
         );
 
-        self.process_into_stream(req)
-            .boxed()
-            .map(|res| {
-                if let Ok(BuildInfo {
-                    error: Some(error), ..
-                }) = res
-                {
-                    Err(Error::DockerStreamError { error })
-                } else {
-                    res
-                }
-            })
+        self.process_into_stream(req).boxed().map(|res| {
+            if let Ok(BuildInfo {
+                error: Some(error), ..
+            }) = res
+            {
+                Err(Error::DockerStreamError { error })
+            } else {
+                res
+            }
+        })
     }
 
     /// ---
@@ -1446,21 +1437,19 @@ impl Docker {
                 .header(CONTENT_TYPE, "application/json"),
             Some(options),
             Ok(body_stream(root_fs)),
-            credentials.map(|c| DockerCredentialsHeader::Config(c)),
+            credentials.map(DockerCredentialsHeader::Config),
         );
 
-        self.process_into_stream(req)
-            .boxed()
-            .map(|res| {
-                if let Ok(BuildInfo {
-                    error: Some(error), ..
-                }) = res
-                {
-                    Err(Error::DockerStreamError { error })
-                } else {
-                    res
-                }
-            })
+        self.process_into_stream(req).boxed().map(|res| {
+            if let Ok(BuildInfo {
+                error: Some(error), ..
+            }) = res
+            {
+                Err(Error::DockerStreamError { error })
+            } else {
+                res
+            }
+        })
     }
 }
 

--- a/src/image.rs
+++ b/src/image.rs
@@ -982,7 +982,7 @@ impl Docker {
                 .header(CONTENT_TYPE, "application/json"),
             options,
             Ok(BodyType::Left(Full::new(Bytes::new()))),
-            DockerCredentialsHeader::Auth(credentials),
+            DockerCredentialsHeader::Auth(Some(credentials.unwrap_or_default())),
         );
 
         self.process_into_stream(req).boxed().map(|res| {

--- a/src/service.rs
+++ b/src/service.rs
@@ -242,7 +242,7 @@ impl Docker {
                 .header(CONTENT_TYPE, "application/json"),
             None::<String>,
             Docker::serialize_payload(Some(service_spec)),
-            credentials.map(|c| DockerCredentialsHeader::Auth(c)),
+            credentials.map(DockerCredentialsHeader::Auth),
         );
 
         self.process_into_value(req).await
@@ -404,7 +404,7 @@ impl Docker {
                 .header(CONTENT_TYPE, "application/json"),
             Some(options),
             Docker::serialize_payload(Some(service_spec)),
-            credentials.map(|c| DockerCredentialsHeader::Auth(c)),
+            credentials.map(DockerCredentialsHeader::Auth),
         );
 
         self.process_into_value(req).await

--- a/src/service.rs
+++ b/src/service.rs
@@ -242,7 +242,7 @@ impl Docker {
                 .header(CONTENT_TYPE, "application/json"),
             None::<String>,
             Docker::serialize_payload(Some(service_spec)),
-            credentials.map(DockerCredentialsHeader::Auth),
+            DockerCredentialsHeader::Auth(credentials),
         );
 
         self.process_into_value(req).await
@@ -404,7 +404,7 @@ impl Docker {
                 .header(CONTENT_TYPE, "application/json"),
             Some(options),
             Docker::serialize_payload(Some(service_spec)),
-            credentials.map(DockerCredentialsHeader::Auth),
+            DockerCredentialsHeader::Auth(credentials),
         );
 
         self.process_into_value(req).await


### PR DESCRIPTION
Currently `bollard` unconditionally sends credentials (X-Registry-*) headers to Docker API, even when credentials are not specified (`None` is passed). For example request for image pull will look like this, despite having no specified credentials:
```
POST /images/create?fromImage=...&fromSrc=&repo=&tag=&platform= HTTP/1.1\r
x-registry-auth: eyJ1c2VybmFtZSI6bnVsbCwicGFzc3dvcmQiOm51bGwsImF1dGgiOm51bGwsImVtYWlsIjpudWxsLCJzZXJ2ZXJhZGRyZXNzIjpudWxsLCJpZGVudGl0eXRva2VuIjpudWxsLCJyZWdpc3RyeXRva2VuIjpudWxsfQ==\r
content-type: application/json\r
host: ...\r
```

(the base64 decoded auth is `{"username":null,"password":null,"auth":null,"email":null,"serveraddress":null,"identitytoken":null,"registrytoken":null}`)


For Podman doing so causes it use those "empty" credentials instead of the default system ones, breaking functionality like registry mirrors and so on.

This PR does a small refactoring and sets this header to be empty when they are not specified, bringing it closer to behavior of other Docker libraries (empty or not set).
