### PR TITLE
bump ureq 2.9.7 -> 3.0.12 in `bollard-buildkit-proto`

### DIFF
--- a/codegen/proto/Cargo.toml
+++ b/codegen/proto/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "bollard-buildkit-proto"
 description = "Protobuf definitions to interact with buildkit using Bollard"
-version = "0.6.1"
+version = "0.6.2"
 authors = [ "Bollard contributors" ]
 license = "Apache-2.0"
 repository = "https://github.com/fussybeaver/bollard"
@@ -25,5 +25,5 @@ tonic = { version = "0.13" }
 prost = { version = "0.13" }
 prost-types = "0.13"
 tonic-build = { version = "0.13", optional = true }
-ureq = { version = "2.9.7", features = ["tls"], optional = true, default-features = false }
+ureq = { version = "3.0.12", features = ["rustls-no-provider"], optional = true, default-features = false }
 

--- a/codegen/proto/src/bin/fetch.rs
+++ b/codegen/proto/src/bin/fetch.rs
@@ -140,12 +140,13 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             .expect("Cannot retrieve dirname for resource");
         let abs_resource_dir = Path::join(&target_dir, resource_dir);
         std::fs::create_dir_all(abs_resource_dir).expect("Cannot create resource directory");
-        let response = ureq::get(resource.source)
+        let mut response = ureq::get(resource.source)
             .call()
             .expect("Cannot fetch resource URL");
         let abs_resource_file = Path::join(&target_dir, resource.destination);
         let mut src = response
-            .into_string()
+            .body_mut()
+            .read_to_string()
             .expect("Cannot create UTF8 string from HTTP response");
         for replacement in resource.replacements {
             src.find(replacement.0).expect(


### PR DESCRIPTION
This is a follow up of https://github.com/algesten/ureq/pull/1089

# Motivation

- the `webpki-roots` and `webpki-root-certs` crates recently saw a major version bump
- this means that dependency trees might include two different version of those crates. This leads to unnecessary build time increases in some situations
- `ureq` was updated (https://github.com/algesten/ureq/pull/1089) to reflect these changes 
- `bollard` uses `bollard-buildkit-proto` which in turn still uses a `2.x.y` version of `ureq`
- hence the duplication is still going on for people using the `bollard` crate

# Testing

- The crates still build fine
- I wasn't able to run the tests (yet), not because of the changes but generally (looking into it)

# Further action

This PR only includes the necessary updates to `bollard-buildkit-proto`. Once these are merged and published, `bollard`s dependency on that crate has to be bumped and everything has to be verified.