### PR TITLE
Release 0.17.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "bollard"
 description = "An asynchronous Docker daemon API"
-version = "0.17.0"
+version = "0.17.1"
 authors = [ "Bollard contributors" ]
 license = "Apache-2.0"
 homepage = "https://github.com/fussybeaver/bollard"

--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ bollard = "*"
 #### Latest
 
 Version `0.17` enables the [`secrets`](https://docs.docker.com/build/building/secrets/#secret-mounts) and [`sshforward`](https://docs.docker.com/build/building/secrets/#ssh-mounts) components of
-`buildkit`, [API version 1.45.0](https://docs.docker.com/engine/api/v1.45/).
+`buildkit`, [API version 1.45.0](https://docs.docker.com/engine/api/v1.45/) - (disabled for
+windows).
 Please note: all `buildkit` API's are under *developer preview*, feedback is
 encouraged.
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,7 +35,8 @@
 //! ### Latest
 //!
 //! Version `0.17` enables the [`secrets`](https://docs.docker.com/build/building/secrets/#secret-mounts) and [`sshforward`](https://docs.docker.com/build/building/secrets/#ssh-mounts) components of
-//! `buildkit`, [API version 1.45.0](https://docs.docker.com/engine/api/v1.45/).
+//! `buildkit`, [API version 1.45.0](https://docs.docker.com/engine/api/v1.45/) - (disabled for
+//! windows).
 //! Please note: all `buildkit` API's are under *developer preview*, feedback is
 //! encouraged.
 //!


### PR DESCRIPTION
This includes:
 - Adding crypto provider features for using rustls 
 - Fix builds for windows that uses buildkit