### PR TITLE
Send the API version prefix in request paths

### DIFF
--- a/src/docker.rs
+++ b/src/docker.rs
@@ -8,6 +8,7 @@ use std::path::Path;
 #[cfg(feature = "ssl_providerless")]
 use std::path::PathBuf;
 use std::pin::Pin;
+use std::sync::atomic::AtomicBool;
 use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
@@ -203,6 +204,10 @@ impl fmt::Debug for Transport {
 /// a higher client version is used than is compatible with the server. Beware also, that the
 /// docker server will return stubs for a higher version than the version set when communicating.
 ///
+/// A version passed to a `connect_with_*` constructor is sent as the `/vX.Y` request path prefix.
+/// The `*_defaults` constructors do not pass one, and their requests stay unversioned, so the daemon
+/// resolves them at its own default version.
+///
 /// See also [negotiate_version](Docker::negotiate_version()), and the `client_version` argument when instantiating the
 /// [Docker] client instance.
 pub struct ClientVersion {
@@ -259,6 +264,53 @@ impl From<&(AtomicUsize, AtomicUsize)> for ClientVersion {
     }
 }
 
+/// The API version a [`Docker`] client is set to, and whether it is pinned. Only a pinned
+/// version is sent to the daemon, as the `/vX.Y` request path prefix.
+#[derive(Debug)]
+pub(crate) struct ApiVersion {
+    version: (AtomicUsize, AtomicUsize),
+    pinned: AtomicBool,
+}
+
+impl ApiVersion {
+    fn pinned(client_version: &ClientVersion) -> Self {
+        Self {
+            version: (
+                AtomicUsize::new(client_version.major_version),
+                AtomicUsize::new(client_version.minor_version),
+            ),
+            pinned: AtomicBool::new(true),
+        }
+    }
+
+    fn client_version(&self) -> ClientVersion {
+        (&self.version).into()
+    }
+
+    fn pinned_version(&self) -> Option<ClientVersion> {
+        self.pinned
+            .load(Ordering::Relaxed)
+            .then(|| self.client_version())
+    }
+
+    fn unpin(&self) {
+        self.pinned.store(false, Ordering::Relaxed);
+    }
+
+    /// Downgrade to the daemon's version if the client is ahead of it, and pin the outcome.
+    fn negotiated(&self, server_version: &ClientVersion) {
+        if server_version < &self.client_version() {
+            self.version
+                .0
+                .store(server_version.major_version, Ordering::Relaxed);
+            self.version
+                .1
+                .store(server_version.minor_version, Ordering::Relaxed);
+        }
+        self.pinned.store(true, Ordering::Relaxed);
+    }
+}
+
 pub type RequestModifier = Arc<dyn Fn(BollardRequest) -> BollardRequest + Send + Sync>;
 
 /// ---
@@ -284,7 +336,7 @@ pub struct Docker {
     pub(crate) client_type: ClientType,
     pub(crate) client_addr: String,
     pub(crate) client_timeout: u64,
-    pub(crate) version: Arc<(AtomicUsize, AtomicUsize)>,
+    pub(crate) version: Arc<ApiVersion>,
     pub(crate) request_modifier: Option<RequestModifier>,
 }
 
@@ -462,6 +514,7 @@ impl Docker {
             DEFAULT_TIMEOUT,
             API_DEFAULT_VERSION,
         )
+        .map(Docker::unpin_version)
     }
 
     /// Connect using secure HTTPS.
@@ -567,10 +620,7 @@ impl Docker {
             client_type: ClientType::SSL,
             client_addr,
             client_timeout: timeout,
-            version: Arc::new((
-                AtomicUsize::new(client_version.major_version),
-                AtomicUsize::new(client_version.minor_version),
-            )),
+            version: Arc::new(ApiVersion::pinned(client_version)),
             request_modifier: None,
         };
 
