### PR TITLE
Add buildkit no-op tear down

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 jobs:
   test_ssl:
     docker:
-      - image: docker:27.0
+      - image: docker:27.3
     steps:
       - checkout
       - setup_remote_docker
@@ -20,7 +20,7 @@ jobs:
       - run: docker run -ti -e DOCKER_CERT_PATH=/certs -e DOCKER_HOST='https://test.example.com:2376' --volumes-from certs --rm --link test-docker-daemon:docker bollard cargo test --features test_ssl,aws-lc-rs -- --test test_connect_with_defaults
   test_http:
     docker:
-      - image: docker:27.0
+      - image: docker:27.3
     steps:
       - checkout
       - setup_remote_docker
@@ -30,7 +30,7 @@ jobs:
       - run: docker run -ti -e DOCKER_HOST='tcp://test.example.com:2375' --rm --link test-docker-daemon:docker bollard cargo test -- --test test_connect_with_defaults
   test_unix:
     docker:
-      - image: docker:27.0
+      - image: docker:27.3
     steps:
       - checkout
       - setup_remote_docker
@@ -39,7 +39,7 @@ jobs:
       - run: docker run -ti -e DOCKER_HOST='unix:///var/run/docker.sock' -v /var/run/docker.sock:/var/run/docker.sock --rm bollard cargo test -- --test test_connect_with_defaults
   test_buildkit:
     docker:
-      - image: docker:27.0
+      - image: docker:27.3
     steps:
       - checkout
       - setup_remote_docker
@@ -47,7 +47,7 @@ jobs:
       - run: resources/dockerfiles/bin/run_integration_tests.sh --features buildkit --tests
   test_chrono:
     docker:
-      - image: docker:27.0
+      - image: docker:27.3
     steps:
       - checkout
       - setup_remote_docker
@@ -55,7 +55,7 @@ jobs:
       - run: resources/dockerfiles/bin/run_integration_tests.sh --features chrono --tests
   test_time:
     docker:
-      - image: docker:27.0
+      - image: docker:27.3
     steps:
       - checkout
       - setup_remote_docker
@@ -63,7 +63,7 @@ jobs:
       - run: resources/dockerfiles/bin/run_integration_tests.sh --features time --tests
   test_race:
     docker:
-      - image: docker:27.0
+      - image: docker:27.3
     steps:
       - checkout
       - setup_remote_docker
@@ -73,7 +73,7 @@ jobs:
       - run: docker run -ti -e DOCKER_HOST='unix:///var/run/docker.sock' -v /var/run/docker.sock:/var/run/docker.sock --rm bollard cargo test test_runtime
   test_doc:
     docker:
-      - image: docker:27.0
+      - image: docker:27.3
     steps:
       - checkout
       - setup_remote_docker
@@ -81,7 +81,7 @@ jobs:
       - run: docker run -ti --rm bollard cargo test --all-features --target x86_64-unknown-linux-gnu --doc
   test_crypto_provider:
     docker:
-      - image: docker:27.0
+      - image: docker:27.3
     steps:
       - checkout
       - setup_remote_docker
@@ -91,7 +91,7 @@ jobs:
       - run: docker run -ti --rm bollard bash -c "cargo check --no-default-features --features ssl_providerless"
   test_clippy:
     docker:
-      - image: docker:27.0
+      - image: docker:27.3
     steps:
       - checkout
       - setup_remote_docker
@@ -99,7 +99,7 @@ jobs:
       - run: docker run -ti --rm bollard bash -c "rustup component add clippy && cargo clippy --all-targets -- -Dwarnings"
   test_audit:
     docker:
-      - image: docker:27.0
+      - image: docker:27.3
     steps:
       - checkout
       - setup_remote_docker
@@ -108,7 +108,7 @@ jobs:
       - run: docker run -ti --rm bollard bash -c "cargo install cargo-audit && cargo audit --deny warnings --ignore=RUSTSEC-2020-0071"
   test_fmt:
     docker:
-      - image: docker:27.0
+      - image: docker:27.3
     steps:
       - checkout
       - setup_remote_docker
@@ -116,7 +116,7 @@ jobs:
       - run: docker run -ti --rm bollard bash -c "rustup component add rustfmt && cargo fmt -p bollard -- --check --verbose"
   test_sshforward:
     docker:
-      - image: docker:25.0.3
+      - image: docker:27.3
     steps:
       - checkout
       - setup_remote_docker

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.81.0-slim
+FROM rust:1.82.0-slim
 
 WORKDIR /usr/src/bollard
 

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,1 +1,1 @@
-edition = "2018"
+edition = "2021"

--- a/tests/container_test.rs
+++ b/tests/container_test.rs
@@ -526,7 +526,7 @@ async fn prune_containers_test(docker: Docker) -> Result<(), Error> {
                 "stefanscherer/registry-windows",
                 "moby/buildkit:master",
                 // Containers existing on CircleCI after a prune
-                "docker:27.0",
+                "docker.io/library/docker:27.3",
                 "public.ecr.aws/eks-distro/kubernetes/pause:3.6"
             ]
             .into_iter()


### PR DESCRIPTION
This PR allows the user to prefer their own context and switch off the tear-down functionality of the grpc solver in the docker-container driver.

Closes #469 