### PR TITLE
feat: Add docker contexts support

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -1,0 +1,312 @@
+//! Docker CLI context resolution.
+//!
+//! Resolves the Docker daemon host using the same precedence as the Docker CLI:
+//!
+//! 1. The `DOCKER_HOST` environment variable.
+//! 2. The context named by `DOCKER_CONTEXT`.
+//! 3. The `currentContext` field of `~/.docker/config.json`.
+//! 4. The platform-specific default ([`DEFAULT_DOCKER_HOST`](crate::DEFAULT_DOCKER_HOST)).
+//!
+//! Steps 2 and 3 share the same context lookup: the name `default` (or an empty
+//! value) means the platform default; any other name is looked up under
+//! `$DOCKER_CONFIG/contexts/meta/<dir>/meta.json` (defaulting to `~/.docker`).
+//! A name that does not resolve produces [`Error::DockerContextNotFoundError`].
+
+use std::env;
+use std::fs;
+use std::path::PathBuf;
+
+use serde::Deserialize;
+
+use crate::errors::Error;
+
+const DEFAULT_CONTEXT: &str = "default";
+
+/// Locate the Docker config directory: `$DOCKER_CONFIG` if set, else `$HOME/.docker`
+/// (or `%USERPROFILE%\.docker` on Windows).
+fn docker_config_dir() -> Option<PathBuf> {
+    if let Some(dir) = env::var_os("DOCKER_CONFIG") {
+        if !dir.is_empty() {
+            return Some(PathBuf::from(dir));
+        }
+    }
+    home_dir().map(|p| p.join(".docker"))
+}
+
+#[cfg(unix)]
+fn home_dir() -> Option<PathBuf> {
+    env::var_os("HOME")
+        .filter(|s| !s.is_empty())
+        .map(PathBuf::from)
+}
+
+#[cfg(windows)]
+fn home_dir() -> Option<PathBuf> {
+    env::var_os("USERPROFILE")
+        .filter(|s| !s.is_empty())
+        .map(PathBuf::from)
+}
+
+#[derive(Deserialize)]
+struct DockerConfig {
+    #[serde(rename = "currentContext", default)]
+    current_context: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct ContextMeta {
+    #[serde(rename = "Name")]
+    name: String,
+    #[serde(rename = "Endpoints", default)]
+    endpoints: ContextEndpoints,
+}
+
+#[derive(Deserialize, Default)]
+struct ContextEndpoints {
+    #[serde(default)]
+    docker: Option<ContextEndpoint>,
+}
+
+#[derive(Deserialize)]
+struct ContextEndpoint {
+    #[serde(rename = "Host", default)]
+    host: Option<String>,
+}
+
+/// Read the `currentContext` field from `~/.docker/config.json`. Returns `None` if
+/// the file is missing, unparseable, or has no `currentContext` value.
+fn current_context_from_config() -> Option<String> {
+    let path = docker_config_dir()?.join("config.json");
+    let contents = fs::read_to_string(path).ok()?;
+    let cfg: DockerConfig = serde_json::from_str(&contents).ok()?;
+    cfg.current_context.filter(|s| !s.is_empty())
+}
+
+/// Look up a context by name and return its `Endpoints.docker.Host`. Returns
+/// `Ok(None)` if the context cannot be found, mirroring how Docker stores
+/// context metadata as JSON files indexed by SHA-256 of the context name.
+///
+/// The lookup iterates the metadata directory rather than recomputing the
+/// hash, which avoids a SHA-256 dependency. The number of stored contexts is
+/// typically small.
+fn lookup_context_host(name: &str) -> Option<String> {
+    let dir = docker_config_dir()?.join("contexts").join("meta");
+    let entries = fs::read_dir(dir).ok()?;
+    for entry in entries.flatten() {
+        let meta_path = entry.path().join("meta.json");
+        let contents = match fs::read_to_string(&meta_path) {
+            Ok(c) => c,
+            Err(_) => continue,
+        };
+        let meta: ContextMeta = match serde_json::from_str(&contents) {
+            Ok(m) => m,
+            Err(_) => continue,
+        };
+        if meta.name == name {
+            return meta.endpoints.docker.and_then(|d| d.host);
+        }
+    }
+    None
+}
+
+/// Resolve the Docker daemon host using the Docker CLI precedence rules.
+///
+/// See the [module-level documentation](crate::context) for the full ordering.
+///
+/// # Errors
+///
+/// Returns [`Error::DockerContextNotFoundError`] if `DOCKER_CONTEXT` or the
+/// config file's `currentContext` names a context that does not exist on disk.
+pub fn resolve_host(default_host: &str) -> Result<String, Error> {
+    if let Some(host) = env::var("DOCKER_HOST").ok().filter(|s| !s.is_empty()) {
+        return Ok(host);
+    }
+
+    let context_name = env::var("DOCKER_CONTEXT")
+        .ok()
+        .filter(|s| !s.is_empty())
+        .or_else(current_context_from_config);
+
+    let Some(name) = context_name else {
+        return Ok(default_host.to_string());
+    };
+    if name == DEFAULT_CONTEXT {
+        return Ok(default_host.to_string());
+    }
+    lookup_context_host(&name).ok_or(Error::DockerContextNotFoundError { name })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_lock::ENV_LOCK;
+
+    /// RAII guard that sets an env var and restores the previous value on drop.
+    struct TempEnvVar {
+        key: String,
+        prev: Option<String>,
+    }
+
+    impl TempEnvVar {
+        fn set(key: &str, val: &str) -> Self {
+            let prev = env::var(key).ok();
+            env::set_var(key, val);
+            Self {
+                key: key.to_string(),
+                prev,
+            }
+        }
+
+        fn unset(key: &str) -> Self {
+            let prev = env::var(key).ok();
+            env::remove_var(key);
+            Self {
+                key: key.to_string(),
+                prev,
+            }
+        }
+    }
+
+    impl Drop for TempEnvVar {
+        fn drop(&mut self) {
+            match &self.prev {
+                Some(v) => env::set_var(&self.key, v),
+                None => env::remove_var(&self.key),
+            }
+        }
+    }
+
+    fn write_meta(dir: &std::path::Path, sub: &str, name: &str, host: &str) {
+        let meta_dir = dir.join("contexts").join("meta").join(sub);
+        fs::create_dir_all(&meta_dir).unwrap();
+        let body = format!(
+            r#"{{"Name":"{name}","Endpoints":{{"docker":{{"Host":"{host}"}}}}}}"#
+        );
+        fs::write(meta_dir.join("meta.json"), body).unwrap();
+    }
+
+    fn write_config(dir: &std::path::Path, current: Option<&str>) {
+        let body = match current {
+            Some(c) => format!(r#"{{"currentContext":"{c}"}}"#),
+            None => "{}".to_string(),
+        };
+        fs::write(dir.join("config.json"), body).unwrap();
+    }
+
+    #[test]
+    fn docker_host_wins_over_everything() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let tmp = tempfile::tempdir().unwrap();
+        write_config(tmp.path(), Some("some-context"));
+        write_meta(tmp.path(), "aa", "some-context", "tcp://from-context:1234");
+
+        let _cfg = TempEnvVar::set("DOCKER_CONFIG", tmp.path().to_str().unwrap());
+        let _ctx = TempEnvVar::set("DOCKER_CONTEXT", "some-context");
+        let _host = TempEnvVar::set("DOCKER_HOST", "tcp://from-env:9999");
+
+        let resolved = resolve_host("unix:///default.sock").unwrap();
+        assert_eq!(resolved, "tcp://from-env:9999");
+    }
+
+    #[test]
+    fn docker_context_env_resolves_to_stored_host() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let tmp = tempfile::tempdir().unwrap();
+        write_meta(tmp.path(), "abc", "remote", "ssh://user@host");
+
+        let _cfg = TempEnvVar::set("DOCKER_CONFIG", tmp.path().to_str().unwrap());
+        let _ctx = TempEnvVar::set("DOCKER_CONTEXT", "remote");
+        let _host = TempEnvVar::unset("DOCKER_HOST");
+
+        let resolved = resolve_host("unix:///default.sock").unwrap();
+        assert_eq!(resolved, "ssh://user@host");
+    }
+
+    #[test]
+    fn current_context_from_config_used_when_env_unset() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let tmp = tempfile::tempdir().unwrap();
+        write_config(tmp.path(), Some("staging"));
+        write_meta(tmp.path(), "xyz", "staging", "tcp://staging:2375");
+
+        let _cfg = TempEnvVar::set("DOCKER_CONFIG", tmp.path().to_str().unwrap());
+        let _ctx = TempEnvVar::unset("DOCKER_CONTEXT");
+        let _host = TempEnvVar::unset("DOCKER_HOST");
+
+        let resolved = resolve_host("unix:///default.sock").unwrap();
+        assert_eq!(resolved, "tcp://staging:2375");
+    }
+
+    #[test]
+    fn docker_context_overrides_config_current_context() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let tmp = tempfile::tempdir().unwrap();
+        write_config(tmp.path(), Some("from-config"));
+        write_meta(tmp.path(), "a", "from-config", "tcp://from-config:1");
+        write_meta(tmp.path(), "b", "from-env", "tcp://from-env-ctx:2");
+
+        let _cfg = TempEnvVar::set("DOCKER_CONFIG", tmp.path().to_str().unwrap());
+        let _ctx = TempEnvVar::set("DOCKER_CONTEXT", "from-env");
+        let _host = TempEnvVar::unset("DOCKER_HOST");
+
+        let resolved = resolve_host("unix:///default.sock").unwrap();
+        assert_eq!(resolved, "tcp://from-env-ctx:2");
+    }
+
+    #[test]
+    fn default_context_falls_back_to_default_host() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let tmp = tempfile::tempdir().unwrap();
+        write_config(tmp.path(), Some("default"));
+
+        let _cfg = TempEnvVar::set("DOCKER_CONFIG", tmp.path().to_str().unwrap());
+        let _ctx = TempEnvVar::unset("DOCKER_CONTEXT");
+        let _host = TempEnvVar::unset("DOCKER_HOST");
+
+        let resolved = resolve_host("unix:///default.sock").unwrap();
+        assert_eq!(resolved, "unix:///default.sock");
+    }
+
+    #[test]
+    fn missing_config_and_env_falls_back_to_default() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let tmp = tempfile::tempdir().unwrap();
+
+        let _cfg = TempEnvVar::set("DOCKER_CONFIG", tmp.path().to_str().unwrap());
+        let _ctx = TempEnvVar::unset("DOCKER_CONTEXT");
+        let _host = TempEnvVar::unset("DOCKER_HOST");
+
+        let resolved = resolve_host("unix:///default.sock").unwrap();
+        assert_eq!(resolved, "unix:///default.sock");
+    }
+
+    #[test]
+    fn unknown_context_errors() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let tmp = tempfile::tempdir().unwrap();
+
+        let _cfg = TempEnvVar::set("DOCKER_CONFIG", tmp.path().to_str().unwrap());
+        let _ctx = TempEnvVar::set("DOCKER_CONTEXT", "missing");
+        let _host = TempEnvVar::unset("DOCKER_HOST");
+
+        let err = resolve_host("unix:///default.sock").unwrap_err();
+        match err {
+            Error::DockerContextNotFoundError { name } => assert_eq!(name, "missing"),
+            other => panic!("expected DockerContextNotFoundError, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn empty_docker_host_treated_as_unset() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let tmp = tempfile::tempdir().unwrap();
+        write_meta(tmp.path(), "abc", "remote", "tcp://remote:2375");
+
+        let _cfg = TempEnvVar::set("DOCKER_CONFIG", tmp.path().to_str().unwrap());
+        let _ctx = TempEnvVar::set("DOCKER_CONTEXT", "remote");
+        let _host = TempEnvVar::set("DOCKER_HOST", "");
+
+        let resolved = resolve_host("unix:///default.sock").unwrap();
+        assert_eq!(resolved, "tcp://remote:2375");
+    }
+}

