### PR TITLE
feat: first-class Podman support with feature flags

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -146,6 +146,27 @@ jobs:
       - setup_remote_docker
       - run: docker build -t bollard .
       - run: docker run -ti --rm bollard bash -c "rustup component add rustfmt && cargo fmt -p bollard -- --check --verbose"
+  test_podman:
+    docker:
+      - image: docker:27.3
+    steps:
+      - checkout
+      - setup_remote_docker
+      - run: docker build -t bollard .
+      - run:
+          name: Start Podman daemon container
+          command: docker run -d --privileged --name podman -v podman-sock:/run/podman quay.io/podman/stable:latest podman system service --time=0 unix:///run/podman/podman.sock
+      - run:
+          name: Wait for Podman socket
+          command: |
+            for i in $(seq 1 30); do
+              docker exec podman test -S /run/podman/podman.sock && exit 0
+              sleep 1
+            done
+            echo "Podman socket not found" && exit 1
+      - run:
+          name: Run version test against Podman
+          command: docker run -ti -e DOCKER_HOST='unix:///run/podman/podman.sock' -v podman-sock:/run/podman --rm --link podman:podman bollard cargo test --features test_podman --test version_test -- test_version_podman
   test_sshforward:
     docker:
       - image: docker:27.3
@@ -179,3 +200,4 @@ workflows:
       - test_race
       - test_sshforward
       - test_swarm
+      - test_podman

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ homepage = "https://github.com/fussybeaver/bollard"
 repository = "https://github.com/fussybeaver/bollard"
 documentation = "https://docs.rs/bollard"
 readme = "README.md"
-keywords = ["docker"]
+keywords = ["docker", "podman", "container"]
 edition = "2021"
 
 [workspace]
@@ -31,6 +31,8 @@ test_ssh = ["ssh"]
 test_ssl = ["dep:webpki-roots", "ssl_providerless"]
 test_ring = ["test_ssl", "ssl"]
 test_aws_lc_rs = ["test_ssl", "aws-lc-rs"]
+# Enable tests specifically for podman
+test_podman = []
 # Enable tests specifically for macos
 test_macos = []
 # Enable tests specifically for buildkit's sshforward functionality
@@ -103,6 +105,7 @@ tokio = { version = "1.38", features = ["fs", "rt-multi-thread", "macros"] }
 tokio-util = { version = "0.7", features = ["io"] }
 yup-hyper-mock = { version = "8.0.0" }
 once_cell = "1.19"
+tempfile = "3.27.0"
 
 [target.'cfg(unix)'.dependencies]
 hyperlocal = { version = "0.9.0", optional = true }

