### PR TITLE
Allow building with only `pipe` feature enabled

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ webpki = ["ssl", "dep:webpki-roots"]
 chrono = ["dep:chrono", "bollard-stubs/chrono"]
 time = ["dep:time", "bollard-stubs/time"]
 http = ["hyper-util"]
-pipe = ["hyperlocal", "hyper-named-pipe"]
+pipe = ["hyper-util", "hyperlocal", "hyper-named-pipe"]
 ssh = ["hyper-util", "openssh", "tower-service"]
 
 [dependencies]

--- a/src/docker.rs
+++ b/src/docker.rs
@@ -28,7 +28,7 @@ use hyper::{self, body::Bytes, Method, Request, Response, StatusCode};
 use hyper_rustls::HttpsConnector;
 #[cfg(any(feature = "http", test))]
 use hyper_util::client::legacy::connect::HttpConnector;
-#[cfg(any(feature = "http", feature = "ssh", test))]
+#[cfg(any(feature = "http", feature = "ssh", feature = "pipe", test))]
 use hyper_util::{client::legacy::Client, rt::TokioExecutor};
 #[cfg(all(feature = "pipe", unix))]
 use hyperlocal::UnixConnector;
@@ -80,7 +80,7 @@ pub const DEFAULT_DOCKER_HOST: &str = DEFAULT_SOCKET;
 pub const DEFAULT_DOCKER_HOST: &str = DEFAULT_NAMED_PIPE;
 
 /// Default timeout for all requests is 2 minutes.
-#[cfg(any(feature = "http", feature = "ssh"))]
+#[cfg(any(feature = "http", feature = "ssh", feature = "pipe"))]
 const DEFAULT_TIMEOUT: u64 = 120;
 
 /// Default Client Version to communicate with the server.

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -165,7 +165,7 @@ pub enum Error {
         err: http::uri::InvalidUriParts,
     },
     /// Error that is never emitted
-    #[cfg(any(feature = "http", feature = "ssh"))]
+    #[cfg(any(feature = "http", feature = "ssh", feature = "pipe"))]
     #[error("Error in the hyper legacy client: {}", err)]
     HyperLegacyError {
         /// The original error emitted.


### PR DESCRIPTION
👋 Hi friend! Long time no speak. Hope you are doing well.

I tried using bollard with `default-features = false`, which was fine, but when I went to use `Docker::connect_with_socket` I saw that this was gated by the `pipe` feature.

I added that feature but unfortunately got a compile error due to missing imports!

This PR updates the cfg directives for those imports to allow the crate to be built with the `pipe` feature when `http` or `ssh` is not also present.