### PR TITLE
Added `Docker::prune_build` for `/build/prune` endpoint access

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -113,7 +113,8 @@ jobs:
       - setup_remote_docker
       - run: docker build -t bollard .
         # RUSTSEC-2020-0159 https://github.com/chronotope/chrono/issues/602
-      - run: docker run -ti --rm bollard bash -c "cargo install cargo-audit && cargo audit --deny warnings --ignore=RUSTSEC-2020-0071"
+        # RUSTSEC-2024-0436 https://github.com/aws/aws-lc-rs/issues/722
+      - run: docker run -ti --rm bollard bash -c "cargo install cargo-audit && cargo audit --deny warnings --ignore=RUSTSEC-2020-0071 --ignore=RUSTSEC-2024-0436"
   test_fmt:
     docker:
       - image: docker:27.3

--- a/examples/hoover.rs
+++ b/examples/hoover.rs
@@ -73,6 +73,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + 'static>> {
     let prune = docker
         .prune_build(Some(PruneBuildOptions {
             filters: prune_filters.clone(),
+            ..Default::default()
         }))
         .await?;
 

--- a/examples/hoover.rs
+++ b/examples/hoover.rs
@@ -1,9 +1,9 @@
-//! Removes old docker containers, images, volumes and networks
+//! Removes old docker containers, images, volumes, networks and intermediate build steps
 
 use bollard::Docker;
 use bollard::{
-    container::PruneContainersOptions, image::PruneImagesOptions, network::PruneNetworksOptions,
-    volume::PruneVolumesOptions,
+    container::PruneContainersOptions, image::PruneBuildOptions, image::PruneImagesOptions,
+    network::PruneNetworksOptions, volume::PruneVolumesOptions,
 };
 use std::collections::HashMap;
 
@@ -64,6 +64,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error + 'static>> {
 
     let prune = docker
         .prune_networks(Some(PruneNetworksOptions {
+            filters: prune_filters.clone(),
+        }))
+        .await?;
+
+    println!("{prune:?}");
+
+    let prune = docker
+        .prune_build(Some(PruneBuildOptions {
             filters: prune_filters.clone(),
         }))
         .await?;

--- a/src/image.rs
+++ b/src/image.rs
@@ -496,6 +496,7 @@ where
 ///
 /// PruneBuildOptions{
 ///   filters,
+///   ..Default::default()
 /// };
 /// ```
 ///
@@ -1395,7 +1396,8 @@ impl Docker {
     /// filters.insert("until", vec!["10m"]);
     ///
     /// let options = Some(PruneBuildOptions {
-    ///   filters
+    ///   filters,
+    ///   ..Default::default()
     /// });
     ///
     /// docker.prune_build(options);

--- a/src/image.rs
+++ b/src/image.rs
@@ -512,10 +512,25 @@ pub struct PruneBuildOptions<T>
 where
     T: Into<String> + Eq + Hash + Serialize,
 {
+    /// Amount of disk space in bytes to keep for cache
+    pub reserved_space: Option<i64>,
+    /// Maximum amount of disk space allowed to keep for cache
+    pub max_used_space: Option<i64>,
+    /// Target amount of free disk space after pruning
+    pub min_free_space: Option<i64>,
+    /// Remove all types of build cache
+    pub all: bool,
     /// Filters to process on the prune list, encoded as JSON. Available filters:
-    ///  - `until=<string>` Prune images created before this timestamp. The `<timestamp>` can be
+    ///  - `until=<string>` remove cache older than this timestamp. The `<timestamp>` can be
     ///    Unix timestamps, date formatted timestamps, or Go duration strings (e.g. `10m`, `1h30m`)
     ///    computed relative to the daemon machine’s time.
+    ///  - id=<id>
+    ///  - parent=<id>
+    ///  - type=<string>
+    ///  - description=<string>
+    ///  - inuse
+    ///  - shared
+    ///  - private
     #[serde(serialize_with = "crate::docker::serialize_as_json")]
     pub filters: HashMap<T, Vec<T>>,
 }

--- a/src/image.rs
+++ b/src/image.rs
@@ -482,6 +482,44 @@ where
     }
 }
 
