### PR TITLE
fix: disable codegen formatting

### DIFF
--- a/codegen/proto/rustfmt.toml
+++ b/codegen/proto/rustfmt.toml
@@ -1,0 +1,1 @@
+disable_all_formatting = true

--- a/codegen/swagger/rustfmt.toml
+++ b/codegen/swagger/rustfmt.toml
@@ -1,0 +1,1 @@
+disable_all_formatting = true

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,4 +1,1 @@
 edition = "2021"
-ignore = [
-    'codegen/*'
-]


### PR DESCRIPTION
Adds `rustfmt.toml` with `disable_all_formatting = true` to `codegen/swagger/` and `codegen/proto/` to prevent cargo fmt from reformatting auto-generated code.

 ### Why

  - The root ignore option doesn't work because codegen dirs are workspace members (and ignore requires nightly)