### PR TITLE
Optional builtin http client

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ members = [
 ]
 
 [features]
-default = []
+default = ["http", "pipe"]
 # Enable Buildkit-enabled docker image building
 buildkit = ["chrono", "num", "rand", "tokio/fs", "tokio-stream", "tokio-util/io", "tonic", "tower-service", "ssl", "bollard-stubs/buildkit", "bollard-buildkit-proto", "dep:async-stream", "dep:bitflags"]
 # Enable tests specifically for the http connector
@@ -39,6 +39,8 @@ ssl_providerless = ["home", "hyper-rustls", "rustls", "rustls-native-certs", "ru
 webpki = ["ssl", "dep:webpki-roots"]
 chrono = ["dep:chrono", "bollard-stubs/chrono"]
 time = ["dep:time", "bollard-stubs/time"]
+http = ["hyper-util"]
+pipe = ["hyperlocal", "hyper-named-pipe"]
 
 [dependencies]
 base64 = "0.22"
@@ -54,7 +56,7 @@ http = "1.1"
 http-body-util = "0.1"
 hyper = { version = "1.3", features = ["client", "http1"] }
 hyper-rustls = { version = "0.27", optional = true, default-features = false , features = ["http1"]}
-hyper-util = { version = "0.1.5", features = ["http1", "client-legacy", "tokio"] }
+hyper-util = { version = "0.1.5", optional = true, features = ["http1", "client-legacy", "tokio"] }
 log = "0.4"
 pin-project-lite = "0.2"
 num = { version = "0.4", optional = true }
@@ -89,13 +91,13 @@ yup-hyper-mock = { version = "8.0.0" }
 once_cell = "1.19"
 
 [target.'cfg(unix)'.dependencies]
-hyperlocal = { version = "0.9.0" }
+hyperlocal = { version = "0.9.0", optional = true }
 
 [target.'cfg(unix)'.dev-dependencies]
 termion = "4.0"
 
 [target.'cfg(windows)'.dependencies]
-hyper-named-pipe = { version = "0.1.0" }
+hyper-named-pipe = { version = "0.1.0", optional = true }
 winapi = { version = "0.3.9", features = ["winerror"] }
 tower-service = { version = "0.3" }
 

--- a/src/docker.rs
+++ b/src/docker.rs
@@ -4,6 +4,7 @@ use std::fs;
 use std::future::Future;
 #[cfg(feature = "ssl")]
 use std::io;
+#[cfg(feature = "pipe")]
 use std::path::Path;
 #[cfg(feature = "ssl")]
 use std::path::PathBuf;
@@ -26,9 +27,12 @@ use hyper::body::{Frame, Incoming};
 use hyper::{self, body::Bytes, Method, Request, Response, StatusCode};
 #[cfg(feature = "ssl")]
 use hyper_rustls::HttpsConnector;
-use hyper_util::client::legacy::connect::HttpConnector;
-use hyper_util::{client::legacy::Client, rt::TokioExecutor};
-#[cfg(unix)]
+#[cfg(any(feature = "http", test))]
+use hyper_util::{
+    client::legacy::{connect::HttpConnector, Client},
+    rt::TokioExecutor,
+};
+#[cfg(all(feature = "pipe", unix))]
 use hyperlocal::UnixConnector;
 use log::{debug, trace};
 #[cfg(feature = "ssl")]
@@ -46,7 +50,7 @@ use crate::read::{
     AsyncUpgraded, IncomingStream, JsonLineDecoder, NewlineLogOutputDecoder, StreamReader,
 };
 use crate::uri::Uri;
-#[cfg(windows)]
+#[cfg(all(feature = "pipe", windows))]
 use hyper_named_pipe::NamedPipeConnector;
 
 use crate::auth::{base64_url_encode, DockerCredentialsHeader};
@@ -62,6 +66,7 @@ pub const DEFAULT_SOCKET: &str = "unix:///var/run/docker.sock";
 pub const DEFAULT_NAMED_PIPE: &str = "npipe:////./pipe/docker_engine";
 
 /// The default `DOCKER_TCP_ADDRESS` address that we will try to connect to.
+#[cfg(feature = "http")]
 pub const DEFAULT_TCP_ADDRESS: &str = "tcp://localhost:2375";
 
 /// The default `DOCKER_HOST` address that we will try to connect to.
@@ -73,6 +78,7 @@ pub const DEFAULT_DOCKER_HOST: &str = DEFAULT_SOCKET;
 pub const DEFAULT_DOCKER_HOST: &str = DEFAULT_NAMED_PIPE;
 
 /// Default timeout for all requests is 2 minutes.
+#[cfg(feature = "http")]
 const DEFAULT_TIMEOUT: u64 = 120;
 
 /// Default Client Version to communicate with the server.
@@ -83,12 +89,13 @@ pub const API_DEFAULT_VERSION: &ClientVersion = &ClientVersion {
 
 #[derive(Debug, Clone)]
 pub(crate) enum ClientType {
-    #[cfg(unix)]
+    #[cfg(all(feature = "pipe", unix))]
     Unix,
+    #[cfg(feature = "http")]
     Http,
     #[cfg(feature = "ssl")]
     SSL,
-    #[cfg(windows)]
+    #[cfg(all(feature = "pipe", windows))]
     NamedPipe,
     Custom {
         scheme: String,
@@ -124,6 +131,7 @@ where
 /// Each transport usually encapsulate a hyper client
 /// with various Connect traits fulfilled.
 pub(crate) enum Transport {
+    #[cfg(feature = "http")]
     Http {
         client: Client<HttpConnector, BodyType>,
     },
@@ -131,11 +139,11 @@ pub(crate) enum Transport {
     Https {
         client: Client<HttpsConnector<HttpConnector>, BodyType>,
     },
-    #[cfg(unix)]
+    #[cfg(all(feature = "pipe", unix))]
     Unix {
         client: Client<UnixConnector, BodyType>,
     },
-    #[cfg(windows)]
+    #[cfg(all(feature = "pipe", windows))]
     NamedPipe {
         client: Client<NamedPipeConnector, BodyType>,
     },
@@ -151,12 +159,13 @@ pub(crate) enum Transport {
 impl fmt::Debug for Transport {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
+            #[cfg(feature = "http")]
             Transport::Http { .. } => write!(f, "HTTP"),
             #[cfg(feature = "ssl")]
             Transport::Https { .. } => write!(f, "HTTPS(rustls)"),
-            #[cfg(unix)]
+            #[cfg(all(feature = "pipe", unix))]
             Transport::Unix { .. } => write!(f, "Unix"),
-            #[cfg(windows)]
+            #[cfg(all(feature = "pipe", windows))]
             Transport::NamedPipe { .. } => write!(f, "NamedPipe"),
             #[cfg(test)]
             Transport::Mock { .. } => write!(f, "Mock"),
@@ -408,9 +417,9 @@ impl rustls::client::ResolvesClientCert for DockerClientCertResolver {
     }
 }
 
+#[cfg(feature = "ssl")]
 /// A Docker implementation typed to connect to a secure HTTPS connection using the `rustls`
 /// library.
-#[cfg(feature = "ssl")]
 impl Docker {
     /// Connect using secure HTTPS using defaults that are signalled by environment variables.
     ///
@@ -542,6 +551,7 @@ impl Docker {
     }
 }
 
+#[cfg(feature = "http")]
 /// A Docker implementation typed to connect to an unsecure Http connection.
 impl Docker {
     /// Connect using unsecured HTTP using defaults that are signalled by environment variables.
@@ -618,7 +628,10 @@ impl Docker {
 
         Ok(docker)
     }
+}
 
+/// A Docker implementation typed to custom connector.
+impl Docker {
     /// Connect using custom transport implementation.
     /// It has default implementation for `Fn(Request) -> Future<Output = Result<Response<hyper::body::Incoming>, Error>> + Send + Sync`
     ///
@@ -693,7 +706,11 @@ impl Docker {
 
         Ok(docker)
     }
+}
 
+/// A Docker implementation that wraps away which local implementation we are calling.
+#[cfg(all(feature = "pipe", any(unix, windows)))]
+impl Docker {
     /// Connect using to either a Unix socket or a Windows named pipe using defaults common to the
     /// standard docker configuration.
     ///
@@ -763,6 +780,43 @@ impl Docker {
         Ok(docker)
     }
 
+    /// Connect using the local machine connection method with default arguments.
+    ///
+    /// This is a simple wrapper over the OS specific handlers:
+    ///  * Unix: [`Docker::connect_with_unix_defaults`]
+    ///  * Windows: [`Docker::connect_with_named_pipe_defaults`]
+    ///
+    /// [`Docker::connect_with_unix_defaults`]: Docker::connect_with_unix_defaults()
+    /// [`Docker::connect_with_named_pipe_defaults`]: Docker::connect_with_named_pipe_defaults()
+    pub fn connect_with_local_defaults() -> Result<Docker, Error> {
+        #[cfg(unix)]
+        return Docker::connect_with_unix_defaults();
+        #[cfg(windows)]
+        return Docker::connect_with_named_pipe_defaults();
+    }
+
+    /// Connect using the local machine connection method with supplied arguments.
+    ///
+    /// This is a simple wrapper over the OS specific handlers:
+    ///  * Unix: [`Docker::connect_with_unix`]
+    ///  * Windows: [`Docker::connect_with_named_pipe`]
+    ///
+    /// [`Docker::connect_with_unix`]: Docker::connect_with_unix()
+    /// [`Docker::connect_with_named_pipe`]: Docker::connect_with_named_pipe()
+    pub fn connect_with_local(
+        addr: &str,
+        timeout: u64,
+        client_version: &ClientVersion,
+    ) -> Result<Docker, Error> {
+        #[cfg(unix)]
+        return Docker::connect_with_unix(addr, timeout, client_version);
+        #[cfg(windows)]
+        return Docker::connect_with_named_pipe(addr, timeout, client_version);
+    }
+}
+
+/// A Docker implementation with defaults.
+impl Docker {
     /// Connect using a Unix socket, a Windows named pipe, or via HTTP.
     /// The connection method is determined by the `DOCKER_HOST` environment variable.
     ///
@@ -779,14 +833,15 @@ impl Docker {
     pub fn connect_with_defaults() -> Result<Docker, Error> {
         let host = env::var("DOCKER_HOST").unwrap_or_else(|_| DEFAULT_DOCKER_HOST.to_string());
         match host {
-            #[cfg(unix)]
+            #[cfg(all(feature = "pipe", unix))]
             h if h.starts_with("unix://") => {
                 Docker::connect_with_unix(&h, DEFAULT_TIMEOUT, API_DEFAULT_VERSION)
             }
-            #[cfg(windows)]
+            #[cfg(all(feature = "pipe", windows))]
             h if h.starts_with("npipe://") => {
                 Docker::connect_with_named_pipe(&h, DEFAULT_TIMEOUT, API_DEFAULT_VERSION)
             }
+            #[cfg(feature = "http")]
             h if h.starts_with("tcp://") || h.starts_with("http://") => {
                 #[cfg(feature = "ssl")]
                 if env::var("DOCKER_TLS_VERIFY").is_ok() {
@@ -803,7 +858,7 @@ impl Docker {
     }
 }
 
-#[cfg(unix)]
+#[cfg(all(feature = "pipe", unix))]
 /// A Docker implementation typed to connect to a Unix socket.
 impl Docker {
     /// Connect using a Unix socket using defaults common to the standard docker configuration.
@@ -890,7 +945,7 @@ impl Docker {
     }
 }
 
-#[cfg(windows)]
+#[cfg(all(feature = "pipe", windows))]
 /// A Docker implementation typed to connect to a Windows Named Pipe, exclusive to the windows
 /// target.
 impl Docker {
@@ -964,44 +1019,6 @@ impl Docker {
         };
 
         Ok(docker)
-    }
-}
-
-/// A Docker implementation that wraps away which local implementation we are calling.
-#[cfg(any(unix, windows))]
-impl Docker {
-    /// Connect using the local machine connection method with default arguments.
-    ///
-    /// This is a simple wrapper over the OS specific handlers:
-    ///  * Unix: [`Docker::connect_with_unix_defaults`]
-    ///  * Windows: [`Docker::connect_with_named_pipe_defaults`]
-    ///
-    /// [`Docker::connect_with_unix_defaults`]: Docker::connect_with_unix_defaults()
-    /// [`Docker::connect_with_named_pipe_defaults`]: Docker::connect_with_named_pipe_defaults()
-    pub fn connect_with_local_defaults() -> Result<Docker, Error> {
-        #[cfg(unix)]
-        return Docker::connect_with_unix_defaults();
-        #[cfg(windows)]
-        return Docker::connect_with_named_pipe_defaults();
-    }
-
-    /// Connect using the local machine connection method with supplied arguments.
-    ///
-    /// This is a simple wrapper over the OS specific handlers:
-    ///  * Unix: [`Docker::connect_with_unix`]
-    ///  * Windows: [`Docker::connect_with_named_pipe`]
-    ///
-    /// [`Docker::connect_with_unix`]: Docker::connect_with_unix()
-    /// [`Docker::connect_with_named_pipe`]: Docker::connect_with_named_pipe()
-    pub fn connect_with_local(
-        addr: &str,
-        timeout: u64,
-        client_version: &ClientVersion,
-    ) -> Result<Docker, Error> {
-        #[cfg(unix)]
-        return Docker::connect_with_unix(addr, timeout, client_version);
-        #[cfg(windows)]
-        return Docker::connect_with_named_pipe(addr, timeout, client_version);
     }
 }
 
@@ -1350,13 +1367,15 @@ impl Docker {
         timeout: u64,
     ) -> Result<Response<Incoming>, Error> {
         // This is where we determine to which transport we issue the request.
+        #[allow(clippy::let_unit_value, unused_variables)]
         let request = match *transport {
+            #[cfg(feature = "http")]
             Transport::Http { ref client } => client.request(req),
             #[cfg(feature = "ssl")]
             Transport::Https { ref client } => client.request(req),
-            #[cfg(unix)]
+            #[cfg(all(feature = "pipe", unix))]
             Transport::Unix { ref client } => client.request(req),
-            #[cfg(windows)]
+            #[cfg(all(feature = "pipe", windows))]
             Transport::NamedPipe { ref client } => client.request(req),
             #[cfg(test)]
             Transport::Mock { ref client } => client.request(req),
@@ -1373,6 +1392,7 @@ impl Docker {
             }
         };
 
+        #[cfg(any(feature = "http", feature = "ssl", feature = "pipe"))]
         match tokio::time::timeout(Duration::from_secs(timeout), request).await {
             Ok(v) => Ok(v?),
             Err(_) => Err(RequestTimeoutError),

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -158,6 +158,7 @@ pub enum Error {
         err: http::uri::InvalidUriParts,
     },
     /// Error that is never emitted
+    #[cfg(feature = "http")]
     #[error("Error in the hyper legacy client: {}", err)]
     HyperLegacyError {
         /// The original error emitted.

--- a/src/uri.rs
+++ b/src/uri.rs
@@ -66,12 +66,13 @@ impl<'a> Uri<'a> {
         P: AsRef<OsStr>,
     {
         match client_type {
+            #[cfg(feature = "http")]
             ClientType::Http => socket.as_ref().to_string_lossy().into_owned(),
             #[cfg(feature = "ssl")]
             ClientType::SSL => socket.as_ref().to_string_lossy().into_owned(),
-            #[cfg(unix)]
+            #[cfg(all(feature = "pipe", unix))]
             ClientType::Unix => hex::encode(socket.as_ref().to_string_lossy().as_bytes()),
-            #[cfg(windows)]
+            #[cfg(all(feature = "pipe", windows))]
             ClientType::NamedPipe => hex::encode(socket.as_ref().to_string_lossy().as_bytes()),
             ClientType::Custom { .. } => socket.as_ref().to_string_lossy().into_owned(),
         }
@@ -79,12 +80,13 @@ impl<'a> Uri<'a> {
 
     fn socket_scheme(client_type: &'a ClientType) -> &'a str {
         match client_type {
+            #[cfg(feature = "http")]
             ClientType::Http => "http",
             #[cfg(feature = "ssl")]
             ClientType::SSL => "https",
-            #[cfg(unix)]
+            #[cfg(all(feature = "pipe", unix))]
             ClientType::Unix => "unix",
-            #[cfg(windows)]
+            #[cfg(all(feature = "pipe", windows))]
             ClientType::NamedPipe => "net.pipe",
             ClientType::Custom { scheme } => scheme.as_str(),
         }


### PR DESCRIPTION
With the custom transport implementation we're
able to provide a [sans-io](https://sans-io.readthedocs.io/) bollard crate.

This also remove the hard dependency on
tokio making possible to use other async runtime.

When the disabling default options (http, pipe),
fresh compile time is reduced from ~24s to ~14s
and rlib size from ~24MiB to ~11MiB.