+/// Parameters to the [Prune Build API](Docker::prune_build())
+///
+/// ## Examples
+///
+/// ```rust
+/// use bollard::image::PruneBuildOptions;
+///
+/// use std::collections::HashMap;
+///
+/// let mut filters = HashMap::new();
+/// filters.insert("until", vec!["10m"]);
+///
+/// PruneBuildOptions{
+///   filters,
+/// };
+/// ```
+///
+/// ```rust
+/// # use bollard::image::PruneBuildOptions;
+/// # use std::default::Default;
+/// PruneBuildOptions::<String>{
+///   ..Default::default()
+/// };
+/// ```
+///
+#[derive(Debug, Clone, Default, PartialEq, Serialize)]
+pub struct PruneBuildOptions<T>
+where
+    T: Into<String> + Eq + Hash + Serialize,
+{
+    /// Filters to process on the prune list, encoded as JSON. Available filters:
+    ///  - `until=<string>` Prune images created before this timestamp. The `<timestamp>` can be
+    ///    Unix timestamps, date formatted timestamps, or Go duration strings (e.g. `10m`, `1h30m`)
+    ///    computed relative to the daemon machine’s time.
+    #[serde(serialize_with = "crate::docker::serialize_as_json")]
+    pub filters: HashMap<T, Vec<T>>,
+}
+
 /// Builder Version to use
 #[derive(Clone, Copy, Debug, PartialEq, Serialize_repr)]
 #[repr(u8)]
@@ -1313,6 +1351,57 @@ impl Docker {
         crate::grpc::driver::Driver::grpc_handle(driver, &id, services).await?;
 
         Ok(())
+    }
+
+    /// ---
+    ///
+    /// # Prune Build
+    ///
+    /// Delete contents of the build cache
+    ///
+    /// # Arguments
+    ///
+    /// - An optional [Prune Build Options](PruneBuildOptions) struct.
+    ///
+    /// # Returns
+    ///
+    ///  - a [Prune Build Response](BuildPruneResponse), wrapped in a Future.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use bollard::Docker;
+    /// # let docker = Docker::connect_with_http_defaults().unwrap();
+    /// use bollard::image::PruneBuildOptions;
+    ///
+    /// use std::collections::HashMap;
+    ///
+    /// let mut filters = HashMap::new();
+    /// filters.insert("until", vec!["10m"]);
+    ///
+    /// let options = Some(PruneBuildOptions {
+    ///   filters
+    /// });
+    ///
+    /// docker.prune_build(options);
+    /// ```
+    pub async fn prune_build<T>(
+        &self,
+        options: Option<PruneBuildOptions<T>>,
+    ) -> Result<BuildPruneResponse, Error>
+    where
+        T: Into<String> + Eq + Hash + Serialize,
+    {
+        let url = "/build/prune";
+
+        let req = self.build_request(
+            url,
+            Builder::new().method(Method::POST),
+            options,
+            Ok(BodyType::Left(Full::new(Bytes::new()))),
+        );
+
+        self.process_into_value(req).await
     }
 
     /// ---

--- a/tests/image_test.rs
+++ b/tests/image_test.rs
@@ -1419,6 +1419,17 @@ RUN touch empty.txt
     Ok(())
 }
 
