### PR TITLE
chore(release): bump version of proto dep and bollard itself

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "bollard"
 description = "An asynchronous Docker daemon API"
-version = "0.19.1"
+version = "0.19.2"
 authors = [ "Bollard contributors" ]
 license = "Apache-2.0"
 homepage = "https://github.com/fussybeaver/bollard"
@@ -52,7 +52,7 @@ ssh = ["hyper-util", "openssh", "tower-service"]
 [dependencies]
 base64 = "0.22"
 bollard-stubs = { version = "=1.48.3-rc.28.0.4", default-features = false }
-bollard-buildkit-proto = { version = "0.6.1", optional = true }
+bollard-buildkit-proto = { version = "0.6.2", optional = true }
 bytes = "1"
 chrono = { version = "0.4", default-features = false, features = ["std", "clock", "serde"], optional = true }
 futures-core = "0.3"


### PR DESCRIPTION
This is a follow up for https://github.com/fussybeaver/bollard/pull/547 . The changes are not actually used yet within `bollard` itself. So we need to:

- [ ] 1. publish a release of `bollard-buildkit-proto` (`v 0.6.2`)
- [ ] 2. then this PR here (which is currently broken) will hopefully start being green
- [ ] 3. (optional): I fix tests that are red
- [ ] 4. we can merge this PR here
- [ ] 5. a new release of `bollard` itself can be done to include the changes