### PR TITLE
Allow users to pass their own build reference

### DIFF
--- a/examples/build_buildkit_with_cache.rs
+++ b/examples/build_buildkit_with_cache.rs
@@ -92,6 +92,7 @@ async fn main() {
             frontend_opts,
             load_input,
             Some(creds_hsh),
+            None,
         )
         .await
         .unwrap();

--- a/examples/export_oci_image.rs
+++ b/examples/export_oci_image.rs
@@ -66,6 +66,7 @@ async fn main() {
             frontend_opts,
             load_input,
             Some(creds_hsh),
+            None,
         )
         .await
         .unwrap();

--- a/src/grpc/driver/buildkitd.rs
+++ b/src/grpc/driver/buildkitd.rs
@@ -5,6 +5,7 @@ pub use bollard_buildkit_proto::moby::buildkit::v1::control_client::ControlClien
 use crate::grpc::driver::ImageBuildFrontendOptions;
 use crate::grpc::driver::ImageBuildLoadInput;
 use crate::grpc::driver::ImageExporterEnum;
+use crate::grpc::BuildRef;
 
 use crate::grpc::registry::ImageRegistryOutput;
 use crate::grpc::DockerCredentials;
@@ -65,6 +66,7 @@ impl super::Build for BuildkitDaemon {
         frontend_opts: ImageBuildFrontendOptions,
         load_input: ImageBuildLoadInput,
         credentials: Option<HashMap<&str, DockerCredentials>>,
+        build_ref: Option<BuildRef>,
     ) -> Result<(), GrpcError> {
         let mut exporter_attrs = HashMap::new();
         exporter_attrs.insert(String::from("type"), String::from("docker"));
@@ -77,6 +79,7 @@ impl super::Build for BuildkitDaemon {
             frontend_opts,
             load_input,
             credentials,
+            build_ref,
         )
         .await
     }
