### PR TITLE
buildkit: centralise solve lifecycle cleanup

### DIFF
--- a/src/grpc/driver/buildkitd.rs
+++ b/src/grpc/driver/buildkitd.rs
@@ -54,7 +54,9 @@ impl Driver for BuildkitDaemon {
 struct BuildkitDaemonTearDownHandler {}
 
 impl DriverTearDownHandler for BuildkitDaemonTearDownHandler {
-    fn tear_down(&self) -> Pin<Box<dyn futures_core::Future<Output = Result<(), GrpcError>>>> {
+    fn tear_down(
+        &self,
+    ) -> Pin<Box<dyn futures_core::Future<Output = Result<(), GrpcError>> + Send + 'static>> {
         Box::pin(futures_util::future::ok(()))
     }
 }

--- a/src/grpc/driver/channel.rs
+++ b/src/grpc/driver/channel.rs
@@ -99,9 +99,10 @@ impl super::Driver for BuildkitChannel {
 struct NoOpDriverTearDownHandler;
 
 impl super::DriverTearDownHandler for NoOpDriverTearDownHandler {
-    fn tear_down<'a>(
-        &'a self,
-    ) -> Pin<Box<dyn Future<Output = Result<(), crate::grpc::error::GrpcError>> + 'a>> {
+    fn tear_down(
+        &self,
+    ) -> Pin<Box<dyn Future<Output = Result<(), crate::grpc::error::GrpcError>> + Send + 'static>>
+    {
         Box::pin(async { Ok(()) })
     }
 }

--- a/src/grpc/driver/docker_container.rs
+++ b/src/grpc/driver/docker_container.rs
@@ -20,7 +20,7 @@ use http::{
     request::Builder,
     Method,
 };
-use log::{debug, info};
+use log::{debug, info, warn};
 use tonic::transport::Endpoint;
 use tonic::{codegen::InterceptedService, transport::Channel};
 use tower_service::Service;
@@ -158,26 +158,29 @@ impl DockerContainerBuilder {
             self.network("host");
         }
 
-        if let Err(crate::errors::Error::DockerResponseServerError {
-            status_code: 404,
-            message: _,
-        }) = self
-            .inner
-            .docker
-            .inspect_container(
-                &self.inner.name,
-                None::<bollard_stubs::query_parameters::InspectContainerOptions>,
-            )
-            .await
-        {
-            self.inner.create().await?
-        };
+        let tear_down_handler = Box::new(DockerContainerTearDownHandler {
+            name: String::from(&self.inner.name),
+            docker: Docker::clone(&self.inner.docker),
+        });
+        let mut tear_down_guard = super::TearDownGuard::new(tear_down_handler);
+
+        self.inner.create().await?;
 
         debug!("starting container {}", &self.inner.name);
 
-        self.inner.start().await?;
-        self.inner.wait().await?;
+        let start_result: Result<(), GrpcError> = async {
+            self.inner.start().await?;
+            self.inner.wait().await
+        }
+        .await;
+        if let Err(error) = start_result {
+            if let Err(teardown_error) = tear_down_guard.tear_down().await {
+                warn!("failed to tear down BuildKit container after bootstrap failure: {teardown_error}");
+            }
+            return Err(error);
+        }
 
+        tear_down_guard.disarm();
         Ok(self.inner)
     }
 
@@ -354,10 +357,6 @@ impl DockerContainer {
             .create_container(Some(container_options), container_config)
             .await?;
 
-        self.start().await?;
-
-        self.wait().await?;
-
         Ok(())
     }
 
