### PR TITLE
fix: Re-add upload_to_container_streaming and mark deprecated

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.82.0-slim
+FROM rust:1.84.0-slim
 
 WORKDIR /usr/src/bollard
 

--- a/src/container.rs
+++ b/src/container.rs
@@ -1185,7 +1185,7 @@ impl Docker {
     ///
     /// docker.list_containers(options);
     /// ```
-    pub async fn list_containers<'de, T>(
+    pub async fn list_containers<T>(
         &self,
         options: Option<ListContainersOptions<T>>,
     ) -> Result<Vec<ContainerSummary>, Error>

--- a/src/container.rs
+++ b/src/container.rs
@@ -2126,6 +2126,67 @@ impl Docker {
 
     /// ---
     ///
+    /// # Stream Upload To Container
+    ///
+    /// Stream an upload of a tar archive to be extracted to a path in the filesystem of container
+    /// id.
+    ///
+    /// # Arguments
+    ///
+    ///  - Optional [Upload To Container Options](UploadToContainerOptions) struct.
+    ///
+    /// # Returns
+    ///
+    ///  - unit type `()`, wrapped in a Future.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,no_run
+    /// # use bollard::Docker;
+    /// use bollard::container::UploadToContainerOptions;
+    /// use futures_util::{StreamExt, TryFutureExt};
+    /// use tokio::fs::File;
+    /// use tokio_util::io::ReaderStream;
+    ///
+    /// # #[tokio::main]
+    /// # async fn main() {
+    /// # let docker = Docker::connect_with_http_defaults().unwrap();
+    /// let options = Some(UploadToContainerOptions{
+    ///     path: "/opt",
+    ///     ..Default::default()
+    /// });
+    ///
+    /// let file = File::open("tarball.tar.gz")
+    ///     .map_ok(ReaderStream::new)
+    ///     .try_flatten_stream()
+    ///     .map(|x|x.expect("failed to stream file"));
+    ///
+    /// docker
+    ///     .upload_to_container_streaming("my-container", options, file)
+    ///     .await
+    ///     .expect("upload failed");
+    /// # }
+    /// ```
+    #[inline(always)]
+    #[deprecated(
+        since = "0.19.0",
+        note = "This method is refactored into upload_to_container"
+    )]
+    pub async fn upload_to_container_streaming<T>(
+        &self,
+        container_name: &str,
+        options: Option<UploadToContainerOptions<T>>,
+        tar: impl Stream<Item = Bytes> + Send + 'static,
+    ) -> Result<(), Error>
+    where
+        T: Into<String> + Serialize,
+    {
+        self.upload_to_container(container_name, options, crate::body_stream(tar))
+            .await
+    }
+
+    /// ---
+    ///
     /// # Upload To Container
     ///
     /// Upload a tar archive to be extracted to a path in the filesystem of container id.

--- a/src/docker.rs
+++ b/src/docker.rs
@@ -670,7 +670,7 @@ impl Docker {
     /// use bollard::{API_DEFAULT_VERSION, Docker, BollardRequest};
     /// use futures_util::future::TryFutureExt;
     /// use futures_util::FutureExt;
-
+    ///
     /// let http_connector = hyper_util::client::legacy::connect::HttpConnector::new();
     ///
     /// let mut client_builder = hyper_util::client::legacy::Client::builder(hyper_util::rt::TokioExecutor::new());


### PR DESCRIPTION
Bump rust to 1.84.0

Closes #493 