@@ -89,6 +92,7 @@ impl super::Export for BuildkitDaemon {
         frontend_opts: ImageBuildFrontendOptions,
         load_input: ImageBuildLoadInput,
         credentials: Option<HashMap<&str, DockerCredentials>>,
+        build_ref: Option<BuildRef>,
     ) -> Result<(), GrpcError> {
         let (exporter, exporter_attrs, path) = match exporter_request {
             ImageExporterEnum::OCI(request) => ("oci", request.output.into_map(), request.path),
@@ -104,6 +108,7 @@ impl super::Export for BuildkitDaemon {
             frontend_opts,
             load_input,
             credentials,
+            build_ref,
         )
         .await
     }
@@ -116,6 +121,7 @@ impl super::Image for BuildkitDaemon {
         frontend_opts: ImageBuildFrontendOptions,
         load_input: ImageBuildLoadInput,
         credentials: Option<HashMap<&str, DockerCredentials>>,
+        build_ref: Option<BuildRef>,
     ) -> Result<(), GrpcError> {
         let exporter = "image";
         let exporter_attrs = output.into_map();
@@ -127,6 +133,7 @@ impl super::Image for BuildkitDaemon {
             frontend_opts,
             load_input,
             credentials,
+            build_ref,
         )
         .await
     }

--- a/src/grpc/driver/docker_container.rs
+++ b/src/grpc/driver/docker_container.rs
@@ -31,8 +31,10 @@ use crate::{
     grpc::{
         build::{ImageBuildFrontendOptions, ImageBuildLoadInput},
         error::GrpcError,
+        io::GrpcFramedTransport,
+        registry::ImageRegistryOutput,
+        BuildRef, GrpcServer,
     },
-    grpc::{io::GrpcFramedTransport, registry::ImageRegistryOutput, GrpcServer},
     Docker,
 };
 
@@ -458,6 +460,7 @@ impl super::Export for DockerContainer {
         frontend_opts: ImageBuildFrontendOptions,
         load_input: ImageBuildLoadInput,
         credentials: Option<HashMap<&str, DockerCredentials>>,
+        build_ref: Option<BuildRef>,
     ) -> Result<(), GrpcError> {
         let (exporter, exporter_attrs, path) = match exporter_request {
             ImageExporterEnum::OCI(request) => ("oci", request.output.into_map(), request.path),
@@ -473,6 +476,7 @@ impl super::Export for DockerContainer {
             frontend_opts,
             load_input,
             credentials,
+            build_ref,
         )
         .await
     }
@@ -485,6 +489,7 @@ impl super::Image for DockerContainer {
         frontend_opts: ImageBuildFrontendOptions,
         load_input: ImageBuildLoadInput,
         credentials: Option<HashMap<&str, DockerCredentials>>,
+        build_ref: Option<BuildRef>,
     ) -> Result<(), GrpcError> {
         let exporter = "image";
         let exporter_attrs = output.into_map();
@@ -496,6 +501,7 @@ impl super::Image for DockerContainer {
             frontend_opts,
             load_input,
             credentials,
+            build_ref,
         )
         .await
     }

--- a/src/grpc/driver/moby.rs
+++ b/src/grpc/driver/moby.rs
@@ -15,6 +15,7 @@ use tonic::transport::{Channel, Endpoint};
 use crate::auth::DockerCredentials;
 use crate::docker::BodyType;
 use crate::grpc::build::{ImageBuildFrontendOptions, ImageBuildLoadInput};
+use crate::grpc::BuildRef;
 use crate::{
     grpc::error::GrpcError,
     grpc::{io::GrpcTransport, GrpcClient, GrpcServer, HealthServerImpl},
@@ -136,6 +137,7 @@ impl super::Build for Moby {
         frontend_opts: ImageBuildFrontendOptions,
         load_input: ImageBuildLoadInput,
         credentials: Option<HashMap<&str, DockerCredentials>>,
+        build_ref: Option<BuildRef>,
     ) -> Result<(), GrpcError> {
         let mut exporter_attrs = HashMap::new();
         exporter_attrs.insert(String::from("type"), String::from("docker"));
@@ -148,6 +150,7 @@ impl super::Build for Moby {
             frontend_opts,
             load_input,
             credentials,
+            build_ref,
         )
         .await
     }

--- a/src/grpc/driver/mod.rs
+++ b/src/grpc/driver/mod.rs
@@ -15,7 +15,10 @@ use tonic::{
     codegen::InterceptedService, metadata::MetadataValue, service::Interceptor, transport::Channel,
 };
 
-use crate::{auth::DockerCredentials, grpc::build::ImageBuildFrontendOptionsIngest};
+use crate::{
+    auth::DockerCredentials,
+    grpc::{build::ImageBuildFrontendOptionsIngest, BuildRef},
+};
 
 use super::{
     build::{ImageBuildFrontendOptions, ImageBuildLoadInput},
@@ -110,6 +113,7 @@ pub trait Export {
         frontend_opts: ImageBuildFrontendOptions,
         load_input: ImageBuildLoadInput,
         credentials: Option<HashMap<&str, DockerCredentials>>,
+        build_ref: Option<BuildRef>,
     ) -> Result<(), GrpcError>;
 }
 
@@ -122,6 +126,7 @@ pub trait Build {
         frontend_opts: ImageBuildFrontendOptions,
         load_input: ImageBuildLoadInput,
         credentials: Option<HashMap<&str, DockerCredentials>>,
+        build_ref: Option<BuildRef>,
     ) -> Result<(), GrpcError>;
 }
 
@@ -134,9 +139,14 @@ pub trait Image {
         frontend_opts: ImageBuildFrontendOptions,
         load_input: ImageBuildLoadInput,
         credentials: Option<HashMap<&str, DockerCredentials>>,
+        build_ref: Option<BuildRef>,
     ) -> Result<(), GrpcError>;
 }
 
+#[allow(
+    clippy::too_many_arguments,
+    reason = "The nature of this function requires many parameters, maybe we can eventually create a Request structure?"
+)]
 pub(crate) async fn solve(
     driver: impl Driver,
     exporter: &str,
@@ -145,6 +155,7 @@ pub(crate) async fn solve(
     frontend_opts: ImageBuildFrontendOptions,
     load_input: ImageBuildLoadInput,
     credentials: Option<HashMap<&str, DockerCredentials>>,
+    build_ref: Option<super::BuildRef>,
 ) -> Result<(), GrpcError> {
     let session_id = crate::grpc::new_id();
 
@@ -211,10 +222,10 @@ pub(crate) async fn solve(
         .max_decoding_message_size(DEFAULT_MAX_RECV_MSG_SIZE)
         .max_encoding_message_size(DEFAULT_MAX_SEND_MSG_SIZE);
 
-    let id = super::new_id();
+    let id = build_ref.unwrap_or_default();
 
     let solve_request = SolveRequest {
-        r#ref: id,
+        r#ref: id.into(),
         cache: Some(CacheOptions {
             export_ref_deprecated: String::new(),
             import_refs_deprecated: Vec::new(),

--- a/src/grpc/mod.rs
+++ b/src/grpc/mod.rs
@@ -938,6 +938,38 @@ impl Service<tonic::transport::Uri> for GrpcClient {
     }
 }
 
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+/// A reference to a build within a BuildKit session
+/// It may be used to keep track of the progress of a build in BuildKit.
+///
+/// See [`bollard_buildkit_proto::moby::buildkit::v1::control_client::ControlClient::status`].
+pub struct BuildRef(String);
+
+impl From<BuildRef> for String {
+    fn from(value: BuildRef) -> Self {
+        value.0
+    }
+}
+
+impl AsRef<str> for BuildRef {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
+impl Default for BuildRef {
+    fn default() -> Self {
+        Self::random()
+    }
+}
+
+impl BuildRef {
+    /// Generate a new, random BuildRef
+    pub fn random() -> Self {
+        Self(new_id())
+    }
+}
+
 // Reference: https://github.com/moby/buildkit/blob/master/identity/randomid.go
 pub(crate) fn new_id() -> String {
     let mut p: [u8; 17] = Default::default();

--- a/tests/export_test.rs
+++ b/tests/export_test.rs
@@ -73,6 +73,7 @@ async fn export_buildkit_oci_test(docker: Docker) -> Result<(), Error> {
         frontend_opts,
         load_input,
         Some(creds_hsh),
+        None,
     )
     .await;
 

--- a/tests/image_test.rs
+++ b/tests/image_test.rs
@@ -727,6 +727,7 @@ COPY --from=builder1 /token /",
         frontend_opts,
         load_input,
         Some(creds_hsh),
+        None,
     )
     .await;
 
@@ -854,6 +855,7 @@ RUN touch bollard.txt
         frontend_opts,
         load_input,
         Some(creds_hsh),
+        None,
     )
     .await;
 
@@ -918,6 +920,7 @@ async fn build_buildkit_named_context_test(docker: Docker) -> Result<(), Error> 
         frontend_opts,
         load_input,
         Some(creds_hsh),
+        None,
     )
     .await;
 
@@ -1041,6 +1044,7 @@ RUN --mount=type=ssh git clone ssh://git@{}:{}/srv/git/config.git /config
         frontend_opts,
         load_input,
         Some(creds_hsh),
+        None,
     )
     .await;
 
@@ -1166,6 +1170,7 @@ ENTRYPOINT ls buildkit-bollard.txt
         frontend_opts,
         load_input,
         Some(creds_hsh),
+        None,
     )
     .await;
 
@@ -1258,9 +1263,15 @@ RUN touch bollard.txt
     let load_input =
         bollard::grpc::build::ImageBuildLoadInput::Upload(bytes::Bytes::from(compressed));
 
-    let res =
-        bollard::grpc::driver::Build::docker_build(driver, name, frontend_opts, load_input, None)
-            .await;
+    let res = bollard::grpc::driver::Build::docker_build(
+        driver,
+        name,
+        frontend_opts,
+        load_input,
+        None,
+        None,
+    )
+    .await;
 
     assert!(res.is_ok());
     let _ = &docker


### PR DESCRIPTION
By randomly generating the build references users can't really use BuildKits status API. 

Unfortunately this is a breaking change as I had to change the function signatures. I've considered adding it to the `ImageBuildFrontendOptions` but I don't think it really belongs there. 