### PR TITLE
Add named context support to BuildKit solver pipeline

### DIFF
--- a/src/grpc/build.rs
+++ b/src/grpc/build.rs
@@ -40,6 +40,7 @@ pub struct ImageBuildFrontendOptions {
     pub(crate) shmsize: u64,
     pub(crate) secrets: HashMap<String, SecretSource>,
     pub(crate) ssh: bool,
+    pub(crate) named_contexts: HashMap<String, String>,
     //pub(crate) ulimit: Vec<String>,
 }
 
@@ -224,6 +225,16 @@ impl ImageBuildFrontendOptions {
             attrs.insert(String::from("shm-size"), self.shmsize.to_string());
         }
 
+        if !self.named_contexts.is_empty() {
+            attrs.insert(
+                String::from("frontend.caps"),
+                String::from("moby.buildkit.frontend.contexts+forward"),
+            );
+            for (k, v) in self.named_contexts {
+                attrs.insert(format!("context:{k}"), v);
+            }
+        }
+
         ImageBuildFrontendOptionsIngest {
             cache_to: self.cacheto,
             cache_from: self.cachefrom,
@@ -345,6 +356,14 @@ impl ImageBuildFrontendOptionsBuilder {
     /// Enable sshforward to ssh agent.
     pub fn enable_ssh(mut self, value: bool) -> Self {
         self.inner.ssh = value;
+        self
+    }
+
+    /// Add a named build context.
+    pub fn named_context(mut self, key: &str, value: &str) -> Self {
+        self.inner
+            .named_contexts
+            .insert(String::from(key), String::from(value));
         self
     }
 

--- a/src/grpc/build.rs
+++ b/src/grpc/build.rs
@@ -40,7 +40,7 @@ pub struct ImageBuildFrontendOptions {
     pub(crate) shmsize: u64,
     pub(crate) secrets: HashMap<String, SecretSource>,
     pub(crate) ssh: bool,
-    pub(crate) named_contexts: HashMap<String, String>,
+    pub(crate) named_contexts: HashMap<String, NamedContext>,
     //pub(crate) ulimit: Vec<String>,
 }
 
@@ -146,6 +146,13 @@ impl Display for ImageBuildOutputCompression {
     }
 }
 
+#[derive(Debug, Clone, PartialEq)]
+/// An additional build context. Can be used to override a named stage in the Dockerfile.
+pub struct NamedContext {
+    /// Container image (with `docker-image://` prefix), Git, or HTTP URL.
+    pub path: String,
+}
+
 pub(crate) struct ImageBuildFrontendOptionsIngest {
     pub cache_to: Vec<CacheOptionsEntry>,
     pub cache_from: Vec<CacheOptionsEntry>,
@@ -230,8 +237,8 @@ impl ImageBuildFrontendOptions {
                 String::from("frontend.caps"),
                 String::from("moby.buildkit.frontend.contexts+forward"),
             );
-            for (k, v) in self.named_contexts {
-                attrs.insert(format!("context:{k}"), v);
+            for (name, context) in self.named_contexts {
+                attrs.insert(format!("context:{name}"), context.path);
             }
         }
 
@@ -360,10 +367,8 @@ impl ImageBuildFrontendOptionsBuilder {
     }
 
     /// Add a named build context.
-    pub fn named_context(mut self, key: &str, value: &str) -> Self {
-        self.inner
-            .named_contexts
-            .insert(String::from(key), String::from(value));
+    pub fn named_context(mut self, key: &str, value: NamedContext) -> Self {
+        self.inner.named_contexts.insert(String::from(key), value);
         self
     }
 

--- a/tests/image_test.rs
+++ b/tests/image_test.rs
@@ -746,7 +746,12 @@ async fn build_buildkit_named_context_test(docker: Docker) -> Result<(), Error> 
     let name = "integration_test_build_buildkit_named_context";
 
     let frontend_opts = bollard::grpc::build::ImageBuildFrontendOptions::builder()
-        .named_context(&base_image, "docker-image://localhost:5000/alpine")
+        .named_context(
+            &base_image,
+            bollard::grpc::build::NamedContext {
+                path: String::from("docker-image://localhost:5000/alpine"),
+            },
+        )
         .build();
 
     let driver = bollard::grpc::driver::moby::Moby::new(&docker);


### PR DESCRIPTION
Adds support for overriding named build contexts, like [`buildx build --build-context`](https://docs.docker.com/reference/cli/docker/buildx/build/#build-context).

For example, in the included test, we run `cat /etc/alpine-release` on an image whose Dockerfile consists of:
```
FROM localhost:5000/hello-world:linux
```
this should result in a 400 error, since the `hello-world` image doesn't include this file (or `cat` for that matter).

However, since we've overridden the `hello-world` image reference with `docker-image://localhost:5000/alpine`, it succeeds. This functionality is especially useful for overriding mutable tag references in Dockerfiles with pinned digests.

buildx also lets you specify additional local build contexts by path which automatically get sent to BuildKit, but that seems (probably?) out of scope for a low-level API. [Here is the buildx implementation for reference](https://github.com/docker/buildx/blob/master/build/opt.go#L484-L542). This simple string map will work for common use cases like remote URLs, `docker-image://` references, and `target:` build stages.