+async fn prune_build_test(docker: Docker) -> Result<(), Error> {
+    //create_image_hello_world(&docker).await?;
+    let mut filters = HashMap::new();
+    filters.insert("label", vec!["until=24h"]);
+    let _ = &docker
+        .prune_build(Some(PruneBuildOptions { filters }))
+        .await?;
+
+    Ok(())
+}
+
 async fn export_image_test(docker: Docker) -> Result<(), Error> {
     create_image_hello_world(&docker).await?;
 
@@ -1738,6 +1749,11 @@ fn integration_test_build_buildkit_image_outputs_tar() {
 #[cfg(feature = "buildkit")]
 fn integration_test_build_buildkit_image_outputs_local() {
     connect_to_docker_and_run!(build_buildkit_image_outputs_local_test);
+}
+
+#[test]
+fn integration_test_prune_build() {
+    connect_to_docker_and_run!(prune_build_test);
 }
 
 #[test]

--- a/tests/image_test.rs
+++ b/tests/image_test.rs
@@ -1419,13 +1419,81 @@ RUN touch empty.txt
     Ok(())
 }
 
+// Although prune_build can be run without BuildKit enabled, only the BuildKit builder actually
+// uses it. The V1 builder caches in the form of intermediate images instead.
+#[cfg(feature = "buildkit")]
 async fn prune_build_test(docker: Docker) -> Result<(), Error> {
-    //create_image_hello_world(&docker).await?;
-    let mut filters = HashMap::new();
-    filters.insert("label", vec!["until=24h"]);
+    let dockerfile = format!(
+        "FROM {}alpine
+RUN echo bollard > bollard.txt
+",
+        registry_http_addr()
+    );
+    let mut header = tar::Header::new_gnu();
+    header.set_path("Dockerfile").unwrap();
+    header.set_size(dockerfile.len() as u64);
+    header.set_mode(0o755);
+    header.set_cksum();
+    let mut tar = tar::Builder::new(Vec::new());
+    tar.append(&header, dockerfile.as_bytes()).unwrap();
+
+    let uncompressed = tar.into_inner().unwrap();
+    let mut c = flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::default());
+    c.write_all(&uncompressed).unwrap();
+    let compressed = c.finish().unwrap();
+
+    let credentials = bollard::auth::DockerCredentials {
+        username: Some("bollard".to_string()),
+        password: std::env::var("REGISTRY_PASSWORD").ok(),
+        ..Default::default()
+    };
+    let mut creds_hsh = std::collections::HashMap::new();
+    creds_hsh.insert("localhost:5000".to_string(), credentials);
+
+    let id = "prune_build_test";
+
     let _ = &docker
-        .prune_build(Some(PruneBuildOptions { filters }))
+        .build_image(
+            BuildImageOptions {
+                dockerfile: "Dockerfile".to_string(),
+                t: "integration_test_prune_build".to_string(),
+                pull: true,
+                version: BuilderVersion::BuilderBuildKit,
+                rm: true,
+                #[cfg(feature = "buildkit")]
+                session: Some(String::from(id)),
+                ..Default::default()
+            },
+            Some(creds_hsh),
+            Some(http_body_util::Either::Left(Full::new(compressed.into()))),
+        )
+        .try_collect::<Vec<bollard::models::BuildInfo>>()
         .await?;
+
+    // Remove the image before running prune_build since the bytes of bollard.txt are stored in
+    // the build cache and shared with the image
+    let _ = &docker
+        .remove_image(
+            "integration_test_prune_build",
+            None::<RemoveImageOptions>,
+            None,
+        )
+        .await?;
+
+    let prune_info = docker
+        .prune_build(None::<PruneBuildOptions<String>>)
+        .await?;
+
+    assert!(matches!(prune_info.space_reclaimed, Some(1..)));
+    assert!(prune_info.caches_deleted.is_some_and(|c| !c.is_empty()));
+
+    // Since there was no filter and all images depending on cached data were removed, only cache
+    // entries with 0 size are left behind
+    assert!(docker
+        .df()
+        .await?
+        .build_cache
+        .is_some_and(|data| data.iter().all(|e| matches!(e.size, Some(0)))));
 
     Ok(())
 }
@@ -1752,6 +1820,7 @@ fn integration_test_build_buildkit_image_outputs_local() {
 }
 
 #[test]
+#[cfg(feature = "buildkit")]
 fn integration_test_prune_build() {
     connect_to_docker_and_run!(prune_build_test);
 }


### PR DESCRIPTION
I added the API that uses the `/build/prune` endpoint in Moby to clear the build cache (which powers `docker builder prune`). I named the function `prune_build` and its options struct `PruneBuildOptions`, in alignment with the other prune APIs (e.g. `prune_containers` and `PruneContainersOptions`). The already-existing `BuildPruneResponse` is used as the return type of `prune_build`, so as to be useful.

Relevant integration tests and examples updated.