### PR TITLE
build: buildkit should not depend on a rustls provider by default

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,8 @@ members = [
 [features]
 default = ["http", "pipe"]
 # Enable Buildkit-enabled docker image building
-buildkit = ["chrono", "num", "rand", "tokio/fs", "tokio-stream", "tokio-util/io", "tonic", "tower-service", "ssl", "bollard-stubs/buildkit", "bollard-buildkit-proto", "dep:async-stream", "dep:bitflags"]
+buildkit = ["buildkit_providerless", "ssl"]
+buildkit_providerless = ["chrono", "num", "rand", "tokio/fs", "tokio-stream", "tokio-util/io", "tonic", "tower-service", "ssl_providerless", "bollard-stubs/buildkit", "bollard-buildkit-proto", "dep:async-stream", "dep:bitflags"]
 # Enable tests specifically for the http connector
 test_http = []
 # Enable tests specifically for the ssh connector

--- a/examples/build.rs
+++ b/examples/build.rs
@@ -40,7 +40,7 @@ async fn main() {
         .platform("linux/x86_64")
         .target("");
 
-    #[cfg(feature = "buildkit")]
+    #[cfg(feature = "buildkit_providerless")]
     let build_image_options =
         build_image_options.version(bollard::query_parameters::BuilderVersion::BuilderV1);
 

--- a/examples/build_buildkit.rs
+++ b/examples/build_buildkit.rs
@@ -1,11 +1,11 @@
 //! Builds a container with a bunch of extra options for testing
 #![allow(unused_variables, unused_mut)]
 
-#[cfg(feature = "buildkit")]
+#[cfg(feature = "buildkit_providerless")]
 use bollard::models::BuildInfoAux;
 use bollard::Docker;
 
-#[cfg(feature = "buildkit")]
+#[cfg(feature = "buildkit_providerless")]
 use futures_util::stream::StreamExt;
 use http_body_util::Full;
 
@@ -44,7 +44,7 @@ ENTRYPOINT ls buildkit-bollard.txt
         .version(bollard::query_parameters::BuilderVersion::BuilderBuildKit)
         .pull("true");
 
-    #[cfg(feature = "buildkit")]
+    #[cfg(feature = "buildkit_providerless")]
     let build_image_options = build_image_options.session(id);
 
     let mut image_build_stream = docker.build_image(
@@ -53,7 +53,7 @@ ENTRYPOINT ls buildkit-bollard.txt
         Some(http_body_util::Either::Left(Full::new(compressed.into()))),
     );
 
-    #[cfg(feature = "buildkit")]
+    #[cfg(feature = "buildkit_providerless")]
     while let Some(Ok(bollard::models::BuildInfo {
         aux: Some(BuildInfoAux::BuildKit(inner)),
         ..

--- a/examples/build_buildkit_with_cache.rs
+++ b/examples/build_buildkit_with_cache.rs
@@ -1,18 +1,18 @@
 //! Builds a container with a bunch of extra options for testing
 #![allow(unused_variables, unused_mut, unused_imports)]
 
-#[cfg(feature = "buildkit")]
+#[cfg(feature = "buildkit_providerless")]
 use bollard::grpc::registry::ImageRegistryOutput;
 use bollard::Docker;
 
-#[cfg(feature = "buildkit")]
+#[cfg(feature = "buildkit_providerless")]
 use bollard_buildkit_proto::moby::buildkit::v1::CacheOptionsEntry;
 
 use std::io::Write;
 
 #[tokio::main]
 async fn main() {
-    #[cfg(feature = "buildkit")]
+    #[cfg(feature = "buildkit_providerless")]
     {
         let mut docker = Docker::connect_with_socket_defaults().unwrap();
 

--- a/examples/export_oci_image.rs
+++ b/examples/export_oci_image.rs
@@ -3,7 +3,7 @@
 
 #[tokio::main]
 async fn main() {
-    #[cfg(feature = "buildkit")]
+    #[cfg(feature = "buildkit_providerless")]
     {
         use bollard::grpc::driver::docker_container::DockerContainerBuilder;
         use bollard::Docker;

--- a/src/grpc/driver/channel.rs
+++ b/src/grpc/driver/channel.rs
@@ -1,4 +1,4 @@
-#![cfg(feature = "buildkit")]
+#![cfg(feature = "buildkit_providerless")]
 
 use std::pin::Pin;
 

--- a/src/grpc/driver/docker_container.rs
+++ b/src/grpc/driver/docker_container.rs
@@ -1,4 +1,4 @@
-#![cfg(feature = "buildkit")]
+#![cfg(feature = "buildkit_providerless")]
 
 use std::{
     collections::HashMap,

--- a/src/grpc/driver/moby.rs
+++ b/src/grpc/driver/moby.rs
@@ -1,4 +1,4 @@
-#![cfg(feature = "buildkit")]
+#![cfg(feature = "buildkit_providerless")]
 
 use std::collections::HashMap;
 use std::pin::Pin;

--- a/src/grpc/error.rs
+++ b/src/grpc/error.rs
@@ -1,4 +1,4 @@
-#![cfg(feature = "buildkit")]
+#![cfg(feature = "buildkit_providerless")]
 
 use std::num::TryFromIntError;
 

--- a/src/grpc/export.rs
+++ b/src/grpc/export.rs
@@ -1,4 +1,4 @@
-#![cfg(feature = "buildkit")]
+#![cfg(feature = "buildkit_providerless")]
 
 pub use bollard_buildkit_proto::fsutil;
 pub use bollard_buildkit_proto::health;

--- a/src/grpc/io/into_async_read.rs
+++ b/src/grpc/io/into_async_read.rs
@@ -1,4 +1,4 @@
-#![cfg(feature = "buildkit")]
+#![cfg(feature = "buildkit_providerless")]
 
 use std::{
     cmp,

--- a/src/grpc/io/mod.rs
+++ b/src/grpc/io/mod.rs
@@ -1,4 +1,4 @@
-#![cfg(feature = "buildkit")]
+#![cfg(feature = "buildkit_providerless")]
 
 use std::{
     pin::Pin,

--- a/src/grpc/io/reader_stream.rs
+++ b/src/grpc/io/reader_stream.rs
@@ -1,4 +1,4 @@
-#![cfg(feature = "buildkit")]
+#![cfg(feature = "buildkit_providerless")]
 
 use bollard_buildkit_proto::moby::buildkit::v1::BytesMessage;
 use futures_core::stream::Stream;

--- a/src/grpc/mod.rs
+++ b/src/grpc/mod.rs
@@ -1,5 +1,5 @@
 //! GRPC plumbing to interact with Docker's buildkit client
-#![cfg(feature = "buildkit")]
+#![cfg(feature = "buildkit_providerless")]
 #![allow(dead_code)]
 
 /// End-user buildkit build functions

--- a/src/image.rs
+++ b/src/image.rs
@@ -1,12 +1,12 @@
 //! Image API: creating, manipulating and pushing docker images
 #![allow(deprecated)]
-#[cfg(feature = "buildkit")]
+#[cfg(feature = "buildkit_providerless")]
 use bollard_buildkit_proto::moby::filesync::packet::file_send_server::FileSendServer as FileSendPacketServer;
 use bytes::Bytes;
 use futures_core::Stream;
-#[cfg(feature = "buildkit")]
+#[cfg(feature = "buildkit_providerless")]
 use futures_util::future::{Either, FutureExt};
-#[cfg(feature = "buildkit")]
+#[cfg(feature = "buildkit_providerless")]
 use futures_util::stream;
 use futures_util::stream::StreamExt;
 use http::header::CONTENT_TYPE;
@@ -576,7 +576,7 @@ where
     /// RUN instruction, or for variable expansion in other `Dockerfile` instructions.
     #[serde(serialize_with = "crate::docker::serialize_as_json")]
     pub buildargs: HashMap<T, T>,
-    #[cfg(feature = "buildkit")]
+    #[cfg(feature = "buildkit_providerless")]
     /// Session ID
     pub session: Option<String>,
     /// Size of `/dev/shm` in bytes. The size must be greater than 0. If omitted the system uses 64MB.
@@ -594,7 +594,7 @@ where
     pub platform: T,
     /// Target build stage
     pub target: T,
-    #[cfg(feature = "buildkit")]
+    #[cfg(feature = "buildkit_providerless")]
     /// Specify a custom exporter.
     pub outputs: Option<ImageBuildOutput<T>>,
     /// Builder version to use
@@ -701,14 +701,14 @@ where
             );
         }
 
-        #[cfg(feature = "buildkit")]
+        #[cfg(feature = "buildkit_providerless")]
         let builder = if let Some(outputs) = opts.outputs {
             builder.outputs(outputs.into())
         } else {
             builder
         };
 
-        #[cfg(feature = "buildkit")]
+        #[cfg(feature = "buildkit_providerless")]
         let builder = if let Some(session) = opts.session {
             builder.session(&session)
         } else {
@@ -719,7 +719,7 @@ where
     }
 }
 
-#[cfg(feature = "buildkit")]
+#[cfg(feature = "buildkit_providerless")]
 /// The exporter to use (see [Docker Docs](https://docs.docker.com/reference/cli/docker/buildx/build/#output))
 #[derive(Debug, Clone, PartialEq)]
 #[deprecated(
@@ -744,7 +744,7 @@ where
     Local(T),
 }
 
-#[cfg(feature = "buildkit")]
+#[cfg(feature = "buildkit_providerless")]
 impl<T> From<ImageBuildOutput<T>> for crate::query_parameters::ImageBuildOutput
 where
     T: Into<String>,
@@ -761,7 +761,7 @@ where
     }
 }
 
-#[cfg(feature = "buildkit")]
+#[cfg(feature = "buildkit_providerless")]
 impl<T> Serialize for ImageBuildOutput<T>
 where
     T: Into<String>,
@@ -1571,7 +1571,7 @@ impl Docker {
             },
             &options,
         ) {
-            #[cfg(feature = "buildkit")]
+            #[cfg(feature = "buildkit_providerless")]
             (
                 ImageBuildBuildkitEither::Left(creds),
                 crate::query_parameters::BuildImageOptions {
@@ -1608,7 +1608,7 @@ impl Docker {
                     })
                     .boxed()
             }
-            #[cfg(feature = "buildkit")]
+            #[cfg(feature = "buildkit_providerless")]
             (
                 ImageBuildBuildkitEither::Left(_),
                 crate::query_parameters::BuildImageOptions { session: None, .. },
@@ -1616,9 +1616,9 @@ impl Docker {
                 Error::MissingSessionBuildkitError {},
             ))
             .boxed(),
-            #[cfg(not(feature = "buildkit"))]
+            #[cfg(not(feature = "buildkit_providerless"))]
             (ImageBuildBuildkitEither::Left(_), _) => unimplemented!(
-                "a buildkit enabled build without the 'buildkit' feature should not be possible"
+                "a buildkit enabled build without the 'buildkit_providerless' feature should not be possible"
             ),
             (ImageBuildBuildkitEither::Right(creds), _) => {
                 let req = self.build_request_with_registry_auth(
@@ -1646,7 +1646,7 @@ impl Docker {
         })
     }
 
-    #[cfg(feature = "buildkit")]
+    #[cfg(feature = "buildkit_providerless")]
     async fn start_session(
         &self,
         id: String,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -291,11 +291,11 @@ pub use crate::docker::{
 pub use bollard_stubs::models;
 pub use bollard_stubs::query_parameters;
 
-#[cfg(feature = "buildkit")]
+#[cfg(feature = "buildkit_providerless")]
 pub use bollard_buildkit_proto::fsutil;
 
-#[cfg(feature = "buildkit")]
+#[cfg(feature = "buildkit_providerless")]
 pub use bollard_buildkit_proto::health;
 
-#[cfg(feature = "buildkit")]
+#[cfg(feature = "buildkit_providerless")]
 pub use bollard_buildkit_proto::moby;

--- a/tests/export_test.rs
+++ b/tests/export_test.rs
@@ -105,7 +105,7 @@ async fn export_buildkit_oci_test(docker: Docker) -> Result<(), Error> {
 }
 
 #[test]
-#[cfg(feature = "buildkit")]
+#[cfg(feature = "buildkit_providerless")]
 fn integration_test_export_buildkit_oci() {
     connect_to_docker_and_run!(export_buildkit_oci_test);
 }

--- a/tests/image_test.rs
+++ b/tests/image_test.rs
@@ -451,7 +451,7 @@ RUN touch bollard.txt
     Ok(())
 }
 
-#[cfg(feature = "buildkit")]
+#[cfg(feature = "buildkit_providerless")]
 async fn build_buildkit_image_test(docker: Docker, streaming_upload: bool) -> Result<(), Error> {
     use bollard::body_stream;
 
@@ -499,7 +499,7 @@ ENTRYPOINT ls buildkit-bollard.txt
                     pull: true,
                     version: BuilderVersion::BuilderBuildKit,
                     rm: true,
-                    #[cfg(feature = "buildkit")]
+                    #[cfg(feature = "buildkit_providerless")]
                     session: Some(String::from(id)),
                     ..Default::default()
                 },
@@ -517,7 +517,7 @@ ENTRYPOINT ls buildkit-bollard.txt
                     pull: true,
                     version: BuilderVersion::BuilderBuildKit,
                     rm: true,
-                    #[cfg(feature = "buildkit")]
+                    #[cfg(feature = "buildkit_providerless")]
                     session: Some(String::from(id)),
                     ..Default::default()
                 },
@@ -595,7 +595,7 @@ ENTRYPOINT ls buildkit-bollard.txt
     Ok(())
 }
 
-#[cfg(feature = "buildkit")]
+#[cfg(feature = "buildkit_providerless")]
 async fn buildkit_image_missing_session_test(docker: Docker) -> Result<(), Error> {
     let dockerfile = String::from(
         "FROM alpine as builder1
@@ -626,7 +626,7 @@ ENTRYPOINT ls buildkit-bollard.txt
                 pull: true,
                 version: BuilderVersion::BuilderBuildKit,
                 rm: true,
-                #[cfg(feature = "buildkit")]
+                #[cfg(feature = "buildkit_providerless")]
                 session: None,
                 ..Default::default()
             },
@@ -643,7 +643,7 @@ ENTRYPOINT ls buildkit-bollard.txt
     Ok(())
 }
 
-#[cfg(feature = "buildkit")]
+#[cfg(feature = "buildkit_providerless")]
 async fn build_buildkit_secret_test(docker: Docker) -> Result<(), Error> {
     use bollard::grpc::build::SecretSource;
     use tokio::io::AsyncWriteExt;
@@ -780,7 +780,7 @@ COPY --from=builder1 /token /",
     Ok(())
 }
 
-#[cfg(feature = "buildkit")]
+#[cfg(feature = "buildkit_providerless")]
 async fn build_buildkit_custom_dockerfile_path_test(docker: Docker) -> Result<(), Error> {
     use std::path::PathBuf;
 
@@ -840,7 +840,7 @@ RUN touch bollard.txt
     Ok(())
 }
 
-#[cfg(feature = "buildkit")]
+#[cfg(feature = "buildkit_providerless")]
 async fn build_buildkit_named_context_test(docker: Docker) -> Result<(), Error> {
     let base_image = if cfg!(windows) {
         format!("{}hello-world:nanoserver", registry_http_addr())
@@ -1069,7 +1069,7 @@ RUN --mount=type=ssh git clone ssh://git@{}:{}/srv/git/config.git /config
     Ok(())
 }
 
-#[cfg(feature = "buildkit")]
+#[cfg(feature = "buildkit_providerless")]
 async fn build_buildkit_image_inline_driver_test(docker: Docker) -> Result<(), Error> {
     let dockerfile = String::from(
         "FROM localhost:5000/alpine as builder1
@@ -1192,7 +1192,7 @@ ENTRYPOINT ls buildkit-bollard.txt
 
     Ok(())
 }
-#[cfg(feature = "buildkit")]
+#[cfg(feature = "buildkit_providerless")]
 async fn build_buildkit_image_anonymous_auth_test(docker: Docker) -> Result<(), Error> {
     let dockerfile = String::from(
         "FROM node:alpine as builder1
@@ -1235,7 +1235,7 @@ RUN touch bollard.txt
     Ok(())
 }
 
-#[cfg(feature = "buildkit")]
+#[cfg(feature = "buildkit_providerless")]
 async fn build_buildkit_image_outputs_tar_test(docker: Docker) -> Result<(), Error> {
     use std::io::Read;
 
@@ -1286,9 +1286,9 @@ COPY --from=builder message-2.txt .
                 pull: true,
                 version: BuilderVersion::BuilderBuildKit,
                 rm: true,
-                #[cfg(feature = "buildkit")]
+                #[cfg(feature = "buildkit_providerless")]
                 session: Some(String::from(id)),
-                #[cfg(feature = "buildkit")]
+                #[cfg(feature = "buildkit_providerless")]
                 outputs: Some(ImageBuildOutput::Tar(
                     "/tmp/buildkit-outputs.tar".to_string(),
                 )),
@@ -1344,7 +1344,7 @@ COPY --from=builder message-2.txt .
     Ok(())
 }
 
-#[cfg(feature = "buildkit")]
+#[cfg(feature = "buildkit_providerless")]
 async fn build_buildkit_image_outputs_local_test(docker: Docker) -> Result<(), Error> {
     let dockerfile = String::from(
         "FROM localhost:5000/alpine as builder
@@ -1395,9 +1395,9 @@ RUN touch empty.txt
                 pull: true,
                 version: BuilderVersion::BuilderBuildKit,
                 rm: true,
-                #[cfg(feature = "buildkit")]
+                #[cfg(feature = "buildkit_providerless")]
                 session: Some(String::from(id)),
-                #[cfg(feature = "buildkit")]
+                #[cfg(feature = "buildkit_providerless")]
                 outputs: Some(ImageBuildOutput::Local("/tmp/buildkit-outputs".to_string())),
                 ..Default::default()
             },
@@ -1441,7 +1441,7 @@ RUN touch empty.txt
 
 // Although prune_build can be run without BuildKit enabled, only the BuildKit builder actually
 // uses it. The V1 builder caches in the form of intermediate images instead.
-#[cfg(feature = "buildkit")]
+#[cfg(feature = "buildkit_providerless")]
 async fn prune_build_test(docker: Docker) -> Result<(), Error> {
     use bollard::query_parameters::DataUsageOptions;
 
@@ -1482,7 +1482,7 @@ RUN echo bollard > bollard.txt
                 pull: true,
                 version: BuilderVersion::BuilderBuildKit,
                 rm: true,
-                #[cfg(feature = "buildkit")]
+                #[cfg(feature = "buildkit_providerless")]
                 session: Some(String::from(id)),
                 ..Default::default()
             },
@@ -1791,32 +1791,32 @@ fn integration_test_build_image() {
 }
 
 #[test]
-#[cfg(feature = "buildkit")]
+#[cfg(feature = "buildkit_providerless")]
 fn integration_test_build_buildkit_image() {
     connect_to_docker_and_run!(|docker| build_buildkit_image_test(docker, false));
     connect_to_docker_and_run!(|docker| build_buildkit_image_test(docker, true));
 }
 
 #[test]
-#[cfg(feature = "buildkit")]
+#[cfg(feature = "buildkit_providerless")]
 fn integration_test_buildkit_image_missing_session_test() {
     connect_to_docker_and_run!(buildkit_image_missing_session_test);
 }
 
 #[test]
-#[cfg(feature = "buildkit")]
+#[cfg(feature = "buildkit_providerless")]
 fn integration_test_build_buildkit_secret() {
     connect_to_docker_and_run!(build_buildkit_secret_test);
 }
 
 #[test]
-#[cfg(feature = "buildkit")]
+#[cfg(feature = "buildkit_providerless")]
 fn integration_test_build_buildkit_custom_dockerfile_path() {
     connect_to_docker_and_run!(build_buildkit_custom_dockerfile_path_test);
 }
 
 #[test]
-#[cfg(feature = "buildkit")]
+#[cfg(feature = "buildkit_providerless")]
 fn integration_test_build_buildkit_named_context() {
     connect_to_docker_and_run!(build_buildkit_named_context_test);
 }
@@ -1828,31 +1828,31 @@ fn integration_test_build_buildkit_ssh() {
 }
 
 #[test]
-#[cfg(feature = "buildkit")]
+#[cfg(feature = "buildkit_providerless")]
 fn integration_test_build_buildkit_inline_driver() {
     connect_to_docker_and_run!(build_buildkit_image_inline_driver_test);
 }
 
 #[test]
-#[cfg(feature = "buildkit")]
+#[cfg(feature = "buildkit_providerless")]
 fn integration_test_build_buildkit_anonymous_auth() {
     connect_to_docker_and_run!(build_buildkit_image_anonymous_auth_test);
 }
 
 #[test]
-#[cfg(feature = "buildkit")]
+#[cfg(feature = "buildkit_providerless")]
 fn integration_test_build_buildkit_image_outputs_tar() {
     connect_to_docker_and_run!(build_buildkit_image_outputs_tar_test);
 }
 
 #[test]
-#[cfg(feature = "buildkit")]
+#[cfg(feature = "buildkit_providerless")]
 fn integration_test_build_buildkit_image_outputs_local() {
     connect_to_docker_and_run!(build_buildkit_image_outputs_local_test);
 }
 
 #[test]
-#[cfg(feature = "buildkit")]
+#[cfg(feature = "buildkit_providerless")]
 fn integration_test_prune_build() {
     connect_to_docker_and_run!(prune_build_test);
 }


### PR DESCRIPTION
The `buildkit` feature does bring `ring` in as a dependency because it dependes on `ssl` instead of `ssl_providerless`.

This will cause the known issues with multiple rustls default providers.

To keep compatibility with current users of the `buildkit` flag I have introduced a new `buildkit_providerless` flag and fixed the conditional code checking it.