### PR TITLE
fix: incorrect /commit return type

### DIFF
--- a/src/image.rs
+++ b/src/image.rs
@@ -1457,7 +1457,7 @@ impl Docker {
         &self,
         options: impl Into<crate::query_parameters::CommitContainerOptions>,
         config: impl Into<crate::models::ContainerConfig>,
-    ) -> Result<Commit, Error> {
+    ) -> Result<IdResponse, Error> {
         let url = "/commit";
 
         let req = self.build_request(


### PR DESCRIPTION
As described in PR #578, it changes `/commit` response type from `Commit` to `IdResponse` as defined in Swagger spec:
```yaml
  /commit:
    post:
      // ...
      responses:
        201:
          description: "no error"
          schema:
            $ref: "#/definitions/IDResponse"
        // ...
```

Actual `Commit` model in Swagger model is only used in `/info` endpoint which returns `SystemInfo` model:
```yaml
  SystemInfo:
    type: "object"
    properties:
      // ...
      ContainerdCommit:
        $ref: "#/definitions/Commit"
      RuncCommit:
        $ref: "#/definitions/Commit"
      InitCommit:
        $ref: "#/definitions/Commit"
      // ...
```

Test code for `commit_container()` ignores response altogether:
https://github.com/fussybeaver/bollard/blob/5e83c3d9e489f115d3e4ae8f5f4c70eb38d1ba21/tests/image_test.rs#L211-L223