@@ -604,6 +654,7 @@ impl Docker {
     pub fn connect_with_http_defaults() -> Result<Docker, Error> {
         let host = env::var("DOCKER_HOST").unwrap_or_else(|_| DEFAULT_TCP_ADDRESS.to_string());
         Docker::connect_with_http(&host, DEFAULT_TIMEOUT, API_DEFAULT_VERSION)
+            .map(Docker::unpin_version)
     }
 
     /// Connect using unsecured HTTP.
@@ -647,10 +698,7 @@ impl Docker {
             client_type: ClientType::Http,
             client_addr,
             client_timeout: timeout,
-            version: Arc::new((
-                AtomicUsize::new(client_version.major_version),
-                AtomicUsize::new(client_version.minor_version),
-            )),
+            version: Arc::new(ApiVersion::pinned(client_version)),
             request_modifier: None,
         };
 
@@ -726,10 +774,7 @@ impl Docker {
             client_type: ClientType::Custom { scheme },
             client_addr,
             client_timeout: timeout,
-            version: Arc::new((
-                AtomicUsize::new(client_version.major_version),
-                AtomicUsize::new(client_version.minor_version),
-            )),
+            version: Arc::new(ApiVersion::pinned(client_version)),
             request_modifier: None,
         };
 
@@ -766,6 +811,7 @@ impl Docker {
         let path = DEFAULT_NAMED_PIPE;
 
         Docker::connect_with_socket(path, DEFAULT_TIMEOUT, API_DEFAULT_VERSION)
+            .map(Docker::unpin_version)
     }
 
     /// Connect using a Unix socket or a Windows named pipe.
@@ -881,7 +927,7 @@ impl Docker {
     /// connection.ping().map_ok(|_| Ok::<_, ()>(println!("Connected!")));
     /// ```
     pub fn connect_with_host(host: &str) -> Result<Docker, Error> {
-        match host {
+        let docker = match host {
             #[cfg(all(feature = "pipe", unix))]
             h if h.starts_with("unix://") => {
                 Docker::connect_with_unix(h, DEFAULT_TIMEOUT, API_DEFAULT_VERSION)
@@ -907,7 +953,9 @@ impl Docker {
             _ => Err(UnsupportedURISchemeError {
                 uri: host.to_string(),
             }),
-        }
+        };
+
+        docker.map(Docker::unpin_version)
     }
 
     /// Connect to the named Docker context.
@@ -1011,6 +1059,7 @@ impl Docker {
             DEFAULT_SOCKET.to_string()
         };
         Docker::connect_with_unix(&path, DEFAULT_TIMEOUT, API_DEFAULT_VERSION)
+            .map(Docker::unpin_version)
     }
 
     /// Resolve the rootless Podman socket path for the current user.
@@ -1084,21 +1133,25 @@ impl Docker {
             .ok()
             .filter(|p| p.starts_with("unix://"))
         {
-            return Docker::connect_with_unix(&host, DEFAULT_TIMEOUT, API_DEFAULT_VERSION);
+            return Docker::connect_with_unix(&host, DEFAULT_TIMEOUT, API_DEFAULT_VERSION)
+                .map(Docker::unpin_version);
         }
 
         // Probe for Podman rootless socket
         if let Some(sock) = Self::podman_rootless_socket_path() {
-            return Docker::connect_with_unix(&sock, DEFAULT_TIMEOUT, API_DEFAULT_VERSION);
+            return Docker::connect_with_unix(&sock, DEFAULT_TIMEOUT, API_DEFAULT_VERSION)
+                .map(Docker::unpin_version);
         }
 
         // Probe for Podman system socket
         if let Some(sock) = Self::podman_system_socket_path() {
-            return Docker::connect_with_unix(sock, DEFAULT_TIMEOUT, API_DEFAULT_VERSION);
+            return Docker::connect_with_unix(sock, DEFAULT_TIMEOUT, API_DEFAULT_VERSION)
+                .map(Docker::unpin_version);
         }
 
         // Fall back to default Docker socket
         Docker::connect_with_unix(DEFAULT_SOCKET, DEFAULT_TIMEOUT, API_DEFAULT_VERSION)
+            .map(Docker::unpin_version)
     }
 
     /// Connect using a Unix socket.
@@ -1143,10 +1196,7 @@ impl Docker {
             client_type: ClientType::Unix,
             client_addr,
             client_timeout: timeout,
-            version: Arc::new((
-                AtomicUsize::new(client_version.major_version),
-                AtomicUsize::new(client_version.minor_version),
-            )),
+            version: Arc::new(ApiVersion::pinned(client_version)),
             request_modifier: None,
         };
 
@@ -1196,6 +1246,7 @@ impl Docker {
             DEFAULT_NAMED_PIPE.to_string()
         };
         Docker::connect_with_named_pipe(&path, DEFAULT_TIMEOUT, API_DEFAULT_VERSION)
+            .map(Docker::unpin_version)
     }
 
     /// Connect using a Windows Named Pipe.
@@ -1238,10 +1289,7 @@ impl Docker {
             client_type: ClientType::NamedPipe,
             client_addr,
             client_timeout: timeout,
-            version: Arc::new((
-                AtomicUsize::new(client_version.major_version),
-                AtomicUsize::new(client_version.minor_version),
-            )),
+            version: Arc::new(ApiVersion::pinned(client_version)),
             request_modifier: None,
         };
 
@@ -1342,6 +1390,7 @@ impl Docker {
     pub fn connect_with_ssh_defaults() -> Result<Docker, Error> {
         let host = env::var("DOCKER_HOST").unwrap_or_else(|_| DEFAULT_SSH_ADDRESS.to_string());
         Docker::connect_with_ssh(&host, DEFAULT_TIMEOUT, API_DEFAULT_VERSION, None)
+            .map(Docker::unpin_version)
     }
 
     /// Connect using SSH.
@@ -1431,10 +1480,7 @@ impl Docker {
             client_type: ClientType::Ssh,
             client_addr,
             client_timeout: timeout,
-            version: Arc::new((
-                AtomicUsize::new(client_version.major_version),
-                AtomicUsize::new(client_version.minor_version),
-            )),
+            version: Arc::new(ApiVersion::pinned(client_version)),
             request_modifier: None,
         };
 
@@ -1488,10 +1534,7 @@ impl Docker {
             client_type,
             client_addr,
             client_timeout: timeout,
-            version: Arc::new((
-                AtomicUsize::new(client_version.major_version),
-                AtomicUsize::new(client_version.minor_version),
-            )),
+            version: Arc::new(ApiVersion::pinned(client_version)),
             request_modifier: None,
         };
 
@@ -1734,11 +1777,21 @@ impl Docker {
 
     /// Return the currently set client version.
     pub fn client_version(&self) -> ClientVersion {
-        self.version.as_ref().into()
+        self.version.client_version()
+    }
+
+    /// For the `*_defaults` constructors, which supply [`API_DEFAULT_VERSION`] on the
+    /// caller's behalf: the caller pinned nothing, so requests stay unversioned.
+    fn unpin_version(self) -> Self {
+        self.version.unpin();
+        self
     }
 
     /// Check with the server for a supported version, and downgrade the client version if
     /// appropriate.
+    ///
+    /// The probe is sent unversioned, so it also reaches daemons that reject the client's
+    /// version as too new. The negotiated version is then sent with every request.
     ///
     /// # Examples:
     ///
@@ -1774,14 +1827,7 @@ impl Docker {
             return Err(APIVersionParseError {});
         };
 
-        if server_version < self.client_version() {
-            self.version
-                .0
-                .store(server_version.major_version, Ordering::Relaxed);
-            self.version
-                .1
-                .store(server_version.minor_version, Ordering::Relaxed);
-        }
+        self.version.negotiated(&server_version);
 
         Ok(self)
     }
@@ -1845,7 +1891,7 @@ impl Docker {
     where
         O: Serialize,
     {
-        self.build_versioned_request(path, builder, query, payload, Some(self.client_version()))
+        self.build_versioned_request(path, builder, query, payload, self.version.pinned_version())
     }
 
     /// Build a request with an explicit API version, or none at all. An unversioned
@@ -2310,6 +2356,82 @@ mod tests {
                 Error::DockerContextNotFoundError { name } => assert_eq!(name, "does-not-exist"),
                 other => panic!("expected DockerContextNotFoundError, got {other:?}"),
             }
+        }
+    }
+
+    #[cfg(feature = "http")]
+    mod api_version {
+        use super::*;
+
+        const V1_44: ClientVersion = ClientVersion {
+            major_version: 1,
+            minor_version: 44,
+        };
+
+        fn client(client_version: &ClientVersion) -> Docker {
+            Docker::connect_with_http("http://localhost:2375", 5, client_version).unwrap()
+        }
+
+        fn request_path(docker: &Docker) -> String {
+            docker
+                .build_request(
+                    "/containers/json",
+                    Builder::new().method(Method::GET),
+                    None::<String>,
+                    Ok(body_full(Bytes::new())),
+                )
+                .unwrap()
+                .uri()
+                .path()
+                .to_owned()
+        }
+
+        #[test]
+        fn pinned_version_is_sent() {
+            assert_eq!(request_path(&client(&V1_44)), "/v1.44/containers/json");
+        }
+
+        #[test]
+        fn pinned_default_version_is_sent() {
+            assert_eq!(
+                request_path(&client(API_DEFAULT_VERSION)),
+                format!("/v{API_DEFAULT_VERSION}/containers/json")
+            );
+        }
+
+        #[test]
+        fn defaults_constructor_pins_nothing() {
+            let _lock = crate::test_lock::ENV_LOCK.lock().unwrap();
+            let docker = Docker::connect_with_http_defaults().unwrap();
+
+            assert_eq!(docker.client_version(), *API_DEFAULT_VERSION);
+            assert_eq!(request_path(&docker), "/containers/json");
+        }
+
+        #[test]
+        fn negotiation_pins_the_downgraded_version() {
+            let _lock = crate::test_lock::ENV_LOCK.lock().unwrap();
+            let docker = Docker::connect_with_http_defaults().unwrap();
+            docker.version.negotiated(&V1_44);
+
+            assert_eq!(docker.client_version(), V1_44);
+            assert_eq!(request_path(&docker), "/v1.44/containers/json");
+        }
+
+        #[test]
+        fn negotiation_pins_the_version_it_keeps() {
+            let _lock = crate::test_lock::ENV_LOCK.lock().unwrap();
+            let docker = Docker::connect_with_http_defaults().unwrap();
+            docker.version.negotiated(&ClientVersion {
+                major_version: 1,
+                minor_version: 99,
+            });
+
+            assert_eq!(docker.client_version(), *API_DEFAULT_VERSION);
+            assert_eq!(
+                request_path(&docker),
+                format!("/v{API_DEFAULT_VERSION}/containers/json")
+            );
         }
     }
 }

--- a/src/docker.rs
+++ b/src/docker.rs
@@ -1751,11 +1751,12 @@ impl Docker {
     ///     };
     /// ```
     pub async fn negotiate_version(self) -> Result<Self, Error> {
-        let req = self.build_request(
+        let req = self.build_versioned_request(
             "/version",
             Builder::new().method(Method::GET),
             None::<String>,
             Ok(BodyType::Left(Full::new(Bytes::new()))),
+            None,
         );
 
         let res = self
@@ -1844,12 +1845,30 @@ impl Docker {
     where
         O: Serialize,
     {
+        self.build_versioned_request(path, builder, query, payload, Some(self.client_version()))
+    }
+
+    /// Build a request with an explicit API version, or none at all. An unversioned
+    /// request is resolved against the daemon's default API version, which allows
+    /// [version negotiation](Docker::negotiate_version()) to succeed against daemons
+    /// that reject the client's default version as too new.
+    pub(crate) fn build_versioned_request<O>(
+        &self,
+        path: &str,
+        builder: Builder,
+        query: Option<O>,
+        payload: Result<BodyType, Error>,
+        client_version: Option<ClientVersion>,
+    ) -> Result<Request<BodyType>, Error>
+    where
+        O: Serialize,
+    {
         let uri = Uri::parse(
             &self.client_addr,
             &self.client_type,
             path,
             query,
-            &self.client_version(),
+            client_version.as_ref(),
         )?;
         let request_uri: hyper::Uri = uri.try_into()?;
         debug!("{}", request_uri);

--- a/src/docker.rs
+++ b/src/docker.rs
@@ -8,9 +8,6 @@ use std::path::Path;
 #[cfg(feature = "ssl_providerless")]
 use std::path::PathBuf;
 use std::pin::Pin;
-use std::sync::atomic::AtomicBool;
-use std::sync::atomic::AtomicUsize;
-use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use std::time::Duration;
 use std::{cmp, env, fmt};
@@ -255,59 +252,40 @@ impl PartialOrd for ClientVersion {
     }
 }
 
-impl From<&(AtomicUsize, AtomicUsize)> for ClientVersion {
-    fn from(tpl: &(AtomicUsize, AtomicUsize)) -> ClientVersion {
-        ClientVersion {
-            major_version: tpl.0.load(Ordering::Relaxed),
-            minor_version: tpl.1.load(Ordering::Relaxed),
-        }
-    }
-}
-
 /// The API version a [`Docker`] client is set to, and whether it is pinned. Only a pinned
 /// version is sent to the daemon, as the `/vX.Y` request path prefix.
-#[derive(Debug)]
+#[derive(Debug, Copy, Clone)]
 pub(crate) struct ApiVersion {
-    version: (AtomicUsize, AtomicUsize),
-    pinned: AtomicBool,
+    version: ClientVersion,
+    pinned: bool,
 }
 
 impl ApiVersion {
     fn pinned(client_version: &ClientVersion) -> Self {
         Self {
-            version: (
-                AtomicUsize::new(client_version.major_version),
-                AtomicUsize::new(client_version.minor_version),
-            ),
-            pinned: AtomicBool::new(true),
+            version: *client_version,
+            pinned: true,
         }
     }
 
     fn client_version(&self) -> ClientVersion {
-        (&self.version).into()
+        self.version
     }
 
     fn pinned_version(&self) -> Option<ClientVersion> {
-        self.pinned
-            .load(Ordering::Relaxed)
-            .then(|| self.client_version())
+        self.pinned.then_some(self.version)
     }
 
-    fn unpin(&self) {
-        self.pinned.store(false, Ordering::Relaxed);
+    fn unpin(&mut self) {
+        self.pinned = false;
     }
 
     /// Downgrade to the daemon's version if the client is ahead of it, and pin the outcome.
-    fn negotiated(&self, server_version: &ClientVersion) {
-        if server_version < &self.client_version() {
-            self.version
-                .0
-                .store(server_version.major_version, Ordering::Relaxed);
-            self.version
-                .1
-                .store(server_version.minor_version, Ordering::Relaxed);
+    fn negotiated(&mut self, server_version: &ClientVersion) {
+        if server_version < &self.version {
+            self.version = *server_version;
         }
-        self.pinned.store(true, Ordering::Relaxed);
+        self.pinned = true;
     }
 }
 
@@ -336,7 +314,7 @@ pub struct Docker {
     pub(crate) client_type: ClientType,
     pub(crate) client_addr: String,
     pub(crate) client_timeout: u64,
-    pub(crate) version: Arc<ApiVersion>,
+    pub(crate) version: ApiVersion,
     pub(crate) request_modifier: Option<RequestModifier>,
 }
 
@@ -363,7 +341,7 @@ impl Clone for Docker {
             client_type: self.client_type.clone(),
             client_addr: self.client_addr.clone(),
             client_timeout: self.client_timeout,
-            version: self.version.clone(),
+            version: self.version,
             request_modifier: self.request_modifier.clone(),
         }
     }
@@ -620,7 +598,7 @@ impl Docker {
             client_type: ClientType::SSL,
             client_addr,
             client_timeout: timeout,
-            version: Arc::new(ApiVersion::pinned(client_version)),
+            version: ApiVersion::pinned(client_version),
             request_modifier: None,
         };
 
@@ -698,7 +676,7 @@ impl Docker {
             client_type: ClientType::Http,
             client_addr,
             client_timeout: timeout,
-            version: Arc::new(ApiVersion::pinned(client_version)),
+            version: ApiVersion::pinned(client_version),
             request_modifier: None,
         };
 
@@ -774,7 +752,7 @@ impl Docker {
             client_type: ClientType::Custom { scheme },
             client_addr,
             client_timeout: timeout,
-            version: Arc::new(ApiVersion::pinned(client_version)),
+            version: ApiVersion::pinned(client_version),
             request_modifier: None,
         };
 
@@ -1196,7 +1174,7 @@ impl Docker {
             client_type: ClientType::Unix,
             client_addr,
             client_timeout: timeout,
-            version: Arc::new(ApiVersion::pinned(client_version)),
+            version: ApiVersion::pinned(client_version),
             request_modifier: None,
         };
 
@@ -1289,7 +1267,7 @@ impl Docker {
             client_type: ClientType::NamedPipe,
             client_addr,
             client_timeout: timeout,
-            version: Arc::new(ApiVersion::pinned(client_version)),
+            version: ApiVersion::pinned(client_version),
             request_modifier: None,
         };
 
@@ -1480,7 +1458,7 @@ impl Docker {
             client_type: ClientType::Ssh,
             client_addr,
             client_timeout: timeout,
-            version: Arc::new(ApiVersion::pinned(client_version)),
+            version: ApiVersion::pinned(client_version),
             request_modifier: None,
         };
 
@@ -1534,7 +1512,7 @@ impl Docker {
             client_type,
             client_addr,
             client_timeout: timeout,
-            version: Arc::new(ApiVersion::pinned(client_version)),
+            version: ApiVersion::pinned(client_version),
             request_modifier: None,
         };
 
@@ -1782,7 +1760,7 @@ impl Docker {
 
     /// For the `*_defaults` constructors, which supply [`API_DEFAULT_VERSION`] on the
     /// caller's behalf: the caller pinned nothing, so requests stay unversioned.
-    fn unpin_version(self) -> Self {
+    fn unpin_version(mut self) -> Self {
         self.version.unpin();
         self
     }
@@ -1803,7 +1781,7 @@ impl Docker {
     ///         &docker.negotiate_version().await.unwrap().version();
     ///     };
     /// ```
-    pub async fn negotiate_version(self) -> Result<Self, Error> {
+    pub async fn negotiate_version(mut self) -> Result<Self, Error> {
         let req = self.build_versioned_request(
             "/version",
             Builder::new().method(Method::GET),
@@ -2411,7 +2389,7 @@ mod tests {
         #[test]
         fn negotiation_pins_the_downgraded_version() {
             let _lock = crate::test_lock::ENV_LOCK.lock().unwrap();
-            let docker = Docker::connect_with_http_defaults().unwrap();
+            let mut docker = Docker::connect_with_http_defaults().unwrap();
             docker.version.negotiated(&V1_44);
 
             assert_eq!(docker.client_version(), V1_44);
@@ -2421,7 +2399,7 @@ mod tests {
         #[test]
         fn negotiation_pins_the_version_it_keeps() {
             let _lock = crate::test_lock::ENV_LOCK.lock().unwrap();
-            let docker = Docker::connect_with_http_defaults().unwrap();
+            let mut docker = Docker::connect_with_http_defaults().unwrap();
             docker.version.negotiated(&ClientVersion {
                 major_version: 1,
                 minor_version: 99,

--- a/src/uri.rs
+++ b/src/uri.rs
@@ -27,21 +27,23 @@ impl<'a> Uri<'a> {
         client_type: &ClientType,
         path: &'a str,
         query: Option<O>,
-        client_version: &ClientVersion,
+        client_version: Option<&ClientVersion>,
     ) -> Result<Self, Error>
     where
         O: serde::ser::Serialize,
     {
-        let host_str = format!(
-            "{}://{}/v{}.{}{}",
+        let mut url = Url::parse(&format!(
+            "{}://{}",
             Uri::socket_scheme(client_type),
-            Uri::socket_host(socket, client_type),
-            client_version.major_version,
-            client_version.minor_version,
-            path
-        );
-        let mut url = Url::parse(host_str.as_ref())?;
-        url = url.join(path)?;
+            Uri::socket_host(socket, client_type)
+        ))?;
+        match client_version {
+            Some(version) => url.set_path(&format!(
+                "/v{}.{}{}",
+                version.major_version, version.minor_version, path
+            )),
+            None => url.set_path(path),
+        }
 
         if let Some(pairs) = query {
             trace!("pairs: {}", serde_json::to_string(&pairs)?);
@@ -94,5 +96,103 @@ impl<'a> Uri<'a> {
             ClientType::Ssh => "ssh",
             ClientType::Custom { scheme } => scheme.as_str(),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const VERSION: ClientVersion = ClientVersion {
+        major_version: 1,
+        minor_version: 53,
+    };
+
+    fn client_type() -> ClientType {
+        ClientType::Custom {
+            scheme: String::from("http"),
+        }
+    }
+
+    #[test]
+    fn parse_retains_api_version_prefix() {
+        let uri = Uri::parse(
+            "localhost:2375",
+            &client_type(),
+            "/containers/json",
+            None::<String>,
+            Some(&VERSION),
+        )
+        .unwrap();
+        let uri: HyperUri = uri.try_into().unwrap();
+
+        assert_eq!(uri.path(), "/v1.53/containers/json");
+    }
+
+    #[test]
+    fn parse_appends_query_after_version_prefix() {
+        let query = std::collections::HashMap::from([("all", "true")]);
+        let uri = Uri::parse(
+            "localhost:2375",
+            &client_type(),
+            "/containers/json",
+            Some(query),
+            Some(&VERSION),
+        )
+        .unwrap();
+        let uri: HyperUri = uri.try_into().unwrap();
+
+        assert_eq!(
+            uri.path_and_query().unwrap().as_str(),
+            "/v1.53/containers/json?all=true"
+        );
+    }
+
+    #[test]
+    fn parse_percent_encodes_path_segments() {
+        let uri = Uri::parse(
+            "localhost:2375",
+            &client_type(),
+            "/containers/my container/json",
+            None::<String>,
+            Some(&VERSION),
+        )
+        .unwrap();
+        let uri: HyperUri = uri.try_into().unwrap();
+
+        assert_eq!(uri.path(), "/v1.53/containers/my%20container/json");
+    }
+
+    #[test]
+    fn parse_confines_delimiters_to_the_path() {
+        let uri = Uri::parse(
+            "localhost:2375",
+            &client_type(),
+            "/containers/a?b#c/json",
+            None::<String>,
+            Some(&VERSION),
+        )
+        .unwrap();
+        let uri: HyperUri = uri.try_into().unwrap();
+
+        assert_eq!(
+            uri.path_and_query().unwrap().as_str(),
+            "/v1.53/containers/a%3Fb%23c/json"
+        );
+    }
+
+    #[test]
+    fn parse_without_version_omits_prefix() {
+        let uri = Uri::parse(
+            "localhost:2375",
+            &client_type(),
+            "/version",
+            None::<String>,
+            None,
+        )
+        .unwrap();
+        let uri: HyperUri = uri.try_into().unwrap();
+
+        assert_eq!(uri.path(), "/version");
     }
 }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -24,13 +24,14 @@ macro_rules! connect_to_docker_and_run {
     ($exec:expr) => {{
         let rt = Runtime::new().unwrap();
         #[cfg(all(unix, not(feature = "test_http"), not(feature = "test_ssl")))]
-        let fut = $exec(Docker::connect_with_unix_defaults().unwrap());
+        let docker = Docker::connect_with_unix_defaults().unwrap();
         #[cfg(all(feature = "test_http", not(feature = "test_ssl")))]
-        let fut = $exec(Docker::connect_with_http_defaults().unwrap());
+        let docker = Docker::connect_with_http_defaults().unwrap();
         #[cfg(feature = "test_ssl")]
-        let fut = $exec(Docker::connect_with_ssl_defaults().unwrap());
+        let docker = Docker::connect_with_ssl_defaults().unwrap();
         #[cfg(windows)]
-        let fut = $exec(Docker::connect_with_named_pipe_defaults().unwrap());
+        let docker = Docker::connect_with_named_pipe_defaults().unwrap();
+        let fut = async move { $exec(docker.negotiate_version().await.unwrap()).await };
         run_runtime(rt, fut);
     }};
 }

--- a/tests/podman_test.rs
+++ b/tests/podman_test.rs
@@ -23,6 +23,13 @@ mod podman_integration {
         };
 
         let rt = Runtime::new().unwrap();
+        let docker = match rt.block_on(docker.negotiate_version()) {
+            Ok(d) => d,
+            Err(e) => {
+                eprintln!("skipping: no Podman socket available ({e})");
+                return;
+            }
+        };
         let pong = rt.block_on(docker.ping());
         assert!(pong.is_ok(), "ping failed: {:?}", pong.err());
     }
@@ -61,6 +68,13 @@ mod podman_integration {
         };
 
         let rt = Runtime::new().unwrap();
+        let docker = match rt.block_on(docker.negotiate_version()) {
+            Ok(d) => d,
+            Err(e) => {
+                eprintln!("skipping: no Podman socket available ({e})");
+                return;
+            }
+        };
         let result = rt.block_on(docker.list_containers(Some(ListContainersOptions {
             all: true,
             ..Default::default()

--- a/tests/race_test.rs
+++ b/tests/race_test.rs
@@ -43,7 +43,12 @@ async fn test_runtime_4() {
 }
 
 async fn run_test(count: usize) {
-    let docker = get_docker().unwrap();
+    let docker = get_docker()
+        .unwrap()
+        .clone()
+        .negotiate_version()
+        .await
+        .unwrap();
     for _ in 0..count {
         let _ = &docker
             .list_images(Some(ListImagesOptionsBuilder::default().all(true).build()))

--- a/tests/version_test.rs
+++ b/tests/version_test.rs
@@ -76,22 +76,36 @@ fn test_version_podman() {
 fn test_downversioning() {
     let rt = Runtime::new().unwrap();
 
-    let docker = Docker::connect_with_unix(
-        "unix:///var/run/docker.sock",
-        120,
-        &ClientVersion {
-            major_version: 1,
-            minor_version: 24,
-        },
-    )
-    .unwrap();
-
     let fut = async move {
+        // Pin to the daemon's minimum supported API version, so that the pin
+        // is below the daemon's maximum on any engine.
+        let min_api_version = Docker::connect_with_unix_defaults()
+            .unwrap()
+            .negotiate_version()
+            .await
+            .unwrap()
+            .version()
+            .await
+            .unwrap()
+            .min_api_version
+            .unwrap();
+        let (major, minor) = min_api_version.split_once('.').unwrap();
+
+        let docker = Docker::connect_with_unix(
+            "unix:///var/run/docker.sock",
+            120,
+            &ClientVersion {
+                major_version: major.parse().unwrap(),
+                minor_version: minor.parse().unwrap(),
+            },
+        )
+        .unwrap();
+
         let docker = &docker.negotiate_version().await.unwrap();
 
         let _ = &docker.version().await.unwrap();
 
-        assert_eq!(docker.client_version().to_string(), "1.24".to_string());
+        assert_eq!(docker.client_version().to_string(), min_api_version);
     };
     rt.block_on(fut);
 }

--- a/tests/version_test.rs
+++ b/tests/version_test.rs
@@ -11,9 +11,15 @@ mod common;
 #[test]
 fn test_version_named_pipe() {
     rt_exec!(
-        Docker::connect_with_named_pipe_defaults()
-            .unwrap()
-            .version(),
+        async {
+            Docker::connect_with_named_pipe_defaults()
+                .unwrap()
+                .negotiate_version()
+                .await
+                .unwrap()
+                .version()
+                .await
+        },
         |version: SystemVersion| assert_eq!(version.os.unwrap(), "windows")
     )
 }
@@ -23,7 +29,15 @@ fn test_version_named_pipe() {
 #[allow(clippy::redundant_closure_call)]
 fn test_version_unix() {
     rt_exec!(
-        Docker::connect_with_unix_defaults().unwrap().version(),
+        async {
+            Docker::connect_with_unix_defaults()
+                .unwrap()
+                .negotiate_version()
+                .await
+                .unwrap()
+                .version()
+                .await
+        },
         |version: SystemVersion| assert_eq!(version.os.unwrap(), "linux")
     )
 }
@@ -32,7 +46,15 @@ fn test_version_unix() {
 #[test]
 fn test_version_ssl() {
     rt_exec!(
-        Docker::connect_with_ssl_defaults().unwrap().version(),
+        async {
+            Docker::connect_with_ssl_defaults()
+                .unwrap()
+                .negotiate_version()
+                .await
+                .unwrap()
+                .version()
+                .await
+        },
         |version: SystemVersion| assert_eq!(version.os.unwrap(), "linux")
     )
 }
@@ -42,12 +64,28 @@ fn test_version_ssl() {
 fn test_version_http() {
     #[cfg(unix)]
     rt_exec!(
-        Docker::connect_with_http_defaults().unwrap().version(),
+        async {
+            Docker::connect_with_http_defaults()
+                .unwrap()
+                .negotiate_version()
+                .await
+                .unwrap()
+                .version()
+                .await
+        },
         |version: SystemVersion| assert_eq!(version.os.unwrap(), "linux")
     );
     #[cfg(windows)]
     rt_exec!(
-        Docker::connect_with_http_defaults().unwrap().version(),
+        async {
+            Docker::connect_with_http_defaults()
+                .unwrap()
+                .negotiate_version()
+                .await
+                .unwrap()
+                .version()
+                .await
+        },
         |version: SystemVersion| assert_eq!(version.os.unwrap(), "windows")
     )
 }
@@ -56,7 +94,15 @@ fn test_version_http() {
 #[test]
 fn test_version_ssh() {
     rt_exec!(
-        Docker::connect_with_ssh_defaults().unwrap().version(),
+        async {
+            Docker::connect_with_ssh_defaults()
+                .unwrap()
+                .negotiate_version()
+                .await
+                .unwrap()
+                .version()
+                .await
+        },
         |version: SystemVersion| assert_eq!(version.os.unwrap(), "linux")
     );
 }
@@ -66,7 +112,15 @@ fn test_version_ssh() {
 #[allow(clippy::redundant_closure_call)]
 fn test_version_podman() {
     rt_exec!(
-        Docker::connect_with_podman_defaults().unwrap().version(),
+        async {
+            Docker::connect_with_podman_defaults()
+                .unwrap()
+                .negotiate_version()
+                .await
+                .unwrap()
+                .version()
+                .await
+        },
         |version: SystemVersion| assert_eq!(version.os.unwrap(), "linux")
     )
 }
@@ -115,12 +169,28 @@ fn test_downversioning() {
 fn test_connect_with_defaults() {
     #[cfg(unix)]
     rt_exec!(
-        Docker::connect_with_defaults().unwrap().version(),
+        async {
+            Docker::connect_with_defaults()
+                .unwrap()
+                .negotiate_version()
+                .await
+                .unwrap()
+                .version()
+                .await
+        },
         |version: SystemVersion| assert_eq!(version.os.unwrap(), "linux")
     );
     #[cfg(windows)]
     rt_exec!(
-        Docker::connect_with_defaults().unwrap().version(),
+        async {
+            Docker::connect_with_defaults()
+                .unwrap()
+                .negotiate_version()
+                .await
+                .unwrap()
+                .version()
+                .await
+        },
         |version: SystemVersion| assert_eq!(version.os.unwrap(), "windows")
     )
 }


### PR DESCRIPTION
The version prefix has been dropped from every request URI since it was introduced in f35f39b.

In this fix the negotiation probe itself is sent unversioned to avoid default mismatch.

Closes https://github.com/fussybeaver/bollard/issues/736