### PR TITLE
Add upload_to_container_streaming to Container

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,6 +82,7 @@ webpki-roots = { version = "0.26", optional = true }
 flate2 = "1.0"
 tar = "0.4"
 tokio = { version = "1.38", features = ["fs", "rt-multi-thread", "macros"] }
+tokio-util = { version = "0.7", features = ["io"] }
 yup-hyper-mock = { version = "8.0.0" }
 once_cell = "1.19"
 

--- a/src/container.rs
+++ b/src/container.rs
@@ -2138,6 +2138,35 @@ impl Docker {
     /// # Returns
     ///
     ///  - unit type `()`, wrapped in a Future.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,no_run
+    /// # use bollard::Docker;
+    /// use bollard::container::UploadToContainerOptions;
+    /// use futures_util::{StreamExt, TryFutureExt};
+    /// use tokio::fs::File;
+    /// use tokio_util::io::ReaderStream;
+    ///
+    /// # #[tokio::main]
+    /// # async fn main() {
+    /// # let docker = Docker::connect_with_http_defaults().unwrap();
+    /// let options = Some(UploadToContainerOptions{
+    ///     path: "/opt",
+    ///     ..Default::default()
+    /// });
+    ///
+    /// let file = File::open("tarball.tar.gz")
+    ///     .map_ok(ReaderStream::new)
+    ///     .try_flatten_stream()
+    ///     .map(|x|x.expect("failed to stream file"));
+    ///
+    /// docker
+    ///     .upload_to_container_streaming("my-container", options, file)
+    ///     .await
+    ///     .expect("upload failed");
+    /// # }
+    /// ```
     pub async fn upload_to_container_streaming<T>(
         &self,
         container_name: &str,
@@ -2179,13 +2208,13 @@ impl Docker {
     ///
     /// ```rust,no_run
     /// # use bollard::Docker;
-    /// # let docker = Docker::connect_with_http_defaults().unwrap();
     /// use bollard::container::UploadToContainerOptions;
-    ///
-    /// use std::default::Default;
     /// use std::fs::File;
     /// use std::io::Read;
     ///
+    /// # #[tokio::main]
+    /// # async fn main() {
+    /// # let docker = Docker::connect_with_http_defaults().unwrap();
     /// let options = Some(UploadToContainerOptions{
     ///     path: "/opt",
     ///     ..Default::default()
@@ -2195,7 +2224,11 @@ impl Docker {
     /// let mut contents = Vec::new();
     /// file.read_to_end(&mut contents).unwrap();
     ///
-    /// docker.upload_to_container("my-container", options, contents.into());
+    /// docker
+    ///     .upload_to_container("my-container", options, contents.into())
+    ///     .await
+    ///     .expect("upload failed");
+    /// # }
     /// ```
     pub async fn upload_to_container<T>(
         &self,


### PR DESCRIPTION
[upload_to_container](https://docs.rs/bollard/0.17.0/bollard/struct.Docker.html#method.upload_to_container) required loading the entire file into memory which was inefficient (sometimes impossible) for large files that can be streamed from disk or network.

Our use case is recreating containers with backups of the container's volumes stored in an S3 bucket. The backups are created with [download_from_container](https://docs.rs/bollard/0.17.0/bollard/struct.Docker.html#method.download_from_container) which already supports streaming. Currently for us these volumes can be large and due to the limitations of upload_to_container would cause our demo server (with 1GiB of ram) to quickly run out of memory (especially if multiple customers tried to restore backups).