### PR TITLE
feat: add ssh connection options and fix scheme resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Choose **one** crypto provider:
 |---------|-------------|
 | `ssl` | [Rustls](https://github.com/rustls/rustls) with [ring](https://github.com/briansmith/ring) provider (recommended) |
 | `aws-lc-rs` | [Rustls](https://github.com/rustls/rustls) with [aws-lc-rs](https://github.com/aws/aws-lc-rs) provider (FIPS-compliant) |
-| `ssl_providerless` | [Rustls](https://github.com/rustls/rustls) without crypto provider (bring your own [CryptoProvider](https://docs.rs/rustls/latest/rustls/crypto/struct.CryptoProvider.html)) |
+| `ssl_providerless` | [Rustls](https://github.com/rustls/rustls) without crypto provider (bring your own [`CryptoProvider`](https://docs.rs/rustls/latest/rustls/crypto/struct.CryptoProvider.html)) |
 | `webpki` | Use Mozilla's root certificates instead of OS native certs |
 
 #### DateTime Features
@@ -88,16 +88,13 @@ For timestamp support in events and logs, choose **one**:
 | `buildkit` | Full [BuildKit](https://github.com/moby/buildkit) support (includes `ssl`) |
 | `buildkit_providerless` | BuildKit without bundled crypto provider |
 
-**Note:** BuildKit requires either `chrono` or `time` feature to be enabled for timestamp handling. Example:
-```toml
-bollard = { version = "*", features = ["buildkit", "chrono"] }
-```
+**Note:** BuildKit requires either `chrono` or `time` feature to be enabled for timestamp handling.
 
 #### WebSocket Features
 
 | Feature | Description |
 |---------|-------------|
-| `websocket` | WebSocket support for container attach using [tokio-tungstenite](https://github.com/snapview/tokio-tungstenite) |
+| `websocket` | WebSocket support for [`attach_container_websocket`](Docker::attach_container_websocket) using [tokio-tungstenite](https://github.com/snapview/tokio-tungstenite) |
 
 #### Development Features
 
@@ -130,19 +127,13 @@ use bollard::Docker;
 Docker::connect_with_local_defaults();
 ```
 
-Use the `Docker::connect_with_local` method API to parameterise this interface.
+Use the [`Docker::connect_with_local`] method API to parameterise this interface.
 
 #### Podman
 
 Explicitly connect to Podman with automatic rootless/system socket discovery
-(Unix only).
-
-**Socket discovery order:**
-1. `$DOCKER_HOST` (if set and `unix://`)
-2. `$XDG_RUNTIME_DIR/podman/podman.sock` (rootless)
-3. `/run/user/$UID/podman/podman.sock` (rootless fallback)
-4. `/run/podman/podman.sock` (system/rootful)
-5. `/var/run/docker.sock` (Docker fallback)
+(Unix only). Probes `$DOCKER_HOST`, then rootless Podman sockets, then the
+system Podman socket, and finally falls back to the Docker socket.
 
 ```rust
 use bollard::Docker;
@@ -160,7 +151,7 @@ use bollard::Docker;
 Docker::connect_with_socket_defaults();
 ```
 
-Use the `Docker::connect_with_socket` method API to parameterise this interface.
+Use the [`Docker::connect_with_socket`] method API to parameterise this interface.
 
 #### HTTP
 
@@ -172,7 +163,7 @@ use bollard::Docker;
 Docker::connect_with_http_defaults();
 ```
 
-Use the `Docker::connect_with_http` method API to parameterise the interface.
+Use the [`Docker::connect_with_http`] method API to parameterise the interface.
 
 #### SSL via Rustls
 
@@ -190,6 +181,19 @@ Docker::connect_with_ssl_defaults();
 ```
 
 Use the `Docker::connect_with_ssl` method API to parameterise the interface.
+
+#### SSH
+
+The client will connect to the location pointed to by `DOCKER_HOST` environment variable, or
+`ssh://localhost` if missing.
+
+```rust
+use bollard::Docker;
+#[cfg(feature = "ssh")]
+Docker::connect_with_ssh_defaults();
+```
+
+Use the [`Docker::connect_with_ssh`] or [`Docker::connect_with_ssh_options`] method API to parameterise the interface.
 
 ### Examples
 
@@ -220,20 +224,18 @@ To list docker images available on the Docker server:
 
 ```rust
 use bollard::Docker;
-use bollard::image::ListImagesOptions;
+use bollard::query_parameters::ListImagesOptionsBuilder;
 
 use futures_util::future::FutureExt;
-
-use std::default::Default;
 
 // Use a connection function described above
 // let docker = Docker::connect_...;
 
 async move {
-    let images = &docker.list_images(Some(ListImagesOptions::<String> {
-        all: true,
-        ..Default::default()
-    })).await.unwrap();
+    let options = ListImagesOptionsBuilder::default()
+        .all(true)
+        .build();
+    let images = &docker.list_images(Some(options)).await.unwrap();
 
     for image in images {
         println!("-> {:?}", image);

--- a/src/docker.rs
+++ b/src/docker.rs
@@ -276,7 +276,9 @@ pub type RequestModifier = Arc<dyn Fn(BollardRequest) -> BollardRequest + Send +
 ///  - [`Docker::connect_with_unix_defaults`] (requires `pipe` feature, Unix only)
 ///  - [`Docker::connect_with_local_defaults`]
 ///  - [`Docker::connect_with_podman_defaults`] (Unix only)
-///  - `Docker::connect_with_ssh_defaults` (requires `ssh` feature)
+///  - [`Docker::connect_with_ssh_defaults`] (requires `ssh` feature)
+///  - [`Docker::connect_with_ssh`] (requires `ssh` feature)
+///  - [`Docker::connect_with_ssh_options`] (requires `ssh` feature)
 pub struct Docker {
     pub(crate) transport: Arc<Transport>,
     pub(crate) client_type: ClientType,
@@ -1253,13 +1255,25 @@ impl Docker {
 pub struct SshOptions {
     /// Path to the private key file.
     pub keypair_path: Option<String>,
+
     /// Path to the known hosts file.
     pub user_known_hosts_file: Option<String>,
+
     /// Path to the custom SSH configuration file.
     pub config_file: Option<String>,
-    /// Connection timeout for the SSH handshake.
+
+    /// Timeout applied to establishing the TCP connection and performing the
+    /// initial SSH handshake and key exchange.
     pub connect_timeout: Option<std::time::Duration>,
-    /// Host key check behavior.
+
+    /// Controls how the SSH server's host key is verified.
+    /// See [`openssh::KnownHosts`] for the available verification policies.
+    ///
+    /// The default behavior is [`openssh::KnownHosts::Add`], which verifies known
+    /// hosts and automatically trusts previously unseen hosts.
+    ///
+    /// **Warning:** Using [`openssh::KnownHosts::Accept`] disables host key verification.
+    /// This leaves the connection susceptible to man-in-the-middle (MITM) attacks.
     pub known_hosts_check: Option<openssh::KnownHosts>,
 }
 
@@ -1327,6 +1341,40 @@ impl Docker {
     }
 
     /// Connect using SSH with custom options.
+    ///
+    /// # Arguments
+    ///
+    ///  - `addr`: connection url including scheme and port.
+    ///  - `timeout`: the read/write timeout (seconds) to use for every hyper connection.
+    ///  - `client_version`: the client version to communicate with the server.
+    ///  - `options`: custom SSH options configured via [`SshOptions`].
+    ///
+    /// # Examples
+    ///
+    /// ```rust,no_run
+    /// use bollard::{API_DEFAULT_VERSION, Docker, SshOptions, KnownHosts};
+    /// use std::time::Duration;
+    ///
+    /// use futures_util::future::TryFutureExt;
+    ///
+    /// let options = SshOptions {
+    ///     keypair_path: Some("/path/to/id_rsa".to_string()),
+    ///     user_known_hosts_file: Some("/path/to/known_hosts".to_string()),
+    ///     connect_timeout: Some(Duration::from_secs(10)),
+    ///     known_hosts_check: Some(KnownHosts::Accept),
+    ///     ..Default::default()
+    /// };
+    ///
+    /// let connection = Docker::connect_with_ssh_options(
+    ///     "ssh://user@my-custom-docker-server",
+    ///     4,
+    ///     API_DEFAULT_VERSION,
+    ///     options
+    /// ).unwrap();
+    ///
+    /// connection.ping()
+    ///   .map_ok(|_| Ok::<_, ()>(println!("Connected!")));
+    /// ```
     pub fn connect_with_ssh_options(
         addr: &str,
         timeout: u64,

--- a/src/docker.rs
+++ b/src/docker.rs
@@ -1248,6 +1248,22 @@ impl Docker {
 }
 
 #[cfg(feature = "ssh")]
+/// Options for SSH connection.
+#[derive(Debug, Clone, Default)]
+pub struct SshOptions {
+    /// Path to the private key file.
+    pub keypair_path: Option<String>,
+    /// Path to the known hosts file.
+    pub user_known_hosts_file: Option<String>,
+    /// Path to the custom SSH configuration file.
+    pub config_file: Option<String>,
+    /// Connection timeout for the SSH handshake.
+    pub connect_timeout: Option<std::time::Duration>,
+    /// Host key check behavior.
+    pub known_hosts_check: Option<openssh::KnownHosts>,
+}
+
+#[cfg(feature = "ssh")]
 /// A Docker implementation typed to connect to an SSH connection.
 impl Docker {
     /// Connect using SSH using defaults that are signalled by environment variables.
@@ -1302,12 +1318,24 @@ impl Docker {
         client_version: &ClientVersion,
         keypair_path: Option<String>,
     ) -> Result<Docker, Error> {
+        let options = SshOptions {
+            keypair_path,
+            ..Default::default()
+        };
+        
+        Docker::connect_with_ssh_options(addr, timeout, client_version, options)
+    }
+
+    /// Connect using SSH with custom options.
+    pub fn connect_with_ssh_options(
+        addr: &str,
+        timeout: u64,
+        client_version: &ClientVersion,
+        options: SshOptions,
+    ) -> Result<Docker, Error> {
         let client_addr = addr.replacen("ssh://", "", 1);
 
-        let ssh_connector = match keypair_path {
-            Some(path) => crate::ssh::SshConnector::with_keypair(path.to_string()),
-            None => crate::ssh::SshConnector::new(),
-        };
+        let ssh_connector = crate::ssh::SshConnector::new(options);
 
         let client_builder = Client::builder(TokioExecutor::new());
 

--- a/src/docker.rs
+++ b/src/docker.rs
@@ -1322,7 +1322,7 @@ impl Docker {
             keypair_path,
             ..Default::default()
         };
-        
+
         Docker::connect_with_ssh_options(addr, timeout, client_version, options)
     }
 

--- a/src/docker.rs
+++ b/src/docker.rs
@@ -1279,6 +1279,44 @@ pub struct SshOptions {
 }
 
 #[cfg(feature = "ssh")]
+impl SshOptions {
+    /// Create a new default set of SSH options.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Set the path to the private key file.
+    pub fn with_keypair_path(mut self, path: String) -> Self {
+        self.keypair_path = Some(path);
+        self
+    }
+
+    /// Set the path to the known hosts file.
+    pub fn with_user_known_hosts_file(mut self, path: String) -> Self {
+        self.user_known_hosts_file = Some(path);
+        self
+    }
+
+    /// Set the path to the custom SSH configuration file.
+    pub fn with_config_file(mut self, path: String) -> Self {
+        self.config_file = Some(path);
+        self
+    }
+
+    /// Set the connection timeout.
+    pub fn with_connect_timeout(mut self, timeout: std::time::Duration) -> Self {
+        self.connect_timeout = Some(timeout);
+        self
+    }
+
+    /// Set the host key verification policy.
+    pub fn with_known_hosts_check(mut self, check: openssh::KnownHosts) -> Self {
+        self.known_hosts_check = Some(check);
+        self
+    }
+}
+
+#[cfg(feature = "ssh")]
 /// A Docker implementation typed to connect to an SSH connection.
 impl Docker {
     /// Connect using SSH using defaults that are signalled by environment variables.
@@ -1358,13 +1396,11 @@ impl Docker {
     ///
     /// use futures_util::future::TryFutureExt;
     ///
-    /// let options = SshOptions {
-    ///     keypair_path: Some("/path/to/id_rsa".to_string()),
-    ///     user_known_hosts_file: Some("/path/to/known_hosts".to_string()),
-    ///     connect_timeout: Some(Duration::from_secs(10)),
-    ///     known_hosts_check: Some(KnownHosts::Accept),
-    ///     ..Default::default()
-    /// };
+    /// let options = SshOptions::new()
+    ///     .with_keypair_path("/path/to/id_rsa".to_string())
+    ///     .with_user_known_hosts_file("/path/to/known_hosts".to_string())
+    ///     .with_connect_timeout(Duration::from_secs(10))
+    ///     .with_known_hosts_check(KnownHosts::Accept);
     ///
     /// let connection = Docker::connect_with_ssh_options(
     ///     "ssh://user@my-custom-docker-server",

--- a/src/docker.rs
+++ b/src/docker.rs
@@ -1250,6 +1250,7 @@ impl Docker {
 }
 
 #[cfg(feature = "ssh")]
+#[non_exhaustive]
 /// Options for SSH connection.
 #[derive(Debug, Clone, Default)]
 pub struct SshOptions {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -370,6 +370,11 @@ pub use crate::docker::{
     API_DEFAULT_VERSION,
 };
 
+#[cfg(feature = "ssh")]
+pub use crate::docker::SshOptions;
+#[cfg(feature = "ssh")]
+pub use openssh::KnownHosts;
+
 /// Re-exported request body and response types from `bollard-stubs`.
 ///
 /// Use these types directly from `bollard::models` instead of adding `bollard-stubs`

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -182,6 +182,19 @@
 //!
 //! Use the `Docker::connect_with_ssl` method API to parameterise the interface.
 //!
+//! ### SSH
+//!
+//! The client will connect to the location pointed to by `DOCKER_HOST` environment variable, or
+//! `ssh://localhost` if missing.
+//!
+//! ```rust
+//! use bollard::Docker;
+//! #[cfg(feature = "ssh")]
+//! Docker::connect_with_ssh_defaults();
+//! ```
+//!
+//! Use the [`Docker::connect_with_ssh`] or [`Docker::connect_with_ssh_options`] method API to parameterise the interface.
+//!
 //! ## Examples
 //!
 //! Note: all these examples need a [Tokio

--- a/src/ssh.rs
+++ b/src/ssh.rs
@@ -64,6 +64,10 @@ impl tower_service::Service<hyper::Uri> for SshConnector {
                 builder.connect_timeout(timeout);
             }
             if let Some(hosts_check) = options.known_hosts_check {
+                if matches!(hosts_check, openssh::KnownHosts::Accept) {
+                    log::warn!("host key verification is disabled, this may allow man-in-the-middle (MITM) attacks");
+                }
+
                 builder.known_hosts_check(hosts_check);
             }
 

--- a/src/ssh.rs
+++ b/src/ssh.rs
@@ -1,3 +1,4 @@
+use crate::docker::SshOptions;
 use futures_util::FutureExt;
 use hyper_util::rt::TokioIo;
 use std::future::Future;
@@ -8,18 +9,12 @@ use std::task::{ready, Context, Poll};
 
 #[derive(Clone)]
 pub(crate) struct SshConnector {
-    keypair_path: Option<String>,
+    options: SshOptions,
 }
 
 impl SshConnector {
-    pub fn new() -> Self {
-        Self { keypair_path: None }
-    }
-
-    pub fn with_keypair(keypair_path: String) -> Self {
-        Self {
-            keypair_path: Some(keypair_path),
-        }
+    pub fn new(options: SshOptions) -> Self {
+        Self { options }
     }
 }
 
@@ -40,7 +35,7 @@ impl tower_service::Service<hyper::Uri> for SshConnector {
     }
 
     fn call(&mut self, destination: hyper::Uri) -> Self::Future {
-        let keypair_path = self.keypair_path.clone();
+        let options = self.options.clone();
 
         async move {
             let authority = match destination.scheme() {
@@ -56,8 +51,20 @@ impl tower_service::Service<hyper::Uri> for SshConnector {
 
             let mut builder = openssh::SessionBuilder::default();
 
-            if let Some(key_path) = keypair_path {
+            if let Some(key_path) = options.keypair_path {
                 builder.keyfile(key_path);
+            }
+            if let Some(hosts_file) = options.user_known_hosts_file {
+                builder.user_known_hosts_file(hosts_file);
+            }
+            if let Some(cfg_file) = options.config_file {
+                builder.config_file(cfg_file);
+            }
+            if let Some(timeout) = options.connect_timeout {
+                builder.connect_timeout(timeout);
+            }
+            if let Some(hosts_check) = options.known_hosts_check {
+                builder.known_hosts_check(hosts_check);
             }
 
             let resolved_uri = format!("ssh://{}", authority.as_str());

--- a/src/ssh.rs
+++ b/src/ssh.rs
@@ -60,7 +60,8 @@ impl tower_service::Service<hyper::Uri> for SshConnector {
                 builder.keyfile(key_path);
             }
 
-            let (builder, destination) = builder.resolve(authority.as_str());
+            let resolved_uri = format!("ssh://{}", authority.as_str());
+            let (builder, destination) = builder.resolve(&resolved_uri);
             let tempdir = builder.launch_master(destination).await?;
             let session = Arc::new(openssh::Session::new_process_mux(tempdir));
 


### PR DESCRIPTION
I'm using `bollard` for a project ([slasha](https://github.com/slashacom/slasha)) and it's made a lot of things super easy and simple, so thank you for that.

While using the SSH connection method, I noticed that it wasn't very flexible and would refuse to work properly if the port number was included in the URI string. This PR fixes that port resolution bug, and also introduces a new non-breaking `connect_with_ssh_options` function alongside an `SshOptions` struct so users can pass advanced configurations (like custom known_hosts files) that weren't available before.

If you feel there is a better way to address these issues, I'm completely open to changes. I'm mainly just hoping to get this functionality merged upstream soon.