### PR TITLE
fix: add missing 'stopping' variant to container state enums

### DIFF
--- a/codegen/swagger/src/models.rs
+++ b/codegen/swagger/src/models.rs
@@ -1682,6 +1682,8 @@ pub enum ContainerStateStatusEnum {
     EXITED,
     #[serde(rename = "dead")]
     DEAD,
+    #[serde(rename = "stopping")]
+    STOPPING,
 }
 
 impl ::std::fmt::Display for ContainerStateStatusEnum {
@@ -1695,6 +1697,7 @@ impl ::std::fmt::Display for ContainerStateStatusEnum {
             ContainerStateStatusEnum::REMOVING => write!(f, "{}", "removing"),
             ContainerStateStatusEnum::EXITED => write!(f, "{}", "exited"),
             ContainerStateStatusEnum::DEAD => write!(f, "{}", "dead"),
+            ContainerStateStatusEnum::STOPPING => write!(f, "{}", "stopping"),
 
         }
     }
@@ -1712,6 +1715,7 @@ impl ::std::str::FromStr for ContainerStateStatusEnum {
             "removing" => Ok(ContainerStateStatusEnum::REMOVING),
             "exited" => Ok(ContainerStateStatusEnum::EXITED),
             "dead" => Ok(ContainerStateStatusEnum::DEAD),
+            "stopping" => Ok(ContainerStateStatusEnum::STOPPING),
             x => Err(format!("Invalid enum type: {}", x)),
         }
     }
@@ -1728,6 +1732,7 @@ impl ::std::convert::AsRef<str> for ContainerStateStatusEnum {
             ContainerStateStatusEnum::REMOVING => "removing",
             ContainerStateStatusEnum::EXITED => "exited",
             ContainerStateStatusEnum::DEAD => "dead",
+            ContainerStateStatusEnum::STOPPING => "stopping",
         }
     }
 }
@@ -1949,6 +1954,8 @@ pub enum ContainerSummaryStateEnum {
     REMOVING,
     #[serde(rename = "dead")]
     DEAD,
+    #[serde(rename = "stopping")]
+    STOPPING,
 }
 
 impl ::std::fmt::Display for ContainerSummaryStateEnum {
@@ -1962,6 +1969,7 @@ impl ::std::fmt::Display for ContainerSummaryStateEnum {
             ContainerSummaryStateEnum::EXITED => write!(f, "{}", "exited"),
             ContainerSummaryStateEnum::REMOVING => write!(f, "{}", "removing"),
             ContainerSummaryStateEnum::DEAD => write!(f, "{}", "dead"),
+            ContainerSummaryStateEnum::STOPPING => write!(f, "{}", "stopping"),
 
         }
     }
@@ -1979,6 +1987,7 @@ impl ::std::str::FromStr for ContainerSummaryStateEnum {
             "exited" => Ok(ContainerSummaryStateEnum::EXITED),
             "removing" => Ok(ContainerSummaryStateEnum::REMOVING),
             "dead" => Ok(ContainerSummaryStateEnum::DEAD),
+            "stopping" => Ok(ContainerSummaryStateEnum::STOPPING),
             x => Err(format!("Invalid enum type: {}", x)),
         }
     }
@@ -1995,6 +2004,7 @@ impl ::std::convert::AsRef<str> for ContainerSummaryStateEnum {
             ContainerSummaryStateEnum::EXITED => "exited",
             ContainerSummaryStateEnum::REMOVING => "removing",
             ContainerSummaryStateEnum::DEAD => "dead",
+            ContainerSummaryStateEnum::STOPPING => "stopping",
         }
     }
 }


### PR DESCRIPTION
## Problem

Docker and Podman emit `"stopping"` as a transitional container state (briefly during `docker stop` / `podman stop`) that is not present in `ContainerStateStatusEnum` or `ContainerSummaryStateEnum` in bollard-stubs.

When `list_containers` or `inspect_container` returns a container in `"stopping"` state, serde fails to deserialize the **entire response** — not just the one container — with:

```
unknown variant `stopping`, expected one of ``, `created`, `running`, `paused`, `restarting`, `exited`, `removing`, `dead`
```

This is reliably reproducible when any code that calls `list_containers(.all=true)` races with a container stop — for example during cleanup after an execution timeout.

## Fix

Adds `STOPPING` to both `ContainerStateStatusEnum` and `ContainerSummaryStateEnum` across the enum body, `Display`, `FromStr`, and `AsRef<str>` impls.

## Alternatives

If you prefer a codegen template change over editing generated output, the relevant template is `src/main/resources/bollard/models.mustache` — happy to update that instead if you point me to the right codegen entrypoint to re-generate.