### PR TITLE
fix: Change multiple API's to support streaming

### DIFF
--- a/examples/build_buildkit.rs
+++ b/examples/build_buildkit.rs
@@ -8,6 +8,7 @@ use bollard::Docker;
 
 #[cfg(feature = "buildkit")]
 use futures_util::stream::StreamExt;
+use http_body_util::Full;
 
 use std::io::Write;
 
@@ -48,8 +49,11 @@ ENTRYPOINT ls buildkit-bollard.txt
         ..Default::default()
     };
 
-    let mut image_build_stream =
-        docker.build_image(build_image_options, None, Some(compressed.into()));
+    let mut image_build_stream = docker.build_image(
+        build_image_options,
+        None,
+        Some(http_body_util::Either::Left(Full::new(compressed.into()))),
+    );
 
     #[cfg(feature = "buildkit")]
     while let Some(Ok(bollard::models::BuildInfo {

--- a/src/grpc/mod.rs
+++ b/src/grpc/mod.rs
@@ -300,7 +300,7 @@ impl FileSendPacket for FileSendPacketImpl {
                     },
                     Ok(PacketType::PacketReq) => panic!("server should not request"),
                     Ok(PacketType::PacketData) => {
-                        if packet.data.len() == 0 {
+                        if packet.data.is_empty() {
                             // all data for file has been received
                             stats.remove(&packet.id);
                         } else {
@@ -439,11 +439,9 @@ impl AuthProvider {
             host = DOCKER_HUB_CONFIG_FILE_KEY;
         }
 
-        if let Some(creds) = self.auth_config_cache.get(host) {
-            Some(DockerCredentials::to_owned(creds))
-        } else {
-            None
-        }
+        self.auth_config_cache
+            .get(host)
+            .map(DockerCredentials::to_owned)
     }
 
     fn to_token_response(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -281,7 +281,10 @@ pub mod volume;
 pub mod grpc;
 
 // publicly re-export
-pub use crate::docker::{BollardRequest, ClientVersion, Docker, API_DEFAULT_VERSION};
+pub use crate::docker::{
+    body_full, body_stream, body_try_stream, BollardRequest, ClientVersion, Docker,
+    API_DEFAULT_VERSION,
+};
 pub use bollard_stubs::models;
 
 #[cfg(feature = "buildkit")]

--- a/tests/container_test.rs
+++ b/tests/container_test.rs
@@ -9,8 +9,8 @@ use bollard::container::{
 };
 use bollard::errors::Error;
 use bollard::image::{CreateImageOptions, PushImageOptions, TagImageOptions};
-use bollard::models::*;
-use bollard::Docker;
+use bollard::{body_full, Docker};
+use bollard::{body_stream, models::*};
 
 use futures_util::future::ready;
 use futures_util::stream::TryStreamExt;
@@ -596,7 +596,7 @@ async fn archive_container_test(docker: Docker, streaming_upload: bool) -> Resul
         let payload = futures_util::stream::iter(payload.map(bytes::Bytes::from));
 
         let _ = &docker
-            .upload_to_container_streaming(
+            .upload_to_container(
                 "integration_test_archive_container",
                 Some(UploadToContainerOptions {
                     path: if cfg!(windows) {
@@ -606,7 +606,7 @@ async fn archive_container_test(docker: Docker, streaming_upload: bool) -> Resul
                     },
                     ..Default::default()
                 }),
-                payload,
+                body_stream(payload),
             )
             .await?;
     } else {
@@ -621,7 +621,7 @@ async fn archive_container_test(docker: Docker, streaming_upload: bool) -> Resul
                     },
                     ..Default::default()
                 }),
-                payload.into(),
+                body_full(payload.into()),
             )
             .await?;
     }


### PR DESCRIPTION
Adds a streaming parameter to all API's that previously expected a `Bytes` struct. Convenience methods exposed to convert a stream of `Bytes` or a stream of `Result<Bytes, std::io::Error>` or a single `Bytes` instance to a bollard `BodyType`. 

Merge the implementation of `upload_to_container_streaming` with `upload_to_container`.

Closes #494 #490
