### PR TITLE
Use updated RemoveVolumeOptions and implement CreateVolumeOptions stubs

### DIFF
--- a/codegen/swagger/src/query_parameters.rs
+++ b/codegen/swagger/src/query_parameters.rs
@@ -3896,7 +3896,107 @@ impl Default for ListTasksOptions
 }
 
 
+/// Builder for the `VolumeCreate` API query parameter.
+///
+/// Create a new volume.
+///
+/// ## Examples
+///
+/// ```rust
+/// use bollard_stubs::query_parameters::CreateVolumeOptionsBuilder;
+///
+/// let params = CreateVolumeOptionsBuilder::new()
+/// //  .name(/* ... */)
+/// //  .driver(/* ... */)
+/// //  .driver_opts(/* ... */)
+/// //  .labels(/* ... */)
+///     .build();
+/// ```
+#[derive(Debug, Clone, Default, PartialEq, Serialize)]
+pub struct CreateVolumeOptionsBuilder {
+    inner: CreateVolumeOptions,
+}
 
+impl CreateVolumeOptionsBuilder {
+    /// Construct a builder of query parameters for CreateVolumeOptions using defaults.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// The new volume's name. If not specified, Docker generates a name.
+    pub fn name(mut self, name: &str) -> Self {
+        self.inner.name = Some(name.into());
+        self
+    }
+    
+    /// Name of the volume driver to use.
+    pub fn driver(mut self, driver: &str) -> Self {
+        self.inner.driver = Some(driver.into());
+        self
+    }
+    
+    /// A mapping of driver options and values. These options are passed directly to the driver and are driver specific.
+    pub fn driver_opts(mut self, driver_opts: &HashMap<impl Into<String> + Clone, impl Into<String> + Clone>) -> Self {
+        let mut inner_driver_opts = HashMap::new();
+        for (key, value) in driver_opts {
+            inner_driver_opts.insert(
+                Into::<String>::into(key.clone()),
+                Into::<String>::into(value.clone()),
+            );
+        }
+        self.inner.driver_opts = Some(inner_driver_opts);
+        self
+    }
+
+    /// User-defined key/value metadata.
+    pub fn labels(mut self, labels: &HashMap<impl Into<String> + Clone, impl Into<String> + Clone>) -> Self {
+        let mut inner_labels = HashMap::new();
+        for (key, value) in labels {
+            inner_labels.insert(
+                Into::<String>::into(key.clone()),
+                Into::<String>::into(value.clone()),
+            );
+        }
+        self.inner.labels = Some(inner_labels);
+        self
+    }
+
+    /// Consume this builder and use the `CreateVolumeOptions` as parameter to the
+    /// `VolumeCreate` API
+    pub fn build(self) -> CreateVolumeOptions {
+        self.inner
+    }
+
+}
+
+/// Internal struct used in the `VolumeCreate` API
+/// 
+/// Use a [CreateVolumeOptionsBuilder] to instantiate this struct.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct CreateVolumeOptions {
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub driver: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "driverOpts")]
+    pub driver_opts: Option<HashMap<String, String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub labels: Option<HashMap<String, String>>,
+
+}
+
+impl Default for CreateVolumeOptions {
+    fn default() -> Self {
+        Self {
+            name: None,
+            driver: None,
+            driver_opts: None,
+            labels: None,
+        }
+    }
+}
 
 // Filtered out: TaskLogs
 // Get task logs

--- a/src/volume.rs
+++ b/src/volume.rs
@@ -343,7 +343,7 @@ impl Docker {
     pub async fn remove_volume(
         &self,
         volume_name: &str,
-        options: Option<impl Into<RemoveVolumeOptions>>,
+        options: Option<impl Into<crate::query_parameters::RemoveVolumeOptions>>,
     ) -> Result<(), Error> {
         let url = format!("/volumes/{volume_name}");
 


### PR DESCRIPTION
Hi, thanks for writing bollard! Apologies in advance, as I am still learning Rust.

When testing bollard, I noticed that the RemoveVolumeOptions builder was not recognized during compilation. In particular, for "volume_test.rs" if I replaced
```rs
let remove_volume_options = RemoveVolumeOptions { force: true };
```
with
```rs
let remove_volume_options = RemoveVolumeOptionsBuilder::new().force(true).build();
```
it will throw a compilation error (trait bound is not satisfied). This is addressed by 373c7a8fc5354b7f08e457bddaf99748a6dc6026; also tested it manually with the old and new RemoveVolumeOptions to make sure nothing broke.

While fixing that, I also noticed that there is a deprecation warning for CreateVolumeOptions but there is no builder in query_parameters. So I've attempted to implement it through f6dce46ce831821c7865b07c2df522cd55103c1b, by referencing the CreateImageOptions struct and [CreateVolume](https://docs.docker.com/reference/api/engine/version/v1.41/#tag/Volume/operation/VolumeCreate) docs.

I should also mention that CreateVolumeOptions is not used in function implementations in `volumes.rs`, since bollard's "crate.toml" file does not use these updated stubs (but rather bollard-stubs). Perhaps a future PR will cover this.

Please take a look and review the PR when available, and let me know if there's anything that should be changed. Thanks!