### PR TITLE
chore: Check SemVer to avoid violations

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,17 +1,9 @@
 version: 2
 updates:
   - package-ecosystem: "cargo"
-    directory: "/"
-    schedule:
-      interval: "daily"
-  - package-ecosystem: "cargo"
-    directory: "/codegen/proto"
-    schedule:
-      interval: "daily"
-  - package-ecosystem: "cargo"
-    directory: "/codegen/swagger"
-    schedule:
-      interval: "daily"
+    directories:
+      - "/"
+      - "/codegen/*"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/.github/workflows/semver.yml
+++ b/.github/workflows/semver.yml
@@ -1,0 +1,24 @@
+name: SemVer
+
+# Check the API for semver violations, comparing it to the latest normal
+# (not pre-release or yanked) version published on crates.io.
+
+on:
+  pull_request:
+    types:
+      - opened       # New pull request
+      - synchronize  # New commits
+  push:
+    branches:
+      - master
+
+jobs:
+  semver:  # Uses stable Rust
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Check semver
+        uses: obi1kenobi/cargo-semver-checks-action@5b298c9520f7096a4683c0bd981a7ac5a7e249ae # v2.8
+        with:
+          feature-group: all-features


### PR DESCRIPTION
### Chores
- Check SemVer violations in pull requests (only after code changes) and for pushes to master
- Simplify Dependabot config

Closes #705