### PR TITLE
fix: proper execution branch for `buildkit_providerless`

### DIFF
--- a/src/image.rs
+++ b/src/image.rs
@@ -1562,7 +1562,7 @@ impl Docker {
         let options = options.into();
 
         match (
-            if cfg!(feature = "buildkit")
+            if cfg!(feature = "buildkit_providerless")
                 && options.version == crate::query_parameters::BuilderVersion::BuilderBuildKit
             {
                 ImageBuildBuildkitEither::Left(credentials)


### PR DESCRIPTION
Building wasn't actually working with provider-less option due to wrong execution branch selected

It led to errors like:
```
DockerStreamError { error: "debian:bookworm-slim: failed to resolve source metadata for docker.io/library/debian:bookworm-slim: no active session for 01K88X0FRZ8933A0DZATYJGY4P: context deadline exceeded" }
```

We encountered that in https://github.com/testcontainers/testcontainers-rs/pull/847
I tested this change with `testcontainers` use-cases and it seems to work good