@@ -432,11 +431,13 @@ struct DockerContainerTearDownHandler {
 }
 
 impl super::DriverTearDownHandler for DockerContainerTearDownHandler {
-    fn tear_down<'a>(&'a self) -> Pin<Box<dyn Future<Output = Result<(), GrpcError>> + 'a>> {
-        Box::pin(async {
-            self.docker
+    fn tear_down(&self) -> Pin<Box<dyn Future<Output = Result<(), GrpcError>> + Send + 'static>> {
+        let docker = Docker::clone(&self.docker);
+        let name = String::clone(&self.name);
+        Box::pin(async move {
+            docker
                 .kill_container(
-                    &self.name,
+                    &name,
                     None::<bollard_stubs::query_parameters::KillContainerOptions>,
                 )
                 .map_err(GrpcError::from)
@@ -448,7 +449,9 @@ impl super::DriverTearDownHandler for DockerContainerTearDownHandler {
 struct NoopTearDownHandler {}
 
 impl super::DriverTearDownHandler for NoopTearDownHandler {
-    fn tear_down(&self) -> Pin<Box<dyn futures_core::Future<Output = Result<(), GrpcError>>>> {
+    fn tear_down(
+        &self,
+    ) -> Pin<Box<dyn futures_core::Future<Output = Result<(), GrpcError>> + Send + 'static>> {
         Box::pin(futures_util::future::ok(()))
     }
 }

--- a/src/grpc/driver/moby.rs
+++ b/src/grpc/driver/moby.rs
@@ -125,7 +125,9 @@ impl Driver for Moby {
 struct MobyTearDownHandler {}
 
 impl super::DriverTearDownHandler for MobyTearDownHandler {
-    fn tear_down(&self) -> Pin<Box<dyn futures_core::Future<Output = Result<(), GrpcError>>>> {
+    fn tear_down(
+        &self,
+    ) -> Pin<Box<dyn futures_core::Future<Output = Result<(), GrpcError>> + Send + 'static>> {
         Box::pin(futures_util::future::ok(()))
     }
 }

--- a/src/grpc/driver/mod.rs
+++ b/src/grpc/driver/mod.rs
@@ -1,4 +1,5 @@
-use std::{collections::HashMap, path::PathBuf};
+use std::time::Duration;
+use std::{collections::HashMap, path::PathBuf, sync::Arc};
 
 use bollard_buildkit_proto::moby::{
     buildkit::{
@@ -9,7 +10,7 @@ use bollard_buildkit_proto::moby::{
     sshforward::v1::ssh_server::SshServer,
     upload::v1::upload_server::UploadServer,
 };
-use log::debug;
+use log::{debug, warn};
 // use tonic::service::Interceptor;
 use tonic::{
     codegen::InterceptedService, metadata::MetadataValue, service::Interceptor, transport::Channel,
@@ -38,6 +39,7 @@ const DEFAULT_MAX_SEND_MSG_SIZE: usize = 16 << 20;
 /// See https://github.com/containerd/containerd/blob/997f813b5cfdd7e120ee60d93b83ac6babbcfb1a/defaults/defaults.go#L20-L22
 /// Used by buildkit [here](https://github.com/moby/buildkit/blob/082e8d8cf3267ddd3a28de1e258eaec20ebe3bbe/cmd/buildkitd/main.go#L309)
 const DEFAULT_MAX_RECV_MSG_SIZE: usize = 16 << 20;
+const TEAR_DOWN_TIMEOUT: Duration = Duration::from_secs(30);
 
 /// The Buildkit Daemon driver opens a GRPC connection by connecting to a Buildkit Daemon over a TCP connection.
 pub mod buildkitd;
@@ -59,10 +61,80 @@ pub(crate) trait Driver {
     fn get_tear_down_handler(&self) -> Box<dyn DriverTearDownHandler>;
 }
 
-pub(crate) trait DriverTearDownHandler {
-    fn tear_down<'a>(
-        &'a self,
-    ) -> std::pin::Pin<Box<dyn futures_core::Future<Output = Result<(), GrpcError>> + 'a>>;
+pub(crate) trait DriverTearDownHandler: Send + Sync {
+    fn tear_down(
+        &self,
+    ) -> std::pin::Pin<Box<dyn futures_core::Future<Output = Result<(), GrpcError>> + Send + 'static>>;
+}
+
+struct TearDownGuard {
+    handler: Arc<dyn DriverTearDownHandler>,
+    runtime: tokio::runtime::Handle,
+    task: Option<tokio::task::JoinHandle<Result<(), GrpcError>>>,
+    armed: bool,
+    started: bool,
+}
+
+impl TearDownGuard {
+    fn new(handler: Box<dyn DriverTearDownHandler>) -> Self {
+        Self {
+            handler: Arc::from(handler),
+            runtime: tokio::runtime::Handle::current(),
+            task: None,
+            armed: true,
+            started: false,
+        }
+    }
+
+    fn disarm(&mut self) {
+        self.armed = false;
+    }
+
+    fn start(&mut self) {
+        if self.started {
+            return;
+        }
+
+        self.started = true;
+        let handler = Arc::clone(&self.handler);
+        self.task = Some(self.runtime.spawn(run_tear_down(handler)));
+    }
+
+    async fn tear_down(&mut self) -> Result<(), GrpcError> {
+        self.start();
+        self.task
+            .take()
+            .ok_or_else(|| GrpcError::TearDownTaskUnavailable)?
+            .await
+            .map_err(|error| tonic::Status::internal(format!("teardown task failed: {error}")))?
+    }
+}
+
+async fn run_tear_down(handler: Arc<dyn DriverTearDownHandler>) -> Result<(), GrpcError> {
+    tokio::time::timeout(TEAR_DOWN_TIMEOUT, handler.tear_down())
+        .await
+        .map_err(|_| {
+            GrpcError::from(tonic::Status::deadline_exceeded(
+                "driver teardown exceeded its timeout",
+            ))
+        })?
+}
+
+impl Drop for TearDownGuard {
+    fn drop(&mut self) {
+        if !self.armed || self.started {
+            // Dropping a JoinHandle detaches the task, allowing cleanup to finish after the
+            // solve future is cancelled or unwinds due to a panic.
+            return;
+        }
+
+        let handler = Arc::clone(&self.handler);
+        self.runtime.spawn(async move {
+            if let Err(error) = run_tear_down(handler).await {
+                warn!("failed to tear down BuildKit driver after cancellation: {error}");
+            }
+        });
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -260,13 +332,16 @@ async fn execute_solve<D: Driver>(
     services: Vec<GrpcServer>,
     tear_down_handler: Box<dyn DriverTearDownHandler>,
 ) -> Result<(), GrpcError> {
+    let mut tear_down_guard = TearDownGuard::new(tear_down_handler);
     let mut control_client = match driver.grpc_handle(session_id, services).await {
         Ok(client) => client
             .max_decoding_message_size(DEFAULT_MAX_RECV_MSG_SIZE)
             .max_encoding_message_size(DEFAULT_MAX_SEND_MSG_SIZE),
         Err(error) => {
             // A driver may have created resources before gRPC setup failed.
-            let _ = tear_down_handler.tear_down().await;
+            if let Err(teardown_error) = tear_down_guard.tear_down().await {
+                warn!("failed to tear down BuildKit driver after gRPC setup failure: {teardown_error}");
+            }
             return Err(error);
         }
     };
@@ -275,11 +350,16 @@ async fn execute_solve<D: Driver>(
     let solve_result = control_client.solve(request).await.map_err(GrpcError::from);
     debug!("solve res: {:#?}", solve_result);
 
-    let tear_down_result = tear_down_handler.tear_down().await;
+    let tear_down_result = tear_down_guard.tear_down().await;
 
     // Preserve the original operation failure when cleanup also fails.
     match solve_result {
-        Err(error) => Err(error),
+        Err(error) => {
+            if let Err(teardown_error) = tear_down_result {
+                warn!("failed to tear down BuildKit driver after solve failure: {teardown_error}");
+            }
+            Err(error)
+        }
         Ok(_) => tear_down_result,
     }
 }
@@ -302,7 +382,7 @@ mod tests {
         SolveResponse, StatusRequest, StatusResponse, UpdateBuildHistoryRequest,
         UpdateBuildHistoryResponse, UsageRecord,
     };
-    use futures_util::stream::Empty;
+    use futures_util::{stream::Empty, FutureExt};
     use tokio::{net::TcpListener, sync::oneshot};
     use tokio_stream::wrappers::TcpListenerStream;
     use tonic::{
@@ -315,6 +395,8 @@ mod tests {
     struct TestDriver {
         endpoint: Endpoint,
         setup_error: Option<Status>,
+        setup_pending: bool,
+        setup_panic: bool,
     }
 
     impl Driver for TestDriver {
@@ -326,6 +408,12 @@ mod tests {
         {
             if let Some(error) = self.setup_error {
                 return Err(error.into());
+            }
+            if self.setup_pending {
+                std::future::pending::<()>().await;
+            }
+            if self.setup_panic {
+                panic!("grpc setup panicked");
             }
 
             let interceptor = DriverInterceptor {
@@ -349,9 +437,10 @@ mod tests {
     }
 
     impl DriverTearDownHandler for TestTearDown {
-        fn tear_down<'a>(
-            &'a self,
-        ) -> Pin<Box<dyn futures_core::Future<Output = Result<(), GrpcError>> + 'a>> {
+        fn tear_down(
+            &self,
+        ) -> Pin<Box<dyn futures_core::Future<Output = Result<(), GrpcError>> + Send + 'static>>
+        {
             self.calls.fetch_add(1, Ordering::SeqCst);
             let result = self
                 .error
@@ -474,6 +563,8 @@ mod tests {
         TestDriver {
             endpoint: Endpoint::from_shared(format!("http://{address}")).unwrap(),
             setup_error: None,
+            setup_pending: false,
+            setup_panic: false,
         }
     }
 
@@ -481,6 +572,26 @@ mod tests {
         TestDriver {
             endpoint: Endpoint::from_static("http://127.0.0.1:1"),
             setup_error: Some(Status::internal("grpc setup failed")),
+            setup_pending: false,
+            setup_panic: false,
+        }
+    }
+
+    fn pending_test_driver() -> TestDriver {
+        TestDriver {
+            endpoint: Endpoint::from_static("http://127.0.0.1:1"),
+            setup_error: None,
+            setup_pending: true,
+            setup_panic: false,
+        }
+    }
+
+    fn panicking_test_driver() -> TestDriver {
+        TestDriver {
+            endpoint: Endpoint::from_static("http://127.0.0.1:1"),
+            setup_error: None,
+            setup_pending: false,
+            setup_panic: true,
         }
     }
 
@@ -563,6 +674,48 @@ mod tests {
         stop_test_server(shutdown_sender, handle).await;
 
         assert!(result.is_ok());
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn execute_solve_tears_down_after_cancellation() {
+        let calls = Arc::new(AtomicUsize::new(0));
+        let task = tokio::spawn(execute_solve(
+            pending_test_driver(),
+            "session",
+            SolveRequest::default(),
+            Vec::new(),
+            teardown(calls.clone(), None),
+        ));
+
+        tokio::task::yield_now().await;
+        task.abort();
+        let _ = task.await;
+        for _ in 0..10 {
+            tokio::task::yield_now().await;
+        }
+
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn execute_solve_tears_down_after_panic() {
+        let calls = Arc::new(AtomicUsize::new(0));
+        let result = std::panic::AssertUnwindSafe(execute_solve(
+            panicking_test_driver(),
+            "session",
+            SolveRequest::default(),
+            Vec::new(),
+            teardown(calls.clone(), None),
+        ))
+        .catch_unwind()
+        .await;
+
+        assert!(result.is_err());
+        for _ in 0..10 {
+            tokio::task::yield_now().await;
+        }
+
         assert_eq!(calls.load(Ordering::SeqCst), 1);
     }
 }

--- a/src/grpc/driver/mod.rs
+++ b/src/grpc/driver/mod.rs
@@ -216,11 +216,6 @@ pub(crate) async fn solve(
     }
 
     let tear_down_handler = driver.get_tear_down_handler();
-    let mut control_client = driver
-        .grpc_handle(&session_id, services)
-        .await?
-        .max_decoding_message_size(DEFAULT_MAX_RECV_MSG_SIZE)
-        .max_encoding_message_size(DEFAULT_MAX_SEND_MSG_SIZE);
 
     let id = build_ref.unwrap_or_default();
 
@@ -240,7 +235,7 @@ pub(crate) async fn solve(
         frontend: String::from("dockerfile.v0"),
         frontend_attrs,
         frontend_inputs: HashMap::new(),
-        session: session_id,
+        session: session_id.clone(),
         exporters: vec![],
         internal: false,
         source_policy: None,
@@ -248,15 +243,326 @@ pub(crate) async fn solve(
         source_policy_session: String::new(),
     };
 
-    debug!("sending solve request: {:#?}", solve_request);
-    let res = control_client.solve(solve_request).await;
-    debug!("solve res: {:#?}", res);
+    execute_solve(
+        driver,
+        &session_id,
+        solve_request,
+        services,
+        tear_down_handler,
+    )
+    .await
+}
 
-    // clean up
+async fn execute_solve<D: Driver>(
+    driver: D,
+    session_id: &str,
+    request: SolveRequest,
+    services: Vec<GrpcServer>,
+    tear_down_handler: Box<dyn DriverTearDownHandler>,
+) -> Result<(), GrpcError> {
+    let mut control_client = match driver.grpc_handle(session_id, services).await {
+        Ok(client) => client
+            .max_decoding_message_size(DEFAULT_MAX_RECV_MSG_SIZE)
+            .max_encoding_message_size(DEFAULT_MAX_SEND_MSG_SIZE),
+        Err(error) => {
+            // A driver may have created resources before gRPC setup failed.
+            let _ = tear_down_handler.tear_down().await;
+            return Err(error);
+        }
+    };
 
-    tear_down_handler.tear_down().await?;
-    // tear_down?;
-    res?;
+    debug!("sending solve request: {:#?}", request);
+    let solve_result = control_client.solve(request).await.map_err(GrpcError::from);
+    debug!("solve res: {:#?}", solve_result);
 
-    Ok(())
+    let tear_down_result = tear_down_handler.tear_down().await;
+
+    // Preserve the original operation failure when cleanup also fails.
+    match solve_result {
+        Err(error) => Err(error),
+        Ok(_) => tear_down_result,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        net::SocketAddr,
+        pin::Pin,
+        sync::{
+            atomic::{AtomicUsize, Ordering},
+            Arc,
+        },
+    };
+
+    use bollard_buildkit_proto::moby::buildkit::v1::{
+        control_server::{Control, ControlServer},
+        BuildHistoryEvent, BuildHistoryRequest, BytesMessage, DiskUsageRequest, DiskUsageResponse,
+        InfoRequest, InfoResponse, ListWorkersRequest, ListWorkersResponse, PruneRequest,
+        SolveResponse, StatusRequest, StatusResponse, UpdateBuildHistoryRequest,
+        UpdateBuildHistoryResponse, UsageRecord,
+    };
+    use futures_util::stream::Empty;
+    use tokio::{net::TcpListener, sync::oneshot};
+    use tokio_stream::wrappers::TcpListenerStream;
+    use tonic::{
+        transport::{Channel, Endpoint, Server},
+        Request, Response, Status,
+    };
+
+    use super::*;
+
+    struct TestDriver {
+        endpoint: Endpoint,
+        setup_error: Option<Status>,
+    }
+
+    impl Driver for TestDriver {
+        async fn grpc_handle(
+            self,
+            session_id: &str,
+            _services: Vec<GrpcServer>,
+        ) -> Result<ControlClient<InterceptedService<Channel, DriverInterceptor>>, GrpcError>
+        {
+            if let Some(error) = self.setup_error {
+                return Err(error.into());
+            }
+
+            let interceptor = DriverInterceptor {
+                session_id: String::from(session_id),
+                metadata_grpc_method: Vec::new(),
+            };
+
+            let channel = self.endpoint.connect().await?;
+            Ok(ControlClient::with_interceptor(channel, interceptor))
+        }
+
+        fn get_tear_down_handler(&self) -> Box<dyn DriverTearDownHandler> {
+            Box::new(TestTearDown::default())
+        }
+    }
+
+    #[derive(Default)]
+    struct TestTearDown {
+        calls: Arc<AtomicUsize>,
+        error: Option<Status>,
+    }
+
+    impl DriverTearDownHandler for TestTearDown {
+        fn tear_down<'a>(
+            &'a self,
+        ) -> Pin<Box<dyn futures_core::Future<Output = Result<(), GrpcError>> + 'a>> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            let result = self
+                .error
+                .clone()
+                .map_or(Ok(()), |error| Err(GrpcError::from(error)));
+            Box::pin(std::future::ready(result))
+        }
+    }
+
+    struct TestControl {
+        solve_error: Option<Status>,
+    }
+
+    type EmptyUsageRecords = Empty<Result<UsageRecord, Status>>;
+    type EmptyStatusResponses = Empty<Result<StatusResponse, Status>>;
+    type EmptyBytesMessages = Empty<Result<BytesMessage, Status>>;
+    type EmptyBuildHistoryEvents = Empty<Result<BuildHistoryEvent, Status>>;
+
+    #[tonic::async_trait]
+    impl Control for TestControl {
+        type PruneStream = EmptyUsageRecords;
+        type StatusStream = EmptyStatusResponses;
+        type SessionStream = EmptyBytesMessages;
+        type ListenBuildHistoryStream = EmptyBuildHistoryEvents;
+
+        async fn disk_usage(
+            &self,
+            _request: Request<DiskUsageRequest>,
+        ) -> Result<Response<DiskUsageResponse>, Status> {
+            Err(Status::unimplemented("test service"))
+        }
+
+        async fn prune(
+            &self,
+            _request: Request<PruneRequest>,
+        ) -> Result<Response<Self::PruneStream>, Status> {
+            Err(Status::unimplemented("test service"))
+        }
+
+        async fn solve(
+            &self,
+            _request: Request<SolveRequest>,
+        ) -> Result<Response<SolveResponse>, Status> {
+            match &self.solve_error {
+                Some(error) => Err(error.clone()),
+                None => Ok(Response::new(SolveResponse::default())),
+            }
+        }
+
+        async fn status(
+            &self,
+            _request: Request<StatusRequest>,
+        ) -> Result<Response<Self::StatusStream>, Status> {
+            Err(Status::unimplemented("test service"))
+        }
+
+        async fn session(
+            &self,
+            _request: Request<tonic::Streaming<BytesMessage>>,
+        ) -> Result<Response<Self::SessionStream>, Status> {
+            Err(Status::unimplemented("test service"))
+        }
+
+        async fn list_workers(
+            &self,
+            _request: Request<ListWorkersRequest>,
+        ) -> Result<Response<ListWorkersResponse>, Status> {
+            Err(Status::unimplemented("test service"))
+        }
+
+        async fn info(
+            &self,
+            _request: Request<InfoRequest>,
+        ) -> Result<Response<InfoResponse>, Status> {
+            Err(Status::unimplemented("test service"))
+        }
+
+        async fn listen_build_history(
+            &self,
+            _request: Request<BuildHistoryRequest>,
+        ) -> Result<Response<Self::ListenBuildHistoryStream>, Status> {
+            Err(Status::unimplemented("test service"))
+        }
+
+        async fn update_build_history(
+            &self,
+            _request: Request<UpdateBuildHistoryRequest>,
+        ) -> Result<Response<UpdateBuildHistoryResponse>, Status> {
+            Err(Status::unimplemented("test service"))
+        }
+    }
+
+    async fn start_test_server(
+        solve_error: Option<Status>,
+    ) -> (SocketAddr, oneshot::Sender<()>, tokio::task::JoinHandle<()>) {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let (shutdown_sender, shutdown_receiver) = oneshot::channel();
+        let server = Server::builder()
+            .add_service(ControlServer::new(TestControl { solve_error }))
+            .serve_with_incoming_shutdown(TcpListenerStream::new(listener), async move {
+                let _ = shutdown_receiver.await;
+            });
+        let handle = tokio::spawn(async move {
+            server.await.unwrap();
+        });
+
+        (address, shutdown_sender, handle)
+    }
+
+    async fn stop_test_server(
+        shutdown_sender: oneshot::Sender<()>,
+        handle: tokio::task::JoinHandle<()>,
+    ) {
+        let _ = shutdown_sender.send(());
+        handle.await.unwrap();
+    }
+
+    fn test_driver(address: SocketAddr) -> TestDriver {
+        TestDriver {
+            endpoint: Endpoint::from_shared(format!("http://{address}")).unwrap(),
+            setup_error: None,
+        }
+    }
+
+    fn failing_test_driver() -> TestDriver {
+        TestDriver {
+            endpoint: Endpoint::from_static("http://127.0.0.1:1"),
+            setup_error: Some(Status::internal("grpc setup failed")),
+        }
+    }
+
+    fn teardown(calls: Arc<AtomicUsize>, error: Option<Status>) -> Box<dyn DriverTearDownHandler> {
+        Box::new(TestTearDown { calls, error })
+    }
+
+    fn status_code(result: Result<(), GrpcError>) -> tonic::Code {
+        match result {
+            Err(GrpcError::TonicStatus { err }) => err.code(),
+            other => panic!("expected tonic status error, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn execute_solve_tears_down_after_setup_failure() {
+        let calls = Arc::new(AtomicUsize::new(0));
+        let result = execute_solve(
+            failing_test_driver(),
+            "session",
+            SolveRequest::default(),
+            Vec::new(),
+            teardown(calls.clone(), Some(Status::aborted("teardown failed"))),
+        )
+        .await;
+
+        assert_eq!(status_code(result), tonic::Code::Internal);
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn execute_solve_preserves_solve_failure_over_teardown_failure() {
+        let (address, shutdown_sender, handle) =
+            start_test_server(Some(Status::not_found("solve failed"))).await;
+        let calls = Arc::new(AtomicUsize::new(0));
+        let result = execute_solve(
+            test_driver(address),
+            "session",
+            SolveRequest::default(),
+            Vec::new(),
+            teardown(calls.clone(), Some(Status::aborted("teardown failed"))),
+        )
+        .await;
+        stop_test_server(shutdown_sender, handle).await;
+
+        assert_eq!(status_code(result), tonic::Code::NotFound);
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn execute_solve_returns_teardown_failure_after_success() {
+        let (address, shutdown_sender, handle) = start_test_server(None).await;
+        let calls = Arc::new(AtomicUsize::new(0));
+        let result = execute_solve(
+            test_driver(address),
+            "session",
+            SolveRequest::default(),
+            Vec::new(),
+            teardown(calls.clone(), Some(Status::aborted("teardown failed"))),
+        )
+        .await;
+        stop_test_server(shutdown_sender, handle).await;
+
+        assert_eq!(status_code(result), tonic::Code::Aborted);
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn execute_solve_succeeds_and_tears_down_once() {
+        let (address, shutdown_sender, handle) = start_test_server(None).await;
+        let calls = Arc::new(AtomicUsize::new(0));
+        let result = execute_solve(
+            test_driver(address),
+            "session",
+            SolveRequest::default(),
+            Vec::new(),
+            teardown(calls.clone(), None),
+        )
+        .await;
+        stop_test_server(shutdown_sender, handle).await;
+
+        assert!(result.is_ok());
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+    }
 }

--- a/src/grpc/error.rs
+++ b/src/grpc/error.rs
@@ -5,6 +5,9 @@ use std::num::TryFromIntError;
 /// Errors related to the Grpc functionality
 #[derive(Debug, thiserror::Error)]
 pub enum GrpcError {
+    /// The driver teardown task was unavailable when cleanup was requested.
+    #[error("driver teardown task was unavailable")]
+    TearDownTaskUnavailable,
     /// Generic error emitted by the bollard codebase.
     #[error(transparent)]
     DockerError {


### PR DESCRIPTION
Use one lifecycle for solve setup, execution, and teardown. 
