### PR TITLE
fix(codegen): add Podman "stopping" state to container state enums

### DIFF
--- a/codegen/swagger/src/main/java/bollard/BollardCodegen.java
+++ b/codegen/swagger/src/main/java/bollard/BollardCodegen.java
@@ -55,6 +55,22 @@ public class BollardCodegen extends RustServerCodegen {
         enumValues.add(additionalEnumValues);
 
         patchEnumValues.put("ServiceUpdateStatusStateEnum", enumValues);
+
+        // Podman emits "stopping" during container destruction (containers/podman#25591)
+        // This is a legitimate transient state, not a Podman bug — see fussybeaver/bollard#701
+        enumValues = new ArrayList<Map<String, String>>();
+        additionalEnumValues = new HashMap<String, String>();
+        additionalEnumValues.put("name", "STOPPING");
+        additionalEnumValues.put("value", "\"stopping\"");
+        enumValues.add(additionalEnumValues);
+        patchEnumValues.put("ContainerStateStatusEnum", enumValues);
+
+        enumValues = new ArrayList<Map<String, String>>();
+        additionalEnumValues = new HashMap<String, String>();
+        additionalEnumValues.put("name", "STOPPING");
+        additionalEnumValues.put("value", "\"stopping\"");
+        enumValues.add(additionalEnumValues);
+        patchEnumValues.put("ContainerSummaryStateEnum", enumValues);
     }
 
     // Top-level string enum models whose enum values swagger-codegen fails to carry through to

