### PR TITLE
feat: distinguish 204 from 304 in start/stop container

### DIFF
--- a/src/container.rs
+++ b/src/container.rs
@@ -7,7 +7,7 @@ use futures_util::{StreamExt, TryStreamExt};
 use http::header::{CONNECTION, CONTENT_TYPE, UPGRADE};
 use http::request::Builder;
 use http_body_util::Full;
-use hyper::{body::Bytes, Method};
+use hyper::{body::Bytes, Method, StatusCode};
 use serde::Serialize;
 use serde_derive::Deserialize;
 use std::cmp::Eq;
@@ -88,6 +88,24 @@ impl fmt::Debug for AttachContainerResults {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "AttachContainerResults")
     }
+}
+
+/// Result type for the [Start Container API](Docker::start_container())
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum StartContainerResult {
+    /// The container was started by this request (HTTP status 204)
+    Started,
+    /// The container was already running when the request took effect (HTTP status 304)
+    AlreadyStarted,
+}
+
+/// Result type for the [Stop Container API](Docker::stop_container())
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum StopContainerResult {
+    /// The container was stopped by this request (HTTP status 204)
+    Stopped,
+    /// The container was already stopped when the request took effect (HTTP status 304)
+    AlreadyStopped,
 }
 
 /// Result type for the [Logs API](Docker::logs())
@@ -323,7 +341,8 @@ impl Docker {
     ///
     /// # Returns
     ///
-    ///  - unit type `()`, wrapped in a Future.
+    ///  - a [Start Container Result](StartContainerResult), wrapped in a Future. Distinguishes
+    ///    whether the container was started by this request or was already running.
     ///
     /// # Examples
     ///
@@ -337,7 +356,7 @@ impl Docker {
         &self,
         container_name: &str,
         options: Option<crate::query_parameters::StartContainerOptions>,
-    ) -> Result<(), Error> {
+    ) -> Result<StartContainerResult, Error> {
         let url = format!("/containers/{container_name}/start");
 
         let req = self.build_request(
@@ -347,7 +366,10 @@ impl Docker {
             Ok(BodyType::Left(Full::new(Bytes::new()))),
         );
 
-        self.process_into_unit(req).await
+        match self.process_into_status(req).await? {
+            StatusCode::NOT_MODIFIED => Ok(StartContainerResult::AlreadyStarted),
+            _ => Ok(StartContainerResult::Started),
+        }
     }
 
     /// ---
@@ -363,7 +385,8 @@ impl Docker {
     ///
     /// # Returns
     ///
-    ///  - unit type `()`, wrapped in a Future.
+    ///  - a [Stop Container Result](StopContainerResult), wrapped in a Future. Distinguishes
+    ///    whether the container was stopped by this request or was already stopped.
     ///
     /// # Examples
     ///
@@ -382,7 +405,7 @@ impl Docker {
         &self,
         container_name: &str,
         options: Option<crate::query_parameters::StopContainerOptions>,
-    ) -> Result<(), Error> {
+    ) -> Result<StopContainerResult, Error> {
         let url = format!("/containers/{container_name}/stop");
 
         let req = self.build_request(
@@ -392,7 +415,10 @@ impl Docker {
             Ok(BodyType::Left(Full::new(Bytes::new()))),
         );
 
-        self.process_into_unit(req).await
+        match self.process_into_status(req).await? {
+            StatusCode::NOT_MODIFIED => Ok(StopContainerResult::AlreadyStopped),
+            _ => Ok(StopContainerResult::Stopped),
+        }
     }
 
     /// ---

--- a/src/docker.rs
+++ b/src/docker.rs
@@ -1603,6 +1603,14 @@ impl Docker {
         }
     }
 
+    pub(crate) fn process_into_status(
+        &self,
+        req: Result<Request<BodyType>, Error>,
+    ) -> impl Future<Output = Result<StatusCode, Error>> {
+        let fut = self.process_request(req);
+        async move { Ok(fut.await?.status()) }
+    }
+
     pub(crate) fn process_into_body(
         &self,
         req: Result<Request<BodyType>, Error>,

--- a/tests/container_test.rs
+++ b/tests/container_test.rs
@@ -1,6 +1,6 @@
 #![type_length_limit = "2097152"]
 
-use bollard::container::AttachContainerResults;
+use bollard::container::{AttachContainerResults, StartContainerResult, StopContainerResult};
 #[cfg(feature = "test_checkpoint")]
 use bollard::container::{
     CreateCheckpointOptions, DeleteCheckpointOptions, ListCheckpointsOptions,
@@ -345,6 +345,34 @@ async fn kill_container_test(docker: Docker) -> Result<(), Error> {
     let _ = &docker
         .remove_container("integration_test_kill_container", None)
         .await?;
+
+    Ok(())
+}
+
+async fn start_stop_container_test(docker: Docker) -> Result<(), Error> {
+    create_daemon(&docker, "integration_test_start_stop_container").await?;
+
+    let start_result = &docker
+        .start_container("integration_test_start_stop_container", None)
+        .await?;
+    assert_eq!(start_result, &StartContainerResult::AlreadyStarted);
+
+    let stop_result = &docker
+        .stop_container("integration_test_start_stop_container", None)
+        .await?;
+    assert_eq!(stop_result, &StopContainerResult::Stopped);
+
+    let stop_result = &docker
+        .stop_container("integration_test_start_stop_container", None)
+        .await?;
+    assert_eq!(stop_result, &StopContainerResult::AlreadyStopped);
+
+    let start_result = &docker
+        .start_container("integration_test_start_stop_container", None)
+        .await?;
+    assert_eq!(start_result, &StartContainerResult::Started);
+
+    kill_container(&docker, "integration_test_start_stop_container").await?;
 
     Ok(())
 }
@@ -953,6 +981,11 @@ fn integration_test_stats() {
 #[test]
 fn integration_test_kill_container() {
     connect_to_docker_and_run!(kill_container_test);
+}
+
+#[test]
+fn integration_test_start_stop_container() {
+    connect_to_docker_and_run!(start_stop_container_test);
 }
 
 // note: resource updating isn't supported on Windows


### PR DESCRIPTION
Fixes #734

## Problem

The Docker daemon returns `304 Not Modified` from `POST /containers/{id}/start` and `POST /containers/{id}/stop` when the container was already in the requested state, but `start_container` / `stop_container` discarded the status code and returned `Ok(())` for both 204 and 304. This made it impossible for callers to reliably tell whether a container was actually stopped by their request or had already exited on its own, the only alternative being racey heuristics over inspect data.

## Change

As agreed in the issue discussion, the return types of the two affected methods change to new enums that expose the distinction:

- `start_container` now returns `Result<StartContainerResult, Error>`, with variants `Started` (204) and `AlreadyStarted` (304)
- `stop_container` now returns `Result<StopContainerResult, Error>`, with variants `Stopped` (204) and `AlreadyStopped` (304)

Internally this adds a small `process_into_status` helper alongside the existing `process_into_*` family that resolves to the response's `StatusCode`.

Also added an integration test (`integration_test_start_stop_container`) covering all four variants: starting an already-running container, stopping it, stopping it again, and restarting it.

## Notes

- This is technically a semver-breaking change to the two method signatures, though existing callers that discard the result (`.await?;`) are unaffected at the call site. The version number isn't bumped in this PR, though this is something the maintainer should be aware of when performing the next release.
- `cargo check --all-targets --all-features`, `cargo test --lib`, doc tests, `cargo fmt --check`, and clippy all pass; no other internal call sites needed changes.