### PR TITLE
Remove unused winapi dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -117,8 +117,7 @@ termion = "4.0"
 
 [target.'cfg(windows)'.dependencies]
 hyper-named-pipe = { version = "0.1.0", optional = true }
-winapi = { version = "0.3.9", features = ["winerror"] }
-tower-service = { version = "0.3" }
+tower-service = "0.3"
 
 [[example]]
 name = "websocket_attach"


### PR DESCRIPTION
As far as I can tell the winapi dependency is no longer being used as of #365. I tested and this appears to still build but maybe double check that I'm not missing something here.

Fixes #723.