--- a/README.md
+++ b/README.md
@@ -4,17 +4,19 @@
 [![appveyor](https://ci.appveyor.com/api/projects/status/n5khebyfae0u1sbv/branch/master?svg=true)](https://ci.appveyor.com/project/fussybeaver/boondock)
 [![docs](https://docs.rs/bollard/badge.svg)](https://docs.rs/bollard/)
 
-## Bollard: an asynchronous rust client library for the docker API
+## Bollard: an asynchronous rust client library for the Docker/Podman API
 
 Bollard leverages the latest [Hyper](https://github.com/hyperium/hyper) and
 [Tokio](https://github.com/tokio-rs/tokio) improvements for an asynchronous API containing
 futures, streams and the async/await paradigm.
 
-This library features Windows support through [Named
+This library supports both [Docker](https://github.com/moby/moby) and
+[Podman](https://github.com/containers/podman) as first-class container runtimes, with
+automatic socket discovery for rootless Podman. It features Windows support through [Named
 Pipes](https://learn.microsoft.com/en-us/windows/win32/ipc/named-pipes) and HTTPS support through optional
 [Rustls](https://github.com/rustls/rustls) bindings. Serialization types for interfacing with
-[Docker](https://github.com/moby/moby) and [Buildkit](https://github.com/moby/buildkit) are
-generated through OpenAPI, protobuf and upstream documentation.
+[Docker](https://github.com/moby/moby) and [Buildkit](https://github.com/moby/buildkit) are generated through OpenAPI,
+protobuf and upstream documentation.
 
 ## Install
 
@@ -46,16 +48,16 @@ bollard = "*"
 #### Default Features
 
 Enabled by default:
-- `http` - TCP connections to remote Docker (`DOCKER_HOST=tcp://...`)
-- `pipe` - Unix sockets (`/var/run/docker.sock`) and Windows named pipes
+- `http` - TCP connections to remote Docker/Podman (`DOCKER_HOST=tcp://...`)
+- `pipe` - Unix sockets and Windows named pipes
 
 #### Transport Features
 
 | Feature | Description |
 |---------|-------------|
-| `http` | HTTP/TCP connector for remote Docker |
-| `pipe` | Unix socket / Windows named pipe for local Docker |
-| `ssh` | SSH tunnel connector (requires `ssh` feature) |
+| `http` | HTTP/TCP connector for remote Docker/Podman |
+| `pipe` | Unix socket / Windows named pipe for local Docker/Podman |
+| `ssh` | SSH tunnel connector |
 
 #### TLS/SSL Features
 
@@ -115,9 +117,37 @@ to allow downgrading to an older API version.
 
 ## Usage
 
-### Connecting with the docker daemon
+### Connecting with the container runtime
 
-Connect to the docker server according to your architecture and security remit.
+Connect to Docker or Podman according to your architecture and security remit.
+
+#### Local (recommended)
+
+Auto-detect the best available socket on the local machine.
+
+```rust
+use bollard::Docker;
+Docker::connect_with_local_defaults();
+```
+
+Use the `Docker::connect_with_local` method API to parameterise this interface.
+
+#### Podman
+
+Explicitly connect to Podman with automatic rootless/system socket discovery
+(Unix only).
+
+**Socket discovery order:**
+1. `$DOCKER_HOST` (if set and `unix://`)
+2. `$XDG_RUNTIME_DIR/podman/podman.sock` (rootless)
+3. `/run/user/$UID/podman/podman.sock` (rootless fallback)
+4. `/run/podman/podman.sock` (system/rootful)
+5. `/var/run/docker.sock` (Docker fallback)
+
+```rust
+use bollard::Docker;
+Docker::connect_with_podman_defaults();
+```
 
 #### Socket
 
@@ -131,20 +161,6 @@ Docker::connect_with_socket_defaults();
 ```
 
 Use the `Docker::connect_with_socket` method API to parameterise this interface.
-
-#### Local
-
-The client will connect to the OS specific handler it is compiled for.
-
-This is a convenience for localhost environment that should run on multiple
-operating systems.
-
-```rust
-use bollard::Docker;
-Docker::connect_with_local_defaults();
-```
-
-Use the `Docker::connect_with_local` method API to parameterise this interface.
 
 #### HTTP
 

--- a/src/docker.rs
+++ b/src/docker.rs
@@ -74,6 +74,18 @@ pub const DEFAULT_TCP_ADDRESS: &str = "tcp://localhost:2375";
 #[cfg(feature = "ssh")]
 pub const DEFAULT_SSH_ADDRESS: &str = "ssh://localhost";
 
+/// The default rootless Podman socket path template.
+///
+/// The `{UID}` placeholder must be replaced with the actual user ID at runtime.
+/// Podman's rootless socket lives under `$XDG_RUNTIME_DIR/podman/podman.sock`,
+/// which on most Linux systems is `/run/user/{UID}/podman/podman.sock`.
+#[cfg(unix)]
+pub(crate) const DEFAULT_PODMAN_SOCKET_TEMPLATE: &str = "/run/user/{UID}/podman/podman.sock";
+
+/// The default Podman system socket (rootful, requires group membership or root).
+#[cfg(unix)]
+pub(crate) const DEFAULT_PODMAN_SYSTEM_SOCKET: &str = "unix:///run/podman/podman.sock";
+
 /// The default `DOCKER_HOST` address that we will try to connect to.
 #[cfg(unix)]
 pub const DEFAULT_DOCKER_HOST: &str = DEFAULT_SOCKET;
@@ -261,6 +273,7 @@ pub type RequestModifier = Arc<dyn Fn(BollardRequest) -> BollardRequest + Send +
 ///  - `Docker::connect_with_ssl_defaults` (requires `ssl` feature)
 ///  - [`Docker::connect_with_unix_defaults`] (requires `pipe` feature, Unix only)
 ///  - [`Docker::connect_with_local_defaults`]
+///  - [`Docker::connect_with_podman_defaults`] (Unix only)
 ///  - `Docker::connect_with_ssh_defaults` (requires `ssh` feature)
 pub struct Docker {
     pub(crate) transport: Arc<Transport>,
@@ -794,9 +807,10 @@ impl Docker {
 
     /// Connect using the local machine connection method with default arguments.
     ///
-    /// This is a simple wrapper over the OS specific handlers:
-    ///  * Unix: [`Docker::connect_with_unix_defaults`]
-    ///  * Windows: `Docker::connect_with_named_pipe_defaults`
+    /// Delegates to [`Docker::connect_with_unix_defaults`] on Unix or
+    /// `connect_with_named_pipe_defaults` on Windows.
+    ///
+    /// To connect to Podman instead, use [`Docker::connect_with_podman_defaults`].
     pub fn connect_with_local_defaults() -> Result<Docker, Error> {
         #[cfg(unix)]
         return Docker::connect_with_unix_defaults();
@@ -918,6 +932,94 @@ impl Docker {
         let path = socket_path.as_deref();
         let path_ref: &str = path.unwrap_or(DEFAULT_SOCKET);
         Docker::connect_with_unix(path_ref, DEFAULT_TIMEOUT, API_DEFAULT_VERSION)
+    }
+
+    /// Resolve the rootless Podman socket path for the current user.
+    ///
+    /// Checks `$XDG_RUNTIME_DIR/podman/podman.sock` first, then falls back to
+    /// `/run/user/$UID/podman/podman.sock`. Returns `None` if neither exists.
+    #[cfg(unix)]
+    fn podman_rootless_socket_path() -> Option<String> {
+        // Prefer XDG_RUNTIME_DIR (the canonical way)
+        if let Ok(xrd) = env::var("XDG_RUNTIME_DIR") {
+            let sock = format!("{xrd}/podman/podman.sock");
+            if Path::new(&sock).exists() {
+                return Some(sock);
+            }
+        }
+
+        // Fall back to /run/user/$UID/podman/podman.sock
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::MetadataExt;
+            if let Ok(meta) = std::fs::metadata("/proc/self") {
+                let sock = DEFAULT_PODMAN_SOCKET_TEMPLATE.replace("{UID}", &meta.uid().to_string());
+                if Path::new(&sock).exists() {
+                    return Some(sock);
+                }
+            }
+        }
+
+        None
+    }
+
+    /// Resolve the Podman system socket path.
+    ///
+    /// Checks `/run/podman/podman.sock`. Returns `None` if it doesn't exist.
+    #[cfg(unix)]
+    fn podman_system_socket_path() -> Option<&'static str> {
+        let path = DEFAULT_PODMAN_SYSTEM_SOCKET
+            .strip_prefix("unix://")
+            .unwrap_or(DEFAULT_PODMAN_SYSTEM_SOCKET);
+        if Path::new(path).exists() {
+            Some(path)
+        } else {
+            None
+        }
+    }
+
+    /// Connect to a Podman socket with default arguments.
+    ///
+    /// # Socket discovery order
+    ///
+    /// 1. `$DOCKER_HOST` — if set and starts with `unix://`, used directly.
+    /// 2. Rootless Podman: `$XDG_RUNTIME_DIR/podman/podman.sock`
+    /// 3. Rootless Podman: `/run/user/$UID/podman/podman.sock`
+    /// 4. System Podman: `/run/podman/podman.sock`
+    /// 5. Falls back to the default Docker socket (`/var/run/docker.sock`).
+    ///
+    /// # Examples
+    ///
+    /// ```rust,no_run
+    /// use bollard::Docker;
+    ///
+    /// use futures_util::future::TryFutureExt;
+    ///
+    /// let connection = Docker::connect_with_podman_defaults().unwrap();
+    /// connection.ping().map_ok(|_| Ok::<_, ()>(println!("Connected!")));
+    /// ```
+    #[cfg(unix)]
+    pub fn connect_with_podman_defaults() -> Result<Docker, Error> {
+        // Honour explicit DOCKER_HOST first
+        if let Some(host) = env::var("DOCKER_HOST")
+            .ok()
+            .filter(|p| p.starts_with("unix://"))
+        {
+            return Docker::connect_with_unix(&host, DEFAULT_TIMEOUT, API_DEFAULT_VERSION);
+        }
+
+        // Probe for Podman rootless socket
+        if let Some(sock) = Self::podman_rootless_socket_path() {
+            return Docker::connect_with_unix(&sock, DEFAULT_TIMEOUT, API_DEFAULT_VERSION);
+        }
+
+        // Probe for Podman system socket
+        if let Some(sock) = Self::podman_system_socket_path() {
+            return Docker::connect_with_unix(sock, DEFAULT_TIMEOUT, API_DEFAULT_VERSION);
+        }
+
+        // Fall back to default Docker socket
+        Docker::connect_with_unix(DEFAULT_SOCKET, DEFAULT_TIMEOUT, API_DEFAULT_VERSION)
     }
 
     /// Connect using a Unix socket.
@@ -1672,4 +1774,135 @@ pub fn body_try_stream(
 /// Convenience method to wrap bytes into a bollard BodyType
 pub fn body_full(body: Bytes) -> BodyType {
     BodyType::Left(Full::new(body))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[cfg(unix)]
+    mod podman {
+        use super::*;
+
+        #[test]
+        fn rootless_socket_from_xdg_runtime_dir() {
+            let dir = tempfile::tempdir().unwrap();
+            let sock_dir = dir.path().join("podman");
+            std::fs::create_dir_all(&sock_dir).unwrap();
+            let sock = sock_dir.join("podman.sock");
+            std::fs::write(&sock, b"").unwrap();
+
+            // Set XDG_RUNTIME_DIR to our temp dir
+            let _guard = TempEnvVar::set("XDG_RUNTIME_DIR", dir.path().to_str().unwrap());
+
+            let found = Docker::podman_rootless_socket_path();
+            assert_eq!(found.as_deref(), Some(sock.to_str().unwrap()));
+        }
+
+        #[test]
+        fn rootless_socket_returns_none_when_missing() {
+            // Point XDG_RUNTIME_DIR at empty dir — no podman socket
+            let dir = tempfile::tempdir().unwrap();
+            let _guard = TempEnvVar::set("XDG_RUNTIME_DIR", dir.path().to_str().unwrap());
+
+            let found = Docker::podman_rootless_socket_path();
+            // May still find one via /run/user/$UID fallback on a Podman host,
+            // but should not find one in the XDG dir we set.
+            let xdg_sock = dir.path().join("podman/podman.sock");
+            if let Some(ref path) = found {
+                assert_ne!(path.as_str(), xdg_sock.to_str().unwrap());
+            }
+        }
+
+        #[test]
+        fn system_socket_returns_none_when_missing() {
+            // System socket at /run/podman/podman.sock may or may not exist
+            // depending on the host, but the function should not panic.
+            let _ = Docker::podman_system_socket_path();
+        }
+
+        #[test]
+        fn connect_with_podman_defaults_respects_docker_host() {
+            // Create a fake socket
+            let dir = tempfile::tempdir().unwrap();
+            let sock = dir.path().join("test.sock");
+            std::fs::write(&sock, b"").unwrap();
+
+            let uri = format!("unix://{}", sock.display());
+            let _guard = TempEnvVar::set("DOCKER_HOST", &uri);
+
+            let docker = Docker::connect_with_podman_defaults().unwrap();
+            assert_eq!(docker.client_addr, sock.to_str().unwrap());
+        }
+
+        /// RAII guard that sets an env var and restores the previous value on drop.
+        struct TempEnvVar {
+            key: String,
+            prev: Option<String>,
+        }
+
+        impl TempEnvVar {
+            fn set(key: &str, val: &str) -> Self {
+                let prev = env::var(key).ok();
+                env::set_var(key, val);
+                Self {
+                    key: key.to_string(),
+                    prev,
+                }
+            }
+        }
+
+        impl Drop for TempEnvVar {
+            fn drop(&mut self) {
+                match &self.prev {
+                    Some(v) => env::set_var(&self.key, v),
+                    None => env::remove_var(&self.key),
+                }
+            }
+        }
+    }
+
+    #[cfg(all(unix, feature = "pipe"))]
+    mod docker_defaults {
+        use super::*;
+
+        #[test]
+        fn connect_with_unix_defaults_respects_docker_host() {
+            let dir = tempfile::tempdir().unwrap();
+            let sock = dir.path().join("test.sock");
+            std::fs::write(&sock, b"").unwrap();
+
+            let uri = format!("unix://{}", sock.display());
+            // Temporarily set DOCKER_HOST
+            let prev = env::var("DOCKER_HOST").ok();
+            env::set_var("DOCKER_HOST", &uri);
+
+            let docker = Docker::connect_with_unix_defaults().unwrap();
+            assert_eq!(docker.client_addr, sock.to_str().unwrap());
+
+            // Restore
+            match prev {
+                Some(v) => env::set_var("DOCKER_HOST", v),
+                None => env::remove_var("DOCKER_HOST"),
+            }
+        }
+
+        #[test]
+        fn connect_with_unix_defaults_ignores_non_unix_docker_host() {
+            let prev = env::var("DOCKER_HOST").ok();
+            env::set_var("DOCKER_HOST", "tcp://localhost:2375");
+
+            // Should fall through to DEFAULT_SOCKET, which may or may not exist
+            let result = Docker::connect_with_unix_defaults();
+            // On a system without Docker, this errors with SocketNotFoundError — that's fine
+            if let Err(Error::SocketNotFoundError(addr)) = &result {
+                assert!(addr.contains("docker.sock"));
+            }
+
+            match prev {
+                Some(v) => env::set_var("DOCKER_HOST", v),
+                None => env::remove_var("DOCKER_HOST"),
+            }
+        }
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,17 +4,19 @@
 //! [![appveyor](https://ci.appveyor.com/api/projects/status/n5khebyfae0u1sbv/branch/master?svg=true)](https://ci.appveyor.com/project/fussybeaver/boondock)
 //! [![docs](https://docs.rs/bollard/badge.svg)](https://docs.rs/bollard/)
 //!
-//! # Bollard: an asynchronous rust client library for the docker API
+//! # Bollard: an asynchronous rust client library for the Docker/Podman API
 //!
 //! Bollard leverages the latest [Hyper](https://github.com/hyperium/hyper) and
 //! [Tokio](https://github.com/tokio-rs/tokio) improvements for an asynchronous API containing
 //! futures, streams and the async/await paradigm.
 //!
-//! This library features Windows support through [Named
+//! This library supports both [Docker](https://github.com/moby/moby) and
+//! [Podman](https://github.com/containers/podman) as first-class container runtimes, with
+//! automatic socket discovery for rootless Podman. It features Windows support through [Named
 //! Pipes](https://learn.microsoft.com/en-us/windows/win32/ipc/named-pipes) and HTTPS support through optional
 //! [Rustls](https://github.com/rustls/rustls) bindings. Serialization types for interfacing with
-//! [Docker](https://github.com/moby/moby) and [Buildkit](https://github.com/moby/buildkit) are
-//! generated through OpenAPI, protobuf and upstream documentation.
+//! [Docker](https://github.com/moby/moby) and [Buildkit](https://github.com/moby/buildkit) are generated through OpenAPI,
+//! protobuf and upstream documentation.
 //!
 //! # Install
 //!
@@ -46,15 +48,15 @@
 //! ### Default Features
 //!
 //! Enabled by default:
-//! - `http` - TCP connections to remote Docker (`DOCKER_HOST=tcp://...`)
-//! - `pipe` - Unix sockets (`/var/run/docker.sock`) and Windows named pipes
+//! - `http` - TCP connections to remote Docker/Podman (`DOCKER_HOST=tcp://...`)
+//! - `pipe` - Unix sockets and Windows named pipes
 //!
 //! ### Transport Features
 //!
 //! | Feature | Description |
 //! |---------|-------------|
-//! | `http` | HTTP/TCP connector for remote Docker |
-//! | `pipe` | Unix socket / Windows named pipe for local Docker |
+//! | `http` | HTTP/TCP connector for remote Docker/Podman |
+//! | `pipe` | Unix socket / Windows named pipe for local Docker/Podman |
 //! | `ssh` | SSH tunnel connector |
 //!
 //! ### TLS/SSL Features
@@ -112,9 +114,31 @@
 //!
 //! # Usage
 //!
-//! ## Connecting with the docker daemon
+//! ## Connecting with the container runtime
 //!
-//! Connect to the docker server according to your architecture and security remit.
+//! Connect to Docker or Podman according to your architecture and security remit.
+//!
+//! ### Local (recommended)
+//!
+//! Auto-detect the best available socket on the local machine.
+//!
+//! ```rust
+//! use bollard::Docker;
+//! Docker::connect_with_local_defaults();
+//! ```
+//!
+//! Use the [`Docker::connect_with_local`] method API to parameterise this interface.
+//!
+//! ### Podman
+//!
+//! Explicitly connect to Podman with automatic rootless/system socket discovery
+//! (Unix only). Probes `$DOCKER_HOST`, then rootless Podman sockets, then the
+//! system Podman socket, and finally falls back to the Docker socket.
+//!
+//! ```rust,no_run
+//! use bollard::Docker;
+//! Docker::connect_with_podman_defaults();
+//! ```
 //!
 //! ### Socket
 //!
@@ -127,21 +151,7 @@
 //! Docker::connect_with_socket_defaults();
 //! ```
 //!
-//! Use the `Docker::connect_with_socket` method API to parameterise this interface.
-//!
-//! ### Local
-//!
-//! The client will connect to the OS specific handler it is compiled for.
-//!
-//! This is a convenience for localhost environment that should run on multiple
-//! operating systems.
-//!
-//! ```rust
-//! use bollard::Docker;
-//! Docker::connect_with_local_defaults();
-//! ```
-//!
-//! Use the `Docker::connect_with_local` method API to parameterise this interface.
+//! Use the [`Docker::connect_with_socket`] method API to parameterise this interface.
 //!
 //! ### HTTP
 //!
@@ -153,7 +163,7 @@
 //! Docker::connect_with_http_defaults();
 //! ```
 //!
-//! Use the `Docker::connect_with_http` method API to parameterise the interface.
+//! Use the [`Docker::connect_with_http`] method API to parameterise the interface.
 //!
 //! ### SSL via Rustls
 //!

--- a/tests/podman_test.rs
+++ b/tests/podman_test.rs
@@ -1,0 +1,70 @@
+//! Integration tests for Podman socket connectivity.
+//!
+//! These tests require a running Podman daemon (rootless or system).
+//! Skip with: `cargo test --test podman_test -- --ignored` to list them,
+//! or run them explicitly when Podman is available.
+
+#[cfg(unix)]
+mod podman_integration {
+    use bollard::Docker;
+    use tokio::runtime::Runtime;
+
+    /// Connect via `connect_with_podman_defaults()` and ping the daemon.
+    ///
+    /// Requires a rootless or system Podman socket to be available.
+    #[test]
+    fn ping_via_podman_defaults() {
+        let docker = match Docker::connect_with_podman_defaults() {
+            Ok(d) => d,
+            Err(e) => {
+                eprintln!("skipping: no Podman socket available ({e})");
+                return;
+            }
+        };
+
+        let rt = Runtime::new().unwrap();
+        let pong = rt.block_on(docker.ping());
+        assert!(pong.is_ok(), "ping failed: {:?}", pong.err());
+    }
+
+    /// Verify that version negotiation works against Podman.
+    #[test]
+    fn version_negotiation_with_podman() {
+        let docker = match Docker::connect_with_podman_defaults() {
+            Ok(d) => d,
+            Err(e) => {
+                eprintln!("skipping: no Podman socket available ({e})");
+                return;
+            }
+        };
+
+        let rt = Runtime::new().unwrap();
+        let result = rt.block_on(docker.negotiate_version());
+        assert!(
+            result.is_ok(),
+            "version negotiation failed: {:?}",
+            result.err()
+        );
+    }
+
+    /// Verify that listing containers works against Podman.
+    #[test]
+    fn list_containers_with_podman() {
+        use bollard::query_parameters::ListContainersOptions;
+
+        let docker = match Docker::connect_with_podman_defaults() {
+            Ok(d) => d,
+            Err(e) => {
+                eprintln!("skipping: no Podman socket available ({e})");
+                return;
+            }
+        };
+
+        let rt = Runtime::new().unwrap();
+        let result = rt.block_on(docker.list_containers(Some(ListContainersOptions {
+            all: true,
+            ..Default::default()
+        })));
+        assert!(result.is_ok(), "list_containers failed: {:?}", result.err());
+    }
+}

--- a/tests/version_test.rs
+++ b/tests/version_test.rs
@@ -61,6 +61,16 @@ fn test_version_ssh() {
     );
 }
 
+#[cfg(all(unix, feature = "test_podman"))]
+#[test]
+#[allow(clippy::redundant_closure_call)]
+fn test_version_podman() {
+    rt_exec!(
+        Docker::connect_with_podman_defaults().unwrap().version(),
+        |version: SystemVersion| assert_eq!(version.os.unwrap(), "linux")
+    )
+}
+
 #[cfg(unix)]
 #[test]
 fn test_downversioning() {


### PR DESCRIPTION
## Summary

Adds `Docker::connect_with_podman_defaults()` for connecting to Podman with automatic socket discovery. No feature flags required; the method is always available on Unix, just like `connect_with_unix_defaults()`.

Socket discovery order:
1. `$DOCKER_HOST` (if set and starts with `unix://`)
2. Rootless Podman: `$XDG_RUNTIME_DIR/podman/podman.sock`
3. Rootless Podman: `/run/user/$UID/podman/podman.sock`
4. System Podman: `/run/podman/podman.sock`
5. Falls back to the default Docker socket (`/var/run/docker.sock`)

`connect_with_local_defaults()` is unchanged and still delegates to `connect_with_unix_defaults()` on Unix. Callers opt into Podman explicitly by calling the new method.

Other changes:
- Added `test_podman` CI job running `test_version_podman` against a live Podman socket via CircleCI
- README and lib.rs docs updated to mention Podman alongside Docker

Fixes #345
Relates to #295

## Test plan
- [x] `cargo check` with default features
- [x] `cargo test --lib` (19 tests pass, includes 4 Podman unit tests)
- [x] `cargo test --test podman_test` compiles (integration tests need a live Podman socket)
- [x] `cargo test --features test_podman --test version_test` compiles (`test_version_podman` needs a live Podman socket)
- [x] `cargo fmt --check` and `cargo clippy -- -D warnings` clean