--- a/src/context.rs
+++ b/src/context.rs
@@ -205,9 +205,7 @@ mod tests {
     fn write_meta(dir: &std::path::Path, sub: &str, name: &str, host: &str) {
         let meta_dir = dir.join("contexts").join("meta").join(sub);
         fs::create_dir_all(&meta_dir).unwrap();
-        let body = format!(
-            r#"{{"Name":"{name}","Endpoints":{{"docker":{{"Host":"{host}"}}}}}}"#
-        );
+        let body = format!(r#"{{"Name":"{name}","Endpoints":{{"docker":{{"Host":"{host}"}}}}}}"#);
         fs::write(meta_dir.join("meta.json"), body).unwrap();
     }
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -109,6 +109,41 @@ fn lookup_context_host(name: &str) -> Option<String> {
     None
 }
 
+/// Resolve a context name to its Docker endpoint host.
+///
+/// The name `"default"` (or an empty string) returns the supplied
+/// `default_host`. Any other name is looked up under
+/// `$DOCKER_CONFIG/contexts/meta/*/meta.json`.
+///
+/// # Errors
+///
+/// Returns [`Error::DockerContextNotFoundError`] if `name` is not `"default"`
+/// and no matching context is found.
+pub fn host_for_context(name: &str, default_host: &str) -> Result<String, Error> {
+    if name.is_empty() || name == DEFAULT_CONTEXT {
+        return Ok(default_host.to_string());
+    }
+    lookup_context_host(name).ok_or_else(|| Error::DockerContextNotFoundError {
+        name: name.to_string(),
+    })
+}
+
+/// Return the name of the "current" Docker context, considering only the
+/// Docker CLI's context-selection inputs:
+///
+/// 1. The `DOCKER_CONTEXT` environment variable, if non-empty.
+/// 2. The `currentContext` field of `$DOCKER_CONFIG/config.json`, if present.
+///
+/// Returns `None` if neither is set (the default context is implicit and is
+/// not represented by a name on disk). Notably this does **not** look at
+/// `DOCKER_HOST`, which is a transport override rather than a context name.
+pub fn current_context_name() -> Option<String> {
+    env::var("DOCKER_CONTEXT")
+        .ok()
+        .filter(|s| !s.is_empty())
+        .or_else(current_context_from_config)
+}
+
 /// Resolve the Docker daemon host using the Docker CLI precedence rules.
 ///
 /// See the [module-level documentation](crate::context) for the full ordering.
@@ -121,19 +156,10 @@ pub fn resolve_host(default_host: &str) -> Result<String, Error> {
     if let Some(host) = env::var("DOCKER_HOST").ok().filter(|s| !s.is_empty()) {
         return Ok(host);
     }
-
-    let context_name = env::var("DOCKER_CONTEXT")
-        .ok()
-        .filter(|s| !s.is_empty())
-        .or_else(current_context_from_config);
-
-    let Some(name) = context_name else {
-        return Ok(default_host.to_string());
-    };
-    if name == DEFAULT_CONTEXT {
-        return Ok(default_host.to_string());
+    match current_context_name() {
+        Some(name) => host_for_context(&name, default_host),
+        None => Ok(default_host.to_string()),
     }
-    lookup_context_host(&name).ok_or(Error::DockerContextNotFoundError { name })
 }
 
 #[cfg(test)]
@@ -294,6 +320,75 @@ mod tests {
             Error::DockerContextNotFoundError { name } => assert_eq!(name, "missing"),
             other => panic!("expected DockerContextNotFoundError, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn host_for_context_resolves_named() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let tmp = tempfile::tempdir().unwrap();
+        write_meta(tmp.path(), "x", "prod", "tcp://prod:2375");
+        let _cfg = TempEnvVar::set("DOCKER_CONFIG", tmp.path().to_str().unwrap());
+
+        assert_eq!(
+            host_for_context("prod", "unix:///default.sock").unwrap(),
+            "tcp://prod:2375"
+        );
+    }
+
+    #[test]
+    fn host_for_context_default_returns_default() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let tmp = tempfile::tempdir().unwrap();
+        let _cfg = TempEnvVar::set("DOCKER_CONFIG", tmp.path().to_str().unwrap());
+
+        assert_eq!(
+            host_for_context("default", "unix:///default.sock").unwrap(),
+            "unix:///default.sock"
+        );
+        assert_eq!(
+            host_for_context("", "unix:///default.sock").unwrap(),
+            "unix:///default.sock"
+        );
+    }
+
+    #[test]
+    fn host_for_context_unknown_errors() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let tmp = tempfile::tempdir().unwrap();
+        let _cfg = TempEnvVar::set("DOCKER_CONFIG", tmp.path().to_str().unwrap());
+
+        let err = host_for_context("ghost", "unix:///default.sock").unwrap_err();
+        match err {
+            Error::DockerContextNotFoundError { name } => assert_eq!(name, "ghost"),
+            other => panic!("expected DockerContextNotFoundError, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn current_context_name_reads_env_then_config() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let tmp = tempfile::tempdir().unwrap();
+        write_config(tmp.path(), Some("from-config"));
+
+        let _cfg = TempEnvVar::set("DOCKER_CONFIG", tmp.path().to_str().unwrap());
+        let _ctx = TempEnvVar::set("DOCKER_CONTEXT", "from-env");
+        let _host = TempEnvVar::unset("DOCKER_HOST");
+        assert_eq!(current_context_name().as_deref(), Some("from-env"));
+
+        // env unset → falls back to config
+        let _ctx2 = TempEnvVar::unset("DOCKER_CONTEXT");
+        assert_eq!(current_context_name().as_deref(), Some("from-config"));
+    }
+
+    #[test]
+    fn current_context_name_ignores_docker_host() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let tmp = tempfile::tempdir().unwrap();
+        let _cfg = TempEnvVar::set("DOCKER_CONFIG", tmp.path().to_str().unwrap());
+        let _ctx = TempEnvVar::unset("DOCKER_CONTEXT");
+        let _host = TempEnvVar::set("DOCKER_HOST", "tcp://override:2375");
+
+        assert_eq!(current_context_name(), None);
     }
 
     #[test]

--- a/src/docker.rs
+++ b/src/docker.rs
@@ -1996,9 +1996,8 @@ mod tests {
         fn write_context_meta(cfg_dir: &std::path::Path, name: &str, host: &str) {
             let meta_dir = cfg_dir.join("contexts").join("meta").join("ctx");
             std::fs::create_dir_all(&meta_dir).unwrap();
-            let body = format!(
-                r#"{{"Name":"{name}","Endpoints":{{"docker":{{"Host":"{host}"}}}}}}"#
-            );
+            let body =
+                format!(r#"{{"Name":"{name}","Endpoints":{{"docker":{{"Host":"{host}"}}}}}}"#);
             std::fs::write(meta_dir.join("meta.json"), body).unwrap();
         }
 

--- a/src/docker.rs
+++ b/src/docker.rs
@@ -913,9 +913,19 @@ impl Docker {
     ///
     /// # Defaults
     ///
-    ///  - The socket location defaults to the value of `DEFAULT_SOCKET` env if its set and the URL
-    ///    has `unix` scheme; otherwise `/var/run/docker.sock`.
+    ///  - The socket location is resolved using the Docker CLI precedence (see
+    ///    [`crate::context`]): `DOCKER_HOST`, then `DOCKER_CONTEXT`, then the
+    ///    `currentContext` field of `~/.docker/config.json`. If the resolved host
+    ///    does not use the `unix://` scheme (e.g. a `tcp://` or `ssh://` context),
+    ///    the platform default `/var/run/docker.sock` is used instead — this
+    ///    entry point only supports local sockets. Use
+    ///    [`Docker::connect_with_defaults`] to dispatch to any scheme.
     ///  - The request timeout defaults to 2 minutes.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::DockerContextNotFoundError`] if `DOCKER_CONTEXT` or the
+    /// config file references a context that does not exist on disk.
     ///
     /// # Examples
     ///
@@ -928,17 +938,13 @@ impl Docker {
     /// connection.ping().map_ok(|_| Ok::<_, ()>(println!("Connected!")));
     /// ```
     pub fn connect_with_unix_defaults() -> Result<Docker, Error> {
-        // Using 3 variables to not have to copy/allocate `DEFAULT_SOCKET`.
-        let socket_path = env::var("DOCKER_HOST").ok().and_then(|p| {
-            if p.starts_with("unix://") {
-                Some(p)
-            } else {
-                None
-            }
-        });
-        let path = socket_path.as_deref();
-        let path_ref: &str = path.unwrap_or(DEFAULT_SOCKET);
-        Docker::connect_with_unix(path_ref, DEFAULT_TIMEOUT, API_DEFAULT_VERSION)
+        let resolved = crate::context::resolve_host(DEFAULT_SOCKET)?;
+        let path = if resolved.starts_with("unix://") {
+            resolved
+        } else {
+            DEFAULT_SOCKET.to_string()
+        };
+        Docker::connect_with_unix(&path, DEFAULT_TIMEOUT, API_DEFAULT_VERSION)
     }
 
     /// Resolve the rootless Podman socket path for the current user.
@@ -1091,8 +1097,19 @@ impl Docker {
     ///
     /// # Defaults
     ///
-    ///  - The socket location defaults to `//./pipe/docker_engine`.
+    ///  - The pipe location is resolved using the Docker CLI precedence (see
+    ///    [`crate::context`]): `DOCKER_HOST`, then `DOCKER_CONTEXT`, then the
+    ///    `currentContext` field of `~/.docker/config.json`. If the resolved host
+    ///    does not use the `npipe://` scheme, the platform default
+    ///    `//./pipe/docker_engine` is used — this entry point only supports
+    ///    local named pipes. Use [`Docker::connect_with_defaults`] to dispatch
+    ///    to any scheme.
     ///  - The request timeout defaults to 2 minutes.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::DockerContextNotFoundError`] if `DOCKER_CONTEXT` or the
+    /// config file references a context that does not exist on disk.
     ///
     /// # Examples
     ///
@@ -1106,7 +1123,13 @@ impl Docker {
     ///
     /// ```
     pub fn connect_with_named_pipe_defaults() -> Result<Docker, Error> {
-        Docker::connect_with_named_pipe(DEFAULT_NAMED_PIPE, DEFAULT_TIMEOUT, API_DEFAULT_VERSION)
+        let resolved = crate::context::resolve_host(DEFAULT_NAMED_PIPE)?;
+        let path = if resolved.starts_with("npipe://") {
+            resolved
+        } else {
+            DEFAULT_NAMED_PIPE.to_string()
+        };
+        Docker::connect_with_named_pipe(&path, DEFAULT_TIMEOUT, API_DEFAULT_VERSION)
     }
 
     /// Connect using a Windows Named Pipe.
@@ -1787,6 +1810,44 @@ pub fn body_full(body: Bytes) -> BodyType {
 mod tests {
     use super::*;
 
+    /// RAII guard that sets or unsets an env var and restores the previous
+    /// value on drop. Shared by `podman` and `docker_defaults` test modules.
+    #[allow(dead_code)]
+    struct TempEnvVar {
+        key: String,
+        prev: Option<String>,
+    }
+
+    #[allow(dead_code)]
+    impl TempEnvVar {
+        fn set(key: &str, val: &str) -> Self {
+            let prev = env::var(key).ok();
+            env::set_var(key, val);
+            Self {
+                key: key.to_string(),
+                prev,
+            }
+        }
+
+        fn unset(key: &str) -> Self {
+            let prev = env::var(key).ok();
+            env::remove_var(key);
+            Self {
+                key: key.to_string(),
+                prev,
+            }
+        }
+    }
+
+    impl Drop for TempEnvVar {
+        fn drop(&mut self) {
+            match &self.prev {
+                Some(v) => env::set_var(&self.key, v),
+                None => env::remove_var(&self.key),
+            }
+        }
+    }
+
     #[cfg(unix)]
     mod podman {
         use super::*;
@@ -1844,76 +1905,114 @@ mod tests {
             let docker = Docker::connect_with_podman_defaults().unwrap();
             assert_eq!(docker.client_addr, sock.to_str().unwrap());
         }
-
-        /// RAII guard that sets an env var and restores the previous value on drop.
-        struct TempEnvVar {
-            key: String,
-            prev: Option<String>,
-        }
-
-        impl TempEnvVar {
-            fn set(key: &str, val: &str) -> Self {
-                let prev = env::var(key).ok();
-                env::set_var(key, val);
-                Self {
-                    key: key.to_string(),
-                    prev,
-                }
-            }
-        }
-
-        impl Drop for TempEnvVar {
-            fn drop(&mut self) {
-                match &self.prev {
-                    Some(v) => env::set_var(&self.key, v),
-                    None => env::remove_var(&self.key),
-                }
-            }
-        }
     }
 
     #[cfg(all(unix, feature = "pipe"))]
     mod docker_defaults {
         use super::*;
 
+        /// RAII helper that scrubs every env var the context resolver reads, so a
+        /// test doesn't accidentally pick up the developer's real Docker config.
+        struct IsolatedDockerEnv {
+            _cfg: TempEnvVar,
+            _ctx: TempEnvVar,
+            _host: TempEnvVar,
+        }
+
+        impl IsolatedDockerEnv {
+            fn new(cfg_dir: &std::path::Path) -> Self {
+                Self {
+                    _cfg: TempEnvVar::set("DOCKER_CONFIG", cfg_dir.to_str().unwrap()),
+                    _ctx: TempEnvVar::unset("DOCKER_CONTEXT"),
+                    _host: TempEnvVar::unset("DOCKER_HOST"),
+                }
+            }
+        }
+
+        fn write_context_meta(cfg_dir: &std::path::Path, name: &str, host: &str) {
+            let meta_dir = cfg_dir.join("contexts").join("meta").join("ctx");
+            std::fs::create_dir_all(&meta_dir).unwrap();
+            let body = format!(
+                r#"{{"Name":"{name}","Endpoints":{{"docker":{{"Host":"{host}"}}}}}}"#
+            );
+            std::fs::write(meta_dir.join("meta.json"), body).unwrap();
+        }
+
         #[test]
         fn connect_with_unix_defaults_respects_docker_host() {
             let _lock = crate::test_lock::ENV_LOCK.lock().unwrap();
-            let dir = tempfile::tempdir().unwrap();
-            let sock = dir.path().join("test.sock");
+            let cfg_dir = tempfile::tempdir().unwrap();
+            let _env = IsolatedDockerEnv::new(cfg_dir.path());
+
+            let sock_dir = tempfile::tempdir().unwrap();
+            let sock = sock_dir.path().join("test.sock");
             std::fs::write(&sock, b"").unwrap();
 
             let uri = format!("unix://{}", sock.display());
-            // Temporarily set DOCKER_HOST
-            let prev = env::var("DOCKER_HOST").ok();
-            env::set_var("DOCKER_HOST", &uri);
+            let _host = TempEnvVar::set("DOCKER_HOST", &uri);
 
             let docker = Docker::connect_with_unix_defaults().unwrap();
             assert_eq!(docker.client_addr, sock.to_str().unwrap());
+        }
 
-            // Restore
-            match prev {
-                Some(v) => env::set_var("DOCKER_HOST", v),
-                None => env::remove_var("DOCKER_HOST"),
-            }
+        #[test]
+        fn connect_with_unix_defaults_resolves_unix_context() {
+            let _lock = crate::test_lock::ENV_LOCK.lock().unwrap();
+            let cfg_dir = tempfile::tempdir().unwrap();
+            let sock_dir = tempfile::tempdir().unwrap();
+            let sock = sock_dir.path().join("ctx.sock");
+            std::fs::write(&sock, b"").unwrap();
+            let uri = format!("unix://{}", sock.display());
+            write_context_meta(cfg_dir.path(), "local-ctx", &uri);
+
+            let _env = IsolatedDockerEnv::new(cfg_dir.path());
+            let _ctx = TempEnvVar::set("DOCKER_CONTEXT", "local-ctx");
+
+            let docker = Docker::connect_with_unix_defaults().unwrap();
+            assert_eq!(docker.client_addr, sock.to_str().unwrap());
         }
 
         #[test]
         fn connect_with_unix_defaults_ignores_non_unix_docker_host() {
             let _lock = crate::test_lock::ENV_LOCK.lock().unwrap();
-            let prev = env::var("DOCKER_HOST").ok();
-            env::set_var("DOCKER_HOST", "tcp://localhost:2375");
+            let cfg_dir = tempfile::tempdir().unwrap();
+            let _env = IsolatedDockerEnv::new(cfg_dir.path());
+            let _host = TempEnvVar::set("DOCKER_HOST", "tcp://localhost:2375");
 
             // Should fall through to DEFAULT_SOCKET, which may or may not exist
             let result = Docker::connect_with_unix_defaults();
-            // On a system without Docker, this errors with SocketNotFoundError — that's fine
             if let Err(SocketNotFoundError(addr)) = &result {
                 assert!(addr.contains("docker.sock"));
             }
+        }
 
-            match prev {
-                Some(v) => env::set_var("DOCKER_HOST", v),
-                None => env::remove_var("DOCKER_HOST"),
+        #[test]
+        fn connect_with_unix_defaults_ignores_non_unix_context() {
+            let _lock = crate::test_lock::ENV_LOCK.lock().unwrap();
+            let cfg_dir = tempfile::tempdir().unwrap();
+            write_context_meta(cfg_dir.path(), "tcp-ctx", "tcp://localhost:2375");
+
+            let _env = IsolatedDockerEnv::new(cfg_dir.path());
+            let _ctx = TempEnvVar::set("DOCKER_CONTEXT", "tcp-ctx");
+
+            // Context resolves to tcp:// — falls back to DEFAULT_SOCKET, may not exist
+            let result = Docker::connect_with_unix_defaults();
+            if let Err(SocketNotFoundError(addr)) = &result {
+                assert!(addr.contains("docker.sock"));
+            }
+        }
+
+        #[test]
+        fn connect_with_unix_defaults_propagates_missing_context_error() {
+            let _lock = crate::test_lock::ENV_LOCK.lock().unwrap();
+            let cfg_dir = tempfile::tempdir().unwrap();
+            let _env = IsolatedDockerEnv::new(cfg_dir.path());
+            let _ctx = TempEnvVar::set("DOCKER_CONTEXT", "does-not-exist");
+
+            let err = Docker::connect_with_unix_defaults().unwrap_err();
+            match err {
+                Error::DockerContextNotFoundError { name } => assert_eq!(name, "does-not-exist"),
+                other => panic!("expected DockerContextNotFoundError, got {other:?}"),
             }
         }
     }

--- a/src/docker.rs
+++ b/src/docker.rs
@@ -267,6 +267,9 @@ pub type RequestModifier = Arc<dyn Fn(BollardRequest) -> BollardRequest + Send +
 ///
 /// The main interface for calling the Docker API. Construct a new Docker instance using one of the
 /// connect methods:
+///  - [`Docker::connect_with_defaults`] (Docker CLI env + context aware)
+///  - [`Docker::connect_with_context`] (explicit named context)
+///  - [`Docker::connect_with_current_context`] (`DOCKER_CONTEXT` / config-only)
 ///  - [`Docker::connect_with_http_defaults`] (requires `http` feature)
 ///  - `Docker::connect_with_named_pipe_defaults` (requires `pipe` feature, Windows only)
 ///  - `Docker::connect_with_ssl_defaults` (requires `ssl` feature)
@@ -903,6 +906,67 @@ impl Docker {
                 uri: host.to_string(),
             }),
         }
+    }
+
+    /// Connect to the named Docker context.
+    ///
+    /// The context's `Endpoints.docker.Host` is looked up under
+    /// `$DOCKER_CONFIG/contexts/meta/*/meta.json` (default
+    /// `~/.docker/contexts/meta`). The name `"default"` (or an empty string)
+    /// returns the platform default ([`DEFAULT_DOCKER_HOST`]).
+    ///
+    /// Environment variables (`DOCKER_HOST`, `DOCKER_CONTEXT`) are ignored —
+    /// use [`Docker::connect_with_defaults`] for env-aware resolution and
+    /// [`Docker::connect_with_current_context`] to follow the Docker CLI's
+    /// current-context selection without the `DOCKER_HOST` override.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::DockerContextNotFoundError`] if `name` is not
+    /// `"default"` and no matching context is found.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,no_run
+    /// use bollard::Docker;
+    ///
+    /// let connection = Docker::connect_with_context("desktop-linux").unwrap();
+    /// ```
+    pub fn connect_with_context(name: &str) -> Result<Docker, Error> {
+        let host = crate::context::host_for_context(name, DEFAULT_DOCKER_HOST)?;
+        Self::connect_with_host(&host)
+    }
+
+    /// Connect to the Docker context that is currently selected by the CLI.
+    ///
+    /// The current context is determined by:
+    ///
+    /// 1. The `DOCKER_CONTEXT` environment variable, if non-empty.
+    /// 2. The `currentContext` field of `$DOCKER_CONFIG/config.json`.
+    /// 3. Falling back to the platform default ([`DEFAULT_DOCKER_HOST`]).
+    ///
+    /// `DOCKER_HOST` is intentionally not consulted — it is a transport
+    /// override rather than a context selector. Use
+    /// [`Docker::connect_with_defaults`] if you want `DOCKER_HOST` to win.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::DockerContextNotFoundError`] if the selected context
+    /// name does not match a stored context.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,no_run
+    /// use bollard::Docker;
+    ///
+    /// let connection = Docker::connect_with_current_context().unwrap();
+    /// ```
+    pub fn connect_with_current_context() -> Result<Docker, Error> {
+        let host = match crate::context::current_context_name() {
+            Some(name) => crate::context::host_for_context(&name, DEFAULT_DOCKER_HOST)?,
+            None => DEFAULT_DOCKER_HOST.to_string(),
+        };
+        Self::connect_with_host(&host)
     }
 }
 
@@ -2000,6 +2064,90 @@ mod tests {
             if let Err(SocketNotFoundError(addr)) = &result {
                 assert!(addr.contains("docker.sock"));
             }
+        }
+
+        #[test]
+        fn connect_with_context_uses_named_context() {
+            let _lock = crate::test_lock::ENV_LOCK.lock().unwrap();
+            let cfg_dir = tempfile::tempdir().unwrap();
+            let sock_dir = tempfile::tempdir().unwrap();
+            let sock = sock_dir.path().join("named.sock");
+            std::fs::write(&sock, b"").unwrap();
+            let uri = format!("unix://{}", sock.display());
+            write_context_meta(cfg_dir.path(), "my-ctx", &uri);
+
+            // DOCKER_HOST should be ignored by connect_with_context.
+            let _env = IsolatedDockerEnv::new(cfg_dir.path());
+            let _host = TempEnvVar::set("DOCKER_HOST", "tcp://ignored:9999");
+
+            let docker = Docker::connect_with_context("my-ctx").unwrap();
+            assert_eq!(docker.client_addr, sock.to_str().unwrap());
+        }
+
+        #[test]
+        fn connect_with_context_default_uses_platform_default() {
+            let _lock = crate::test_lock::ENV_LOCK.lock().unwrap();
+            let cfg_dir = tempfile::tempdir().unwrap();
+            let _env = IsolatedDockerEnv::new(cfg_dir.path());
+
+            // "default" → DEFAULT_DOCKER_HOST, which may not exist on the runner.
+            let result = Docker::connect_with_context("default");
+            if let Err(SocketNotFoundError(addr)) = &result {
+                assert!(addr.contains("docker.sock"));
+            }
+        }
+
+        #[test]
+        fn connect_with_context_unknown_errors() {
+            let _lock = crate::test_lock::ENV_LOCK.lock().unwrap();
+            let cfg_dir = tempfile::tempdir().unwrap();
+            let _env = IsolatedDockerEnv::new(cfg_dir.path());
+
+            let err = Docker::connect_with_context("ghost").unwrap_err();
+            match err {
+                Error::DockerContextNotFoundError { name } => assert_eq!(name, "ghost"),
+                other => panic!("expected DockerContextNotFoundError, got {other:?}"),
+            }
+        }
+
+        #[test]
+        fn connect_with_current_context_follows_env() {
+            let _lock = crate::test_lock::ENV_LOCK.lock().unwrap();
+            let cfg_dir = tempfile::tempdir().unwrap();
+            let sock_dir = tempfile::tempdir().unwrap();
+            let sock = sock_dir.path().join("current.sock");
+            std::fs::write(&sock, b"").unwrap();
+            let uri = format!("unix://{}", sock.display());
+            write_context_meta(cfg_dir.path(), "active", &uri);
+
+            let _env = IsolatedDockerEnv::new(cfg_dir.path());
+            let _ctx = TempEnvVar::set("DOCKER_CONTEXT", "active");
+            // DOCKER_HOST must be ignored by connect_with_current_context.
+            let _host = TempEnvVar::set("DOCKER_HOST", "tcp://ignored:9999");
+
+            let docker = Docker::connect_with_current_context().unwrap();
+            assert_eq!(docker.client_addr, sock.to_str().unwrap());
+        }
+
+        #[test]
+        fn connect_with_current_context_follows_config() {
+            let _lock = crate::test_lock::ENV_LOCK.lock().unwrap();
+            let cfg_dir = tempfile::tempdir().unwrap();
+            let sock_dir = tempfile::tempdir().unwrap();
+            let sock = sock_dir.path().join("cfg.sock");
+            std::fs::write(&sock, b"").unwrap();
+            let uri = format!("unix://{}", sock.display());
+            write_context_meta(cfg_dir.path(), "configured", &uri);
+            std::fs::write(
+                cfg_dir.path().join("config.json"),
+                r#"{"currentContext":"configured"}"#,
+            )
+            .unwrap();
+
+            let _env = IsolatedDockerEnv::new(cfg_dir.path());
+
+            let docker = Docker::connect_with_current_context().unwrap();
+            assert_eq!(docker.client_addr, sock.to_str().unwrap());
         }
 
         #[test]

--- a/src/docker.rs
+++ b/src/docker.rs
@@ -1785,6 +1785,7 @@ mod tests {
 
         #[test]
         fn rootless_socket_from_xdg_runtime_dir() {
+            let _lock = crate::test_lock::ENV_LOCK.lock().unwrap();
             let dir = tempfile::tempdir().unwrap();
             let sock_dir = dir.path().join("podman");
             std::fs::create_dir_all(&sock_dir).unwrap();
@@ -1800,6 +1801,7 @@ mod tests {
 
         #[test]
         fn rootless_socket_returns_none_when_missing() {
+            let _lock = crate::test_lock::ENV_LOCK.lock().unwrap();
             // Point XDG_RUNTIME_DIR at empty dir — no podman socket
             let dir = tempfile::tempdir().unwrap();
             let _guard = TempEnvVar::set("XDG_RUNTIME_DIR", dir.path().to_str().unwrap());
@@ -1822,6 +1824,7 @@ mod tests {
 
         #[test]
         fn connect_with_podman_defaults_respects_docker_host() {
+            let _lock = crate::test_lock::ENV_LOCK.lock().unwrap();
             // Create a fake socket
             let dir = tempfile::tempdir().unwrap();
             let sock = dir.path().join("test.sock");
@@ -1867,6 +1870,7 @@ mod tests {
 
         #[test]
         fn connect_with_unix_defaults_respects_docker_host() {
+            let _lock = crate::test_lock::ENV_LOCK.lock().unwrap();
             let dir = tempfile::tempdir().unwrap();
             let sock = dir.path().join("test.sock");
             std::fs::write(&sock, b"").unwrap();
@@ -1888,6 +1892,7 @@ mod tests {
 
         #[test]
         fn connect_with_unix_defaults_ignores_non_unix_docker_host() {
+            let _lock = crate::test_lock::ENV_LOCK.lock().unwrap();
             let prev = env::var("DOCKER_HOST").ok();
             env::set_var("DOCKER_HOST", "tcp://localhost:2375");
 

--- a/src/docker.rs
+++ b/src/docker.rs
@@ -837,7 +837,15 @@ impl Docker {
 /// A Docker implementation with defaults.
 impl Docker {
     /// Connect using a Unix socket, a Windows named pipe, or via HTTP.
-    /// The connection method is determined by the `DOCKER_HOST` environment variable.
+    ///
+    /// The connection host is resolved using the same precedence as the Docker CLI:
+    ///
+    /// 1. The `DOCKER_HOST` environment variable, if set.
+    /// 2. The Docker context named by `DOCKER_CONTEXT`, if set.
+    /// 3. The `currentContext` field of `~/.docker/config.json`, if present.
+    /// 4. The platform-specific default ([`DEFAULT_DOCKER_HOST`]).
+    ///
+    /// See [`crate::context`] for details on context resolution.
     ///
     /// # Examples
     ///
@@ -850,7 +858,7 @@ impl Docker {
     /// connection.ping().map_ok(|_| Ok::<_, ()>(println!("Connected!")));
     /// ```
     pub fn connect_with_defaults() -> Result<Docker, Error> {
-        let host = env::var("DOCKER_HOST").unwrap_or_else(|_| DEFAULT_DOCKER_HOST.to_string());
+        let host = crate::context::resolve_host(DEFAULT_DOCKER_HOST)?;
         Self::connect_with_host(&host)
     }
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -182,6 +182,14 @@ pub enum Error {
     #[error("Socket not found: {0}")]
     SocketNotFoundError(String),
 
+    /// Error emitted when a Docker context referenced by `DOCKER_CONTEXT` or the
+    /// `currentContext` field of `~/.docker/config.json` cannot be found on disk.
+    #[error("Docker context not found: {name}")]
+    DockerContextNotFoundError {
+        /// Name of the missing context.
+        name: String,
+    },
+
     /// Error emitted when a WebSocket connection fails.
     #[cfg(feature = "websocket")]
     #[error("WebSocket error: {err}")]

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -5,6 +5,7 @@ use std::path::PathBuf;
 
 /// Generic Docker errors
 #[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
 pub enum Error {
     /// Error emitted during client instantiation when the `DOCKER_CERT_PATH` environment variable
     /// is invalid.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -331,6 +331,7 @@
 pub mod auth;
 pub mod config;
 pub mod container;
+pub mod context;
 
 #[cfg(test)]
 pub(crate) mod test_lock {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -331,6 +331,18 @@
 pub mod auth;
 pub mod config;
 pub mod container;
+
+#[cfg(test)]
+pub(crate) mod test_lock {
+    //! Process-wide lock for tests that mutate environment variables.
+    //!
+    //! Multiple tests across the crate manipulate `DOCKER_HOST`, `DOCKER_CONTEXT`,
+    //! `DOCKER_CONFIG`, and `XDG_RUNTIME_DIR`. Rust runs unit tests in parallel by
+    //! default, so without a shared lock these tests would race and produce
+    //! flaky failures.
+    use std::sync::Mutex;
+    pub(crate) static ENV_LOCK: Mutex<()> = Mutex::new(());
+}
 mod docker;
 pub mod errors;
 pub mod exec;


### PR DESCRIPTION
  Problem

  Bollard's connect helpers read only DOCKER_HOST, ignoring the Docker CLI's DOCKER_CONTEXT env var and the currentContext field of ~/.docker/config.json. Users who select their default daemon via docker context use (e.g. Docker Desktop's
  desktop-linux, OrbStack, a remote SSH context) saw bollard silently connect to /var/run/docker.sock. There was also no way to ask for a specific named context programmatically.

  Solution

  Resolve the host using the same precedence as the Docker CLI:

  1. DOCKER_HOST environment variable
  2. The context named by DOCKER_CONTEXT
  3. The currentContext field of $DOCKER_CONFIG/config.json (default: ~/.docker/config.json)
  4. The platform-specific DEFAULT_DOCKER_HOST

  The name default (or empty) at steps 2/3 short-circuits to the platform default. A named context that does not exist on disk produces a new Error::DockerContextNotFoundError { name } — mirroring the CLI's "context not found" failure rather than
  silently falling back.

  This is applied to three existing entry points and exposed via two new constructors:

  - Docker::connect_with_defaults — full Docker CLI precedence above, dispatches to any URI scheme (unix://, tcp://, https://, ssh://, npipe://).
  - Docker::connect_with_unix_defaults and Docker::connect_with_named_pipe_defaults (called via connect_with_local_defaults) — same precedence, but only accept the result if it matches the connector's scheme. A tcp:// or ssh:// context falls back
  to the platform default — these entry points are documented as local-only.
  - Docker::connect_with_context(name) (new) — connects to a specific named context, ignoring all env vars. "default" returns DEFAULT_DOCKER_HOST. Unknown name → DockerContextNotFoundError.
  - Docker::connect_with_current_context() (new) — follows DOCKER_CONTEXT then currentContext from config, falling back to the default. Intentionally does not consult DOCKER_HOST — that's a transport override, not a context selector.

  A new bollard::context module exposes the building blocks (resolve_host, host_for_context, current_context_name) so callers building their own connect flow can reuse them.

  Implementation notes

  - The lookup walks $DOCKER_CONFIG/contexts/meta/*/meta.json and matches on the Name field. Docker normally stores these directories under sha256(name), but iterating avoids pulling in a SHA-256 dependency — the directory typically holds a
  handful of entries.
  - Only the Endpoints.docker.Host field is read. TLS data stored in contexts (contexts/tls/...) is out of scope; users needing TLS continue to use DOCKER_TLS_VERIFY / DOCKER_CERT_PATH (already handled in connect_with_host).
  - Missing or unparseable config files are treated as "unset" — same behaviour as the CLI.
  - The connect_with_podman_defaults Podman-discovery path is intentionally not changed; it has its own probing semantics ("find Podman") that are orthogonal to Docker context selection.

  Test plan

  - Context module — 13 unit tests covering every precedence branch: DOCKER_HOST wins, DOCKER_CONTEXT resolves, currentContext used when env unset, DOCKER_CONTEXT overrides config, default falls back, missing config falls back, unknown context
  errors, empty DOCKER_HOST treated as unset, host_for_context resolves/defaults/errors, current_context_name reads env then config and ignores DOCKER_HOST.
  - Docker constructors — 10 unit tests covering: connect_with_unix_defaults respects DOCKER_HOST, resolves a unix-scheme context, ignores non-unix DOCKER_HOST, ignores non-unix context, propagates missing-context error; connect_with_context uses
  the named context (ignoring DOCKER_HOST), "default" falls back, unknown name errors; connect_with_current_context follows DOCKER_CONTEXT and currentContext, ignores DOCKER_HOST.
  - Existing env-mutating tests now share an ENV_LOCK Mutex — fixes a latent race that became visible once more tests touched the same env vars. Split as a separate commit so it can be reviewed independently.
  - cargo build clean on default features, --no-default-features --features pipe, --no-default-features --features http, and --all-features.
  - cargo clippy --lib --no-deps clean.
  - cargo test --lib (41 passing) and cargo test --doc (131 passing).
  - Manual end-to-end check on macOS and Windows with Docker Desktop and desktop-linux as the active context. All four flows resolve to correct socket/named pipe and docker.info() returns the expected kernel:
    - connect_with_defaults() ✅
    - connect_with_local_defaults() ✅
    - connect_with_context("desktop-linux") ✅
    - connect_with_current_context() ✅
    - connect_with_context("does-not-exist") → Docker context not found: does-not-exist ✅