--- a/codegen/swagger/src/models.rs
+++ b/codegen/swagger/src/models.rs
@@ -1702,11 +1702,13 @@ pub enum ContainerStateStatusEnum {
     EXITED,
     #[serde(rename = "dead")]
     DEAD,
+    #[serde(rename = "stopping")]
+    STOPPING,
 }
 
 impl ::std::fmt::Display for ContainerStateStatusEnum {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        match *self { 
+        match *self {
             ContainerStateStatusEnum::EMPTY => write!(f, ""),
             ContainerStateStatusEnum::CREATED => write!(f, "{}", "created"),
             ContainerStateStatusEnum::RUNNING => write!(f, "{}", "running"),
@@ -1715,6 +1717,7 @@ impl ::std::fmt::Display for ContainerStateStatusEnum {
             ContainerStateStatusEnum::REMOVING => write!(f, "{}", "removing"),
             ContainerStateStatusEnum::EXITED => write!(f, "{}", "exited"),
             ContainerStateStatusEnum::DEAD => write!(f, "{}", "dead"),
+            ContainerStateStatusEnum::STOPPING => write!(f, "{}", "stopping"),
 
         }
     }
@@ -1723,7 +1726,7 @@ impl ::std::fmt::Display for ContainerStateStatusEnum {
 impl ::std::str::FromStr for ContainerStateStatusEnum {
     type Err = String;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s { 
+        match s {
             "" => Ok(ContainerStateStatusEnum::EMPTY),
             "created" => Ok(ContainerStateStatusEnum::CREATED),
             "running" => Ok(ContainerStateStatusEnum::RUNNING),
@@ -1732,6 +1735,7 @@ impl ::std::str::FromStr for ContainerStateStatusEnum {
             "removing" => Ok(ContainerStateStatusEnum::REMOVING),
             "exited" => Ok(ContainerStateStatusEnum::EXITED),
             "dead" => Ok(ContainerStateStatusEnum::DEAD),
+            "stopping" => Ok(ContainerStateStatusEnum::STOPPING),
             x => Err(format!("Invalid enum type: {}", x)),
         }
     }
@@ -1739,7 +1743,7 @@ impl ::std::str::FromStr for ContainerStateStatusEnum {
 
 impl ::std::convert::AsRef<str> for ContainerStateStatusEnum {
     fn as_ref(&self) -> &str {
-        match self { 
+        match self {
             ContainerStateStatusEnum::EMPTY => "",
             ContainerStateStatusEnum::CREATED => "created",
             ContainerStateStatusEnum::RUNNING => "running",
@@ -1748,6 +1752,7 @@ impl ::std::convert::AsRef<str> for ContainerStateStatusEnum {
             ContainerStateStatusEnum::REMOVING => "removing",
             ContainerStateStatusEnum::EXITED => "exited",
             ContainerStateStatusEnum::DEAD => "dead",
+            ContainerStateStatusEnum::STOPPING => "stopping",
         }
     }
 }
@@ -1969,11 +1974,13 @@ pub enum ContainerSummaryStateEnum {
     REMOVING,
     #[serde(rename = "dead")]
     DEAD,
+    #[serde(rename = "stopping")]
+    STOPPING,
 }
 
 impl ::std::fmt::Display for ContainerSummaryStateEnum {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        match *self { 
+        match *self {
             ContainerSummaryStateEnum::EMPTY => write!(f, ""),
             ContainerSummaryStateEnum::CREATED => write!(f, "{}", "created"),
             ContainerSummaryStateEnum::RUNNING => write!(f, "{}", "running"),
@@ -1982,6 +1989,7 @@ impl ::std::fmt::Display for ContainerSummaryStateEnum {
             ContainerSummaryStateEnum::EXITED => write!(f, "{}", "exited"),
             ContainerSummaryStateEnum::REMOVING => write!(f, "{}", "removing"),
             ContainerSummaryStateEnum::DEAD => write!(f, "{}", "dead"),
+            ContainerSummaryStateEnum::STOPPING => write!(f, "{}", "stopping"),
 
         }
     }
@@ -1990,7 +1998,7 @@ impl ::std::fmt::Display for ContainerSummaryStateEnum {
 impl ::std::str::FromStr for ContainerSummaryStateEnum {
     type Err = String;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s { 
+        match s {
             "" => Ok(ContainerSummaryStateEnum::EMPTY),
             "created" => Ok(ContainerSummaryStateEnum::CREATED),
             "running" => Ok(ContainerSummaryStateEnum::RUNNING),
@@ -1999,6 +2007,7 @@ impl ::std::str::FromStr for ContainerSummaryStateEnum {
             "exited" => Ok(ContainerSummaryStateEnum::EXITED),
             "removing" => Ok(ContainerSummaryStateEnum::REMOVING),
             "dead" => Ok(ContainerSummaryStateEnum::DEAD),
+            "stopping" => Ok(ContainerSummaryStateEnum::STOPPING),
             x => Err(format!("Invalid enum type: {}", x)),
         }
     }
@@ -2006,7 +2015,7 @@ impl ::std::str::FromStr for ContainerSummaryStateEnum {
 
 impl ::std::convert::AsRef<str> for ContainerSummaryStateEnum {
     fn as_ref(&self) -> &str {
-        match self { 
+        match self {
             ContainerSummaryStateEnum::EMPTY => "",
             ContainerSummaryStateEnum::CREATED => "created",
             ContainerSummaryStateEnum::RUNNING => "running",
@@ -2015,6 +2024,7 @@ impl ::std::convert::AsRef<str> for ContainerSummaryStateEnum {
             ContainerSummaryStateEnum::EXITED => "exited",
             ContainerSummaryStateEnum::REMOVING => "removing",
             ContainerSummaryStateEnum::DEAD => "dead",
+            ContainerSummaryStateEnum::STOPPING => "stopping",
         }
     }
 }


### PR DESCRIPTION
## Summary

Adds the `stopping` variant to `ContainerStateStatusEnum` and `ContainerSummaryStateEnum` via the existing `patchEnumValues` codegen mechanism.

## Problem

Podman emits a `stopping` transient state during container destruction through its Docker-compatible API. This causes bollard to fail with a serde deserialization error:

```
unknown variant `stopping`, expected one of `created`, `running`, `paused`, `restarting`, `removing`, `exited`, `dead`
```

This affects any bollard user running against Podman when a container is in the process of shutting down.

## Podman compat fix

[containers/podman#28390](https://github.com/containers/podman/pull/28390) (merged 2026-03-31) fixed the Podman compat API to map `stopping` → `running` and `stopped` → `exited` on the list endpoint. **Podman versions that include this fix will no longer emit `stopping` through the compat API.**

However, adding defensive handling in bollard is still valuable:
- Users on older Podman versions (pre-fix) will hit this deserialization failure
- The `patchEnumValues` mechanism already handles this pattern for `ServiceUpdateStatusStateEnum` rollback variants
- Graceful handling of unknown-but-valid states is better than hard deserialization failure

## Related issues

- #701 — `list_containers` deserialization fails on Podman (`stopped` variant — same class of issue)
- #293 — Earlier report of unknown variant with Podman
- #700 — First-class Podman support with feature flags
- [containers/podman#28390](https://github.com/containers/podman/pull/28390) — Podman compat fix for both `stopped` and `stopping` (newer Podman versions)

## Changes

- `codegen/swagger/src/main/java/bollard/BollardCodegen.java` — Added `STOPPING` to `patchEnumValues` for both `ContainerStateStatusEnum` and `ContainerSummaryStateEnum`
- `codegen/swagger/src/models.rs` — Manually added `STOPPING` variant to both enums (codegen toolchain not available in CI)