### PR TITLE
buildkit: add persistent Docker-container lifecycle management

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,6 +68,16 @@ jobs:
       - setup_remote_docker
       - run: docker build -t bollard .
       - run: resources/dockerfiles/bin/run_integration_tests.sh --features buildkit,chrono --tests
+      - run:
+          name: Clean up Bollard BuildKit resources
+          command: |
+            for container in $(docker ps -aq --filter label=com.github.fussybeaver.bollard.buildkit.managed=true); do
+              docker rm -f "$container" || true
+            done
+            for volume in $(docker volume ls -q --filter label=com.github.fussybeaver.bollard.buildkit.managed=true); do
+              docker volume rm "$volume" || true
+            done
+          when: always
   test_chrono:
     docker:
       - image: docker:29.3

--- a/examples/build_buildkit_with_cache.rs
+++ b/examples/build_buildkit_with_cache.rs
@@ -1,4 +1,4 @@
-//! Builds a container with a bunch of extra options for testing
+//! Builds and pushes an image using a named persistent BuildKit builder.
 #![allow(unused_variables, unused_mut, unused_imports)]
 
 #[cfg(feature = "buildkit_providerless")]
@@ -70,8 +70,13 @@ async fn main() {
             ImageRegistryOutput::builder(&format!("{}/{}:latest", registry_addr, name)).consume();
 
         // let mut driver = bollard::grpc::driver::moby::Moby::new(&docker);
+        use bollard::grpc::driver::docker_container::DockerContainerLifecycle;
+
         let mut buildkit_builder =
             bollard::grpc::driver::docker_container::DockerContainerBuilder::new(&docker);
+        buildkit_builder
+            .name("bollard-buildkit-with-cache-example")
+            .lifecycle(DockerContainerLifecycle::Persistent);
         buildkit_builder.env("JAEGER_TRACE=localhost:6831");
         let driver = buildkit_builder.bootstrap().await.unwrap();
 
@@ -96,5 +101,9 @@ async fn main() {
         )
         .await
         .unwrap();
+
+        // Persistent builders retain their daemon and state volume until explicitly stopped or
+        // removed. Stop this example's daemon so rerunning it does not leave it active.
+        driver.stop().await.unwrap();
     }
 }

--- a/examples/build_buildkit_with_cache.rs
+++ b/examples/build_buildkit_with_cache.rs
@@ -87,7 +87,7 @@ async fn main() {
         creds_hsh.insert("localhost:5000", credentials);
 
         bollard::grpc::driver::Image::registry(
-            driver,
+            &driver,
             output,
             frontend_opts,
             load_input,

--- a/examples/export_oci_image.rs
+++ b/examples/export_oci_image.rs
@@ -61,7 +61,7 @@ async fn main() {
         creds_hsh.insert("localhost:5000", credentials);
 
         bollard::grpc::driver::Export::export(
-            driver,
+            &driver,
             bollard::grpc::driver::ImageExporterEnum::OCI(output),
             frontend_opts,
             load_input,

--- a/examples/export_oci_image.rs
+++ b/examples/export_oci_image.rs
@@ -1,11 +1,13 @@
-//! Builds a container with a bunch of extra options for testing
+//! Exports an image using an ephemeral BuildKit builder.
 #![allow(unused_variables, unused_mut)]
 
 #[tokio::main]
 async fn main() {
     #[cfg(feature = "buildkit_providerless")]
     {
-        use bollard::grpc::driver::docker_container::DockerContainerBuilder;
+        use bollard::grpc::driver::docker_container::{
+            DockerContainerBuilder, DockerContainerLifecycle,
+        };
         use bollard::Docker;
         use std::io::Write;
 
@@ -46,6 +48,9 @@ async fn main() {
         .dest(std::path::Path::new("/tmp/oci-image.tar"));
 
         let mut buildkit_builder = DockerContainerBuilder::new(&docker);
+        buildkit_builder
+            .name("bollard-oci-export-buildkit-example")
+            .lifecycle(DockerContainerLifecycle::RemoveAfterSolve { keep_state: false });
         buildkit_builder.env("JAEGER_TRACE=localhost:6831");
         let driver = buildkit_builder.bootstrap().await.unwrap();
 

--- a/src/grpc/driver/buildkitd.rs
+++ b/src/grpc/driver/buildkitd.rs
@@ -36,7 +36,7 @@ impl BuildkitDaemon {
 
 impl Driver for BuildkitDaemon {
     async fn grpc_handle(
-        self,
+        &self,
         session_id: &str,
         services: Vec<super::GrpcServer>,
     ) -> Result<ControlClient<InterceptedService<Channel, DriverInterceptor>>, GrpcError> {
@@ -63,7 +63,7 @@ impl DriverTearDownHandler for BuildkitDaemonTearDownHandler {
 
 impl super::Build for BuildkitDaemon {
     async fn docker_build(
-        self,
+        &self,
         name: &str,
         frontend_opts: ImageBuildFrontendOptions,
         load_input: ImageBuildLoadInput,
@@ -89,7 +89,7 @@ impl super::Build for BuildkitDaemon {
 
 impl super::Export for BuildkitDaemon {
     async fn export(
-        self,
+        &self,
         exporter_request: ImageExporterEnum,
         frontend_opts: ImageBuildFrontendOptions,
         load_input: ImageBuildLoadInput,
@@ -118,7 +118,7 @@ impl super::Export for BuildkitDaemon {
 
 impl super::Image for BuildkitDaemon {
     async fn registry(
-        self,
+        &self,
         output: ImageRegistryOutput,
         frontend_opts: ImageBuildFrontendOptions,
         load_input: ImageBuildLoadInput,

--- a/src/grpc/driver/buildkitd.rs
+++ b/src/grpc/driver/buildkitd.rs
@@ -46,8 +46,8 @@ impl Driver for BuildkitDaemon {
         channel.grpc_handle(session_id, services).await
     }
 
-    fn get_tear_down_handler(&self) -> Box<dyn DriverTearDownHandler> {
-        Box::new(BuildkitDaemonTearDownHandler {})
+    fn begin_solve(&self) -> Result<Box<dyn DriverTearDownHandler>, GrpcError> {
+        Ok(Box::new(BuildkitDaemonTearDownHandler {}))
     }
 }
 

--- a/src/grpc/driver/channel.rs
+++ b/src/grpc/driver/channel.rs
@@ -16,6 +16,8 @@ use crate::grpc::{
     HealthServerImpl,
 };
 
+use crate::grpc::error::GrpcError;
+
 use super::DriverInterceptor;
 
 const DUPLEX_BUF_SIZE: usize = 8 * 1024;
@@ -89,9 +91,9 @@ impl super::Driver for BuildkitChannel {
         Ok(control_client)
     }
 
-    fn get_tear_down_handler(&self) -> Box<dyn super::DriverTearDownHandler> {
+    fn begin_solve(&self) -> Result<Box<dyn super::DriverTearDownHandler>, GrpcError> {
         // Teardown is handled by the caller
-        Box::new(NoOpDriverTearDownHandler)
+        Ok(Box::new(NoOpDriverTearDownHandler))
     }
 }
 

--- a/src/grpc/driver/channel.rs
+++ b/src/grpc/driver/channel.rs
@@ -36,7 +36,7 @@ impl BuildkitChannel {
 
 impl super::Driver for BuildkitChannel {
     async fn grpc_handle(
-        self,
+        &self,
         session_id: &str,
         services: Vec<crate::grpc::GrpcServer>,
     ) -> Result<
@@ -52,7 +52,7 @@ impl super::Driver for BuildkitChannel {
             metadata_grpc_method,
         };
 
-        let mut control_client = ControlClient::with_interceptor(self.channel, interceptor);
+        let mut control_client = ControlClient::with_interceptor(self.channel.clone(), interceptor);
 
         let (asyncwriter, asyncreader) = tokio::io::duplex(DUPLEX_BUF_SIZE);
         let streamreader = ReaderStream::new(asyncreader);

--- a/src/grpc/driver/docker_container.rs
+++ b/src/grpc/driver/docker_container.rs
@@ -61,6 +61,10 @@ const DOCKER_STOP_TIMEOUT: Duration = Duration::from_secs(15);
 /// [`DockerContainerLifecycle::Persistent`] is the default. Persistent builders
 /// remain available until callers explicitly invoke [`DockerContainer::stop`]
 /// or [`DockerContainer::remove`].
+///
+/// Select a policy with [`DockerContainerBuilder::lifecycle`]. Use a stable
+/// [`DockerContainerBuilder::name`] when the builder and its state volume should
+/// be reused across bootstrap calls.
 #[non_exhaustive]
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub enum DockerContainerLifecycle {
@@ -178,6 +182,11 @@ impl Service<tonic::transport::Uri> for DockerContainerConnector {
 /// [`crate::grpc::driver::Export::export`] or [`crate::grpc::driver::Image::registry`]
 /// functionality.
 ///
+/// Builders use [`DockerContainerLifecycle::Persistent`] by default. This creates
+/// a privileged Docker container and a dedicated state volume that remain after
+/// solves until explicitly stopped or removed. Select an ephemeral lifecycle when
+/// the daemon should not remain available after a solve.
+///
 /// <div class="warning">
 ///  Warning: Buildkit features in Bollard are currently in Developer Preview and are intended strictly for feedback purposes only.
 /// </div>
@@ -185,14 +194,19 @@ impl Service<tonic::transport::Uri> for DockerContainerConnector {
 /// ## Examples
 ///
 /// ```rust,no_run
-/// use bollard::grpc::driver::docker_container::DockerContainerBuilder;
+/// use bollard::grpc::driver::docker_container::{
+///     DockerContainerBuilder, DockerContainerLifecycle,
+/// };
 /// use bollard::Docker;
 ///
 /// // Use a connection function
 /// // let docker = Docker::connect_...;
 /// # let docker = Docker::connect_with_local_defaults().unwrap();
 ///
-/// let builder = DockerContainerBuilder::new(&docker);
+/// let mut builder = DockerContainerBuilder::new(&docker);
+/// builder
+///     .name("project-builder")
+///     .lifecycle(DockerContainerLifecycle::Persistent);
 ///
 /// ```
 ///
@@ -422,7 +436,9 @@ impl DockerContainerBuilder {
 /// borrowed for multiple solves; each solve opens a fresh Docker exec transport and BuildKit
 /// session while retaining the daemon and state volume.
 ///
-///
+/// The lifecycle policy is selected on [`DockerContainerBuilder`] before bootstrap.
+/// Persistent builders are reused by stable name and must be explicitly stopped or
+/// removed when their resources are no longer needed.
 #[derive(Debug)]
 pub struct DockerContainer {
     name: String,

--- a/src/grpc/driver/docker_container.rs
+++ b/src/grpc/driver/docker_container.rs
@@ -3,7 +3,10 @@
 use std::{
     collections::HashMap,
     pin::Pin,
-    sync::{Arc, Mutex},
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc, Mutex,
+    },
     task::{Context, Poll},
     time::Duration,
 };
@@ -52,6 +55,7 @@ const LABEL_LIFECYCLE_SCHEMA: &str = "com.github.fussybeaver.bollard.buildkit.li
 const LABEL_BUILDER_NAME: &str = "com.github.fussybeaver.bollard.buildkit.builder-name";
 const LABEL_STATE_VOLUME: &str = "com.github.fussybeaver.bollard.buildkit.state-volume";
 const LABEL_RESOURCE_ID: &str = "com.github.fussybeaver.bollard.buildkit.resource-id";
+const LABEL_BOOTSTRAP_ATTEMPT: &str = "com.github.fussybeaver.bollard.buildkit.bootstrap-attempt";
 const LIFECYCLE_SCHEMA_VERSION: &str = "1";
 const DOCKER_STOP_GRACE_PERIOD: u64 = 10;
 
@@ -63,16 +67,20 @@ const DOCKER_STOP_GRACE_PERIOD: u64 = 10;
 ///
 /// Select a policy with [`DockerContainerBuilder::lifecycle`]. Use a stable
 /// [`DockerContainerBuilder::name`] when the builder and its state volume should
-/// be reused across bootstrap calls.
+/// be reused across bootstrap calls. A name is required for any lifecycle that
+/// retains a container or state volume after the solve.
 #[non_exhaustive]
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub enum DockerContainerLifecycle {
-    /// Keep the BuildKit container and its state volume after a solve.
+    /// Keep the BuildKit container and its state volume after a solve. The
+    /// driver can be reused for concurrent solves.
     #[default]
     Persistent,
-    /// Stop the BuildKit container after a solve while retaining its resources.
+    /// Stop the BuildKit container after its one admitted solve while retaining
+    /// its resources.
     StopAfterSolve,
-    /// Remove the BuildKit container after a solve, optionally retaining state.
+    /// Remove the BuildKit container after its one admitted solve, optionally
+    /// retaining state.
     RemoveAfterSolve {
         /// Keep the state volume when removing the container.
         keep_state: bool,
@@ -236,6 +244,8 @@ impl DockerContainerBuilder {
                 args: vec![],
                 lifecycle: DockerContainerLifecycle::Persistent,
                 resource_id: crate::grpc::new_id(),
+                name_explicit: false,
+                solve_started: AtomicBool::new(false),
             },
         }
     }
@@ -245,6 +255,15 @@ impl DockerContainerBuilder {
         debug!("booting buildkit");
 
         validate_container_name(&self.inner.name)?;
+
+        if !self.inner.name_explicit && lifecycle_requires_explicit_name(self.inner.lifecycle) {
+            return Err(tonic::Status::invalid_argument(
+                "an explicit Docker-container builder name is required for a lifecycle that retains resources",
+            )
+            .into());
+        }
+
+        let bootstrap_attempt = crate::grpc::new_id();
 
         if self.inner.net_mode.is_none() {
             self.network("host");
@@ -257,6 +276,7 @@ impl DockerContainerBuilder {
             name: String::from(&self.inner.name),
             volume_name: self.inner.state_volume_name(),
             resource_id: String::clone(&self.inner.resource_id),
+            bootstrap_attempt: bootstrap_attempt.clone(),
         }));
         let tear_down_handler = Box::new(BootstrapTearDownHandler {
             docker: Docker::clone(&self.inner.docker),
@@ -265,9 +285,13 @@ impl DockerContainerBuilder {
         let mut tear_down_guard = super::TearDownGuard::new(tear_down_handler);
 
         let host_config = self.inner.desired_host_config().await?;
-        let existing_container = inspect_container(&self.inner.docker, &self.inner.name).await?;
-        let existing_volume =
-            inspect_volume(&self.inner.docker, &self.inner.state_volume_name()).await?;
+        let state_volume_name = self.inner.state_volume_name();
+        let (existing_container, existing_volume) = tokio::try_join!(
+            inspect_container(&self.inner.docker, &self.inner.name),
+            inspect_volume(&self.inner.docker, &state_volume_name),
+        )?;
+
+        let mut should_start = false;
 
         match (existing_container, existing_volume) {
             (Some(container), Some(volume)) => {
@@ -279,7 +303,7 @@ impl DockerContainerBuilder {
                     Some(ContainerStateStatusEnum::RUNNING)
                     | Some(ContainerStateStatusEnum::RESTARTING) => {}
                     Some(ContainerStateStatusEnum::CREATED)
-                    | Some(ContainerStateStatusEnum::EXITED) => self.inner.start().await?,
+                    | Some(ContainerStateStatusEnum::EXITED) => should_start = true,
                     Some(status) => {
                         return Err(resource_conflict(
                             "container",
@@ -302,8 +326,9 @@ impl DockerContainerBuilder {
                     state.enabled = true;
                     state.container_created = true;
                     state.resource_id = String::clone(&self.inner.resource_id);
-                });
-                self.inner.create(&host_config).await?;
+                })?;
+                self.inner.create(&host_config, &bootstrap_attempt).await?;
+                should_start = true;
             }
             (Some(container), None) => {
                 if let Some(labels) = container
@@ -333,7 +358,7 @@ impl DockerContainerBuilder {
                 update_cleanup_state(&cleanup_state, |state| {
                     state.enabled = true;
                     state.volume_created = true;
-                });
+                })?;
                 let volume = self.inner.create_volume().await?;
                 let resource_id = compatible_volume(&self.inner, &volume)?;
                 if resource_id != self.inner.resource_id {
@@ -343,19 +368,16 @@ impl DockerContainerBuilder {
                         "volume was created concurrently with a different resource identity",
                     ));
                 }
-                update_cleanup_state(&cleanup_state, |state| state.container_created = true);
-                self.inner.create(&host_config).await?;
+                update_cleanup_state(&cleanup_state, |state| state.container_created = true)?;
+                self.inner.create(&host_config, &bootstrap_attempt).await?;
+                should_start = true;
             }
         }
 
         debug!("starting container {}", &self.inner.name);
 
         let start_result: Result<(), GrpcError> = async {
-            if !matches!(
-                self.inner.state().await?,
-                Some(ContainerStateStatusEnum::RUNNING)
-                    | Some(ContainerStateStatusEnum::RESTARTING)
-            ) {
+            if should_start {
                 self.inner.start().await?;
             }
             self.inner.wait().await
@@ -422,10 +444,12 @@ impl DockerContainerBuilder {
 
     /// Set the stable name used for the BuildKit container and state volume.
     ///
-    /// The name is validated when [`Self::bootstrap`] is called. If this method
-    /// is not used, a unique name is generated automatically.
+    /// The name is validated when [`Self::bootstrap`] is called. An explicit name
+    /// is required when the selected lifecycle retains the container or volume.
+    /// A generated name is available only for fully ephemeral builders.
     pub fn name(&mut self, name: &str) -> &mut DockerContainerBuilder {
         self.inner.name = String::from(name);
+        self.inner.name_explicit = true;
         self
     }
 
@@ -439,6 +463,13 @@ impl DockerContainerBuilder {
         self.inner.lifecycle = lifecycle;
         self
     }
+}
+
+fn lifecycle_requires_explicit_name(lifecycle: DockerContainerLifecycle) -> bool {
+    !matches!(
+        lifecycle,
+        DockerContainerLifecycle::RemoveAfterSolve { keep_state: false }
+    )
 }
 
 /// DockerContainer plumbing to communicate with `Buildkit` using an execution pipe.
@@ -463,6 +494,8 @@ pub struct DockerContainer {
     args: Vec<String>,
     lifecycle: DockerContainerLifecycle,
     resource_id: String,
+    name_explicit: bool,
+    solve_started: AtomicBool,
 }
 
 impl super::Driver for DockerContainer {
@@ -483,32 +516,48 @@ impl super::Driver for DockerContainer {
         channel.grpc_handle(session_id, services).await
     }
 
-    fn get_tear_down_handler(&self) -> Box<dyn super::DriverTearDownHandler> {
+    fn begin_solve(&self) -> Result<Box<dyn super::DriverTearDownHandler>, GrpcError> {
         match self.lifecycle {
-            DockerContainerLifecycle::Persistent => Box::new(NoopTearDownHandler {}),
-            DockerContainerLifecycle::StopAfterSolve => Box::new(DockerContainerTearDownHandler {
-                name: String::from(&self.name),
-                volume_name: self.state_volume_name(),
-                resource_id: String::clone(&self.resource_id),
-                expected_labels: self.ownership_labels(),
-                docker: Docker::clone(&self.docker),
-                operation: DockerContainerTearDownOperation::Stop,
-            }),
-            DockerContainerLifecycle::RemoveAfterSolve { keep_state } => {
-                Box::new(DockerContainerTearDownHandler {
+            DockerContainerLifecycle::Persistent => Ok(Box::new(NoopTearDownHandler {})),
+            DockerContainerLifecycle::StopAfterSolve => {
+                self.admit_ephemeral_solve(Box::new(DockerContainerTearDownHandler {
+                    name: String::from(&self.name),
+                    volume_name: self.state_volume_name(),
+                    resource_id: String::clone(&self.resource_id),
+                    expected_labels: self.ownership_labels(),
+                    docker: Docker::clone(&self.docker),
+                    operation: DockerContainerTearDownOperation::Stop,
+                }))
+            }
+            DockerContainerLifecycle::RemoveAfterSolve { keep_state } => self
+                .admit_ephemeral_solve(Box::new(DockerContainerTearDownHandler {
                     name: String::from(&self.name),
                     volume_name: self.state_volume_name(),
                     resource_id: String::clone(&self.resource_id),
                     expected_labels: self.ownership_labels(),
                     docker: Docker::clone(&self.docker),
                     operation: DockerContainerTearDownOperation::Remove { keep_state },
-                })
-            }
+                })),
         }
     }
 }
 
 impl DockerContainer {
+    fn admit_ephemeral_solve(
+        &self,
+        handler: Box<dyn super::DriverTearDownHandler>,
+    ) -> Result<Box<dyn super::DriverTearDownHandler>, GrpcError> {
+        self.solve_started
+            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+            .map(|_| handler)
+            .map_err(|_| {
+                tonic::Status::failed_precondition(
+                    "this Docker-container driver has an ephemeral one-shot lifecycle and has already admitted a solve",
+                )
+                .into()
+            })
+    }
+
     /// Identifies the docker container name that runs `Buildkit`. This should be unique if you
     /// intend to run multiple instances building in parallel on the same host.
     pub fn name(&self) -> &str {
@@ -558,7 +607,11 @@ impl DockerContainer {
     }
 
     fn ownership_labels(&self) -> HashMap<String, String> {
-        HashMap::from([
+        self.ownership_labels_with_attempt("")
+    }
+
+    fn ownership_labels_with_attempt(&self, bootstrap_attempt: &str) -> HashMap<String, String> {
+        let mut labels = HashMap::from([
             (String::from(LABEL_MANAGED), String::from("true")),
             (String::from(LABEL_DRIVER), String::from("docker-container")),
             (
@@ -568,7 +621,14 @@ impl DockerContainer {
             (String::from(LABEL_BUILDER_NAME), self.name.clone()),
             (String::from(LABEL_STATE_VOLUME), self.state_volume_name()),
             (String::from(LABEL_RESOURCE_ID), self.resource_id.clone()),
-        ])
+        ]);
+        if !bootstrap_attempt.is_empty() {
+            labels.insert(
+                String::from(LABEL_BOOTSTRAP_ATTEMPT),
+                String::from(bootstrap_attempt),
+            );
+        }
+        labels
     }
 
     fn restart_policy(&self) -> Option<RestartPolicy> {
@@ -656,7 +716,11 @@ impl DockerContainer {
         Ok(volume)
     }
 
-    async fn create(&self, host_config: &HostConfig) -> Result<(), GrpcError> {
+    async fn create(
+        &self,
+        host_config: &HostConfig,
+        bootstrap_attempt: &str,
+    ) -> Result<(), GrpcError> {
         let image_name = if let Some(image) = &self.image {
             image
         } else {
@@ -694,7 +758,7 @@ impl DockerContainer {
             env: Some(Vec::clone(&self.env)),
             host_config: Some(host_config.clone()),
             cmd: Some(Vec::clone(&self.args)),
-            labels: Some(self.ownership_labels()),
+            labels: Some(self.ownership_labels_with_attempt(bootstrap_attempt)),
             ..Default::default()
         };
 
@@ -723,12 +787,6 @@ impl DockerContainer {
         .await?;
 
         Ok(())
-    }
-
-    async fn state(&self) -> Result<Option<ContainerStateStatusEnum>, GrpcError> {
-        Ok(inspect_container(&self.docker, &self.name)
-            .await?
-            .and_then(|container| container.state.and_then(|state| state.status)))
     }
 
     async fn wait(&self) -> Result<(), GrpcError> {
@@ -950,29 +1008,38 @@ async fn remove_owned_resources(
         volume
     };
 
+    let mut cleanup_error = None;
+
     if let Some(container) = container {
         let container_id = container.id.clone().unwrap_or_else(|| name.to_string());
-        let force = matches!(
-            stop_owned_container(docker, name, container).await?,
-            StopResult::TimedOut
-        );
-        let remove = docker_api_call(
-            docker,
-            "remove container",
-            name,
-            docker.remove_container(
-                &container_id,
-                Some(
-                    bollard_stubs::query_parameters::RemoveContainerOptionsBuilder::default()
-                        .force(force)
-                        .build(),
+        let force = match stop_owned_container(docker, name, container).await {
+            Ok(result) => matches!(result, StopResult::TimedOut),
+            Err(error) => {
+                remember_cleanup_error(&mut cleanup_error, error);
+                false
+            }
+        };
+
+        if cleanup_error.is_none() || force {
+            match docker_api_call(
+                docker,
+                "remove container",
+                name,
+                docker.remove_container(
+                    &container_id,
+                    Some(
+                        bollard_stubs::query_parameters::RemoveContainerOptionsBuilder::default()
+                            .force(force)
+                            .build(),
+                    ),
                 ),
-            ),
-        );
-        match remove.await {
-            Ok(()) => {}
-            Err(error) if is_not_found_grpc(&error) => {}
-            Err(error) => return Err(error),
+            )
+            .await
+            {
+                Ok(()) => {}
+                Err(error) if is_not_found_grpc(&error) => {}
+                Err(error) => remember_cleanup_error(&mut cleanup_error, error),
+            }
         }
     }
 
@@ -992,11 +1059,11 @@ async fn remove_owned_resources(
         {
             Ok(()) => {}
             Err(error) if is_not_found_grpc(&error) => {}
-            Err(error) => return Err(error),
+            Err(error) => remember_cleanup_error(&mut cleanup_error, error),
         }
     }
 
-    Ok(())
+    cleanup_error.map_or(Ok(()), Err)
 }
 
 fn operation_timeout(operation: &str, name: &str) -> GrpcError {
@@ -1252,9 +1319,17 @@ fn normalized_host_config_value(value: Option<&String>) -> Option<&str> {
 fn update_cleanup_state(
     state: &Arc<Mutex<BootstrapCleanupState>>,
     update: impl FnOnce(&mut BootstrapCleanupState),
-) {
-    if let Ok(mut state) = state.lock() {
-        update(&mut state);
+) -> Result<(), GrpcError> {
+    let mut state = state
+        .lock()
+        .map_err(|_| tonic::Status::internal("bootstrap cleanup state was poisoned"))?;
+    update(&mut state);
+    Ok(())
+}
+
+fn remember_cleanup_error(slot: &mut Option<GrpcError>, error: GrpcError) {
+    if slot.is_none() {
+        *slot = Some(error);
     }
 }
 
@@ -1266,6 +1341,7 @@ struct BootstrapCleanupState {
     name: String,
     volume_name: String,
     resource_id: String,
+    bootstrap_attempt: String,
 }
 
 struct BootstrapTearDownHandler {
@@ -1278,7 +1354,15 @@ impl super::DriverTearDownHandler for BootstrapTearDownHandler {
         let docker = Docker::clone(&self.docker);
         let state = Arc::clone(&self.state);
         Box::pin(async move {
-            let (enabled, container_created, volume_created, name, volume_name, resource_id) = {
+            let (
+                enabled,
+                container_created,
+                volume_created,
+                name,
+                volume_name,
+                resource_id,
+                bootstrap_attempt,
+            ) = {
                 let state = state
                     .lock()
                     .map_err(|_| tonic::Status::internal("bootstrap cleanup state was poisoned"))?;
@@ -1289,62 +1373,86 @@ impl super::DriverTearDownHandler for BootstrapTearDownHandler {
                     state.name.clone(),
                     state.volume_name.clone(),
                     state.resource_id.clone(),
+                    state.bootstrap_attempt.clone(),
                 )
             };
             if !enabled {
                 return Ok(());
             }
 
+            let mut cleanup_error = None;
+
             if container_created {
-                if let Some(container) = inspect_container(&docker, &name).await? {
-                    let owned = container
-                        .config
-                        .as_ref()
-                        .and_then(|config| config.labels.as_ref())
-                        .and_then(|labels| labels.get(LABEL_RESOURCE_ID))
-                        == Some(&resource_id);
-                    if owned {
-                        docker_api_call(
-                            &docker,
-                            "remove bootstrap container",
-                            &name,
-                            docker.remove_container(
+                match inspect_container(&docker, &name).await {
+                    Ok(Some(container)) => {
+                        let owned = container
+                            .config
+                            .as_ref()
+                            .and_then(|config| config.labels.as_ref())
+                            .is_some_and(|labels| {
+                                labels.get(LABEL_RESOURCE_ID) == Some(&resource_id)
+                                    && labels.get(LABEL_BOOTSTRAP_ATTEMPT)
+                                        == Some(&bootstrap_attempt)
+                            });
+                        if owned {
+                            if let Err(error) = docker_api_call(
+                                &docker,
+                                "remove bootstrap container",
                                 &name,
-                                Some(
-                                    bollard_stubs::query_parameters::RemoveContainerOptionsBuilder::default()
-                                        .force(true)
-                                        .build(),
+                                docker.remove_container(
+                                    &name,
+                                    Some(
+                                        bollard_stubs::query_parameters::RemoveContainerOptionsBuilder::default()
+                                            .force(true)
+                                            .build(),
+                                    ),
                                 ),
-                            ),
-                        )
-                        .await?;
+                            )
+                            .await
+                            {
+                                if !is_not_found_grpc(&error) {
+                                    remember_cleanup_error(&mut cleanup_error, error);
+                                }
+                            }
+                        }
                     }
+                    Ok(None) => {}
+                    Err(error) => remember_cleanup_error(&mut cleanup_error, error),
                 }
             }
 
             if volume_created {
-                if let Some(volume) = inspect_volume(&docker, &volume_name).await? {
-                    let owned = volume.labels.get(LABEL_RESOURCE_ID) == Some(&resource_id);
-                    if owned {
-                        docker_api_call(
-                            &docker,
-                            "remove bootstrap volume",
-                            &volume_name,
-                            docker.remove_volume(
+                match inspect_volume(&docker, &volume_name).await {
+                    Ok(Some(volume)) => {
+                        let owned = volume.labels.get(LABEL_RESOURCE_ID) == Some(&resource_id);
+                        if owned {
+                            if let Err(error) = docker_api_call(
+                                &docker,
+                                "remove bootstrap volume",
                                 &volume_name,
-                                Some(
-                                    bollard_stubs::query_parameters::RemoveVolumeOptionsBuilder::default()
-                                        .force(true)
-                                        .build(),
+                                docker.remove_volume(
+                                    &volume_name,
+                                    Some(
+                                        bollard_stubs::query_parameters::RemoveVolumeOptionsBuilder::default()
+                                            .force(true)
+                                            .build(),
+                                    ),
                                 ),
-                            ),
-                        )
-                        .await?;
+                            )
+                            .await
+                            {
+                                if !is_not_found_grpc(&error) {
+                                    remember_cleanup_error(&mut cleanup_error, error);
+                                }
+                            }
+                        }
                     }
+                    Ok(None) => {}
+                    Err(error) => remember_cleanup_error(&mut cleanup_error, error),
                 }
             }
 
-            Ok(())
+            cleanup_error.map_or(Ok(()), Err)
         })
     }
 }
@@ -1496,6 +1604,7 @@ impl super::Image for DockerContainer {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::grpc::driver::Driver;
     use bollard_stubs::models::{ContainerConfig, ContainerState, MountPoint};
 
     fn builder() -> DockerContainerBuilder {
@@ -1523,6 +1632,39 @@ mod tests {
             builder.inner.lifecycle,
             DockerContainerLifecycle::RemoveAfterSolve { keep_state: true }
         );
+    }
+
+    #[test]
+    fn retained_lifecycles_require_explicit_names() {
+        assert!(lifecycle_requires_explicit_name(
+            DockerContainerLifecycle::Persistent
+        ));
+        assert!(lifecycle_requires_explicit_name(
+            DockerContainerLifecycle::StopAfterSolve
+        ));
+        assert!(lifecycle_requires_explicit_name(
+            DockerContainerLifecycle::RemoveAfterSolve { keep_state: true }
+        ));
+        assert!(!lifecycle_requires_explicit_name(
+            DockerContainerLifecycle::RemoveAfterSolve { keep_state: false }
+        ));
+    }
+
+    #[test]
+    fn ephemeral_lifecycle_admits_only_one_solve() {
+        let mut builder = builder();
+        builder.lifecycle(DockerContainerLifecycle::StopAfterSolve);
+
+        assert!(builder.inner.begin_solve().is_ok());
+        let error = match builder.inner.begin_solve() {
+            Ok(_) => panic!("ephemeral lifecycle admitted a second solve"),
+            Err(error) => error,
+        };
+
+        assert!(matches!(
+            error,
+            GrpcError::TonicStatus { err } if err.code() == tonic::Code::FailedPrecondition
+        ));
     }
 
     #[test]

--- a/src/grpc/driver/docker_container.rs
+++ b/src/grpc/driver/docker_container.rs
@@ -3,14 +3,16 @@
 use std::{
     collections::HashMap,
     pin::Pin,
+    sync::{Arc, Mutex},
     task::{Context, Poll},
     time::Duration,
 };
 
 use bollard_buildkit_proto::moby::buildkit::v1::control_client::ControlClient;
 use bollard_stubs::models::{
-    ContainerCreateBody, ExecInspectResponse, HostConfig, Mount, MountType, RestartPolicy,
-    RestartPolicyNameEnum, SystemInfoCgroupDriverEnum,
+    ContainerCreateBody, ContainerInspectResponse, ContainerStateStatusEnum, ExecInspectResponse,
+    HostConfig, Mount, MountType, RestartPolicy, RestartPolicyNameEnum, SystemInfoCgroupDriverEnum,
+    Volume, VolumeCreateRequest,
 };
 use bytes::BytesMut;
 use futures_core::Future;
@@ -49,6 +51,7 @@ const LABEL_DRIVER: &str = "com.github.fussybeaver.bollard.buildkit.driver";
 const LABEL_LIFECYCLE_SCHEMA: &str = "com.github.fussybeaver.bollard.buildkit.lifecycle-schema";
 const LABEL_BUILDER_NAME: &str = "com.github.fussybeaver.bollard.buildkit.builder-name";
 const LABEL_STATE_VOLUME: &str = "com.github.fussybeaver.bollard.buildkit.state-volume";
+const LABEL_RESOURCE_ID: &str = "com.github.fussybeaver.bollard.buildkit.resource-id";
 const LIFECYCLE_SCHEMA_VERSION: &str = "1";
 
 /// Controls the lifetime of a Docker container provisioned for BuildKit.
@@ -172,6 +175,7 @@ impl DockerContainerBuilder {
                 env: vec![],
                 args: vec![],
                 lifecycle: DockerContainerLifecycle::Persistent,
+                resource_id: crate::grpc::new_id(),
             },
         }
     }
@@ -186,18 +190,114 @@ impl DockerContainerBuilder {
             self.network("host");
         }
 
-        let tear_down_handler = Box::new(DockerContainerTearDownHandler {
+        let cleanup_state = Arc::new(Mutex::new(BootstrapCleanupState {
+            enabled: false,
+            container_created: false,
+            volume_created: false,
             name: String::from(&self.inner.name),
+            volume_name: self.inner.state_volume_name(),
+            resource_id: String::clone(&self.inner.resource_id),
+        }));
+        let tear_down_handler = Box::new(BootstrapTearDownHandler {
             docker: Docker::clone(&self.inner.docker),
+            state: Arc::clone(&cleanup_state),
         });
         let mut tear_down_guard = super::TearDownGuard::new(tear_down_handler);
 
-        self.inner.create().await?;
+        let host_config = self.inner.desired_host_config().await?;
+        let existing_container = inspect_container(&self.inner.docker, &self.inner.name).await?;
+        let existing_volume =
+            inspect_volume(&self.inner.docker, &self.inner.state_volume_name()).await?;
+
+        match (existing_container, existing_volume) {
+            (Some(container), Some(volume)) => {
+                let resource_id = compatible_volume(&self.inner, &volume)?;
+                compatible_container(&self.inner, &container, &host_config, &resource_id)?;
+                self.inner.resource_id = resource_id;
+
+                match container.state.and_then(|state| state.status) {
+                    Some(ContainerStateStatusEnum::RUNNING)
+                    | Some(ContainerStateStatusEnum::RESTARTING) => {}
+                    Some(ContainerStateStatusEnum::CREATED)
+                    | Some(ContainerStateStatusEnum::EXITED) => self.inner.start().await?,
+                    Some(status) => {
+                        return Err(resource_conflict(
+                            "container",
+                            &self.inner.name,
+                            format!("container is in unsupported state `{status}`"),
+                        ));
+                    }
+                    None => {
+                        return Err(resource_conflict(
+                            "container",
+                            &self.inner.name,
+                            "container state is unavailable",
+                        ));
+                    }
+                }
+            }
+            (None, Some(volume)) => {
+                self.inner.resource_id = compatible_volume(&self.inner, &volume)?;
+                update_cleanup_state(&cleanup_state, |state| {
+                    state.enabled = true;
+                    state.container_created = true;
+                    state.resource_id = String::clone(&self.inner.resource_id);
+                });
+                self.inner.create(&host_config).await?;
+            }
+            (Some(container), None) => {
+                if let Some(labels) = container
+                    .config
+                    .as_ref()
+                    .and_then(|config| config.labels.as_ref())
+                {
+                    if let Err(reason) =
+                        compatible_labels(labels, &self.inner.ownership_labels(), None)
+                    {
+                        return Err(resource_conflict("container", &self.inner.name, reason));
+                    }
+                } else {
+                    return Err(resource_conflict(
+                        "container",
+                        &self.inner.name,
+                        "container labels are missing",
+                    ));
+                }
+                return Err(resource_conflict(
+                    "volume",
+                    &self.inner.state_volume_name(),
+                    "managed container exists but its state volume is missing",
+                ));
+            }
+            (None, None) => {
+                update_cleanup_state(&cleanup_state, |state| {
+                    state.enabled = true;
+                    state.volume_created = true;
+                });
+                let volume = self.inner.create_volume().await?;
+                let resource_id = compatible_volume(&self.inner, &volume)?;
+                if resource_id != self.inner.resource_id {
+                    return Err(resource_conflict(
+                        "volume",
+                        &self.inner.state_volume_name(),
+                        "volume was created concurrently with a different resource identity",
+                    ));
+                }
+                update_cleanup_state(&cleanup_state, |state| state.container_created = true);
+                self.inner.create(&host_config).await?;
+            }
+        }
 
         debug!("starting container {}", &self.inner.name);
 
         let start_result: Result<(), GrpcError> = async {
-            self.inner.start().await?;
+            if !matches!(
+                self.inner.state().await?,
+                Some(ContainerStateStatusEnum::RUNNING)
+                    | Some(ContainerStateStatusEnum::RESTARTING)
+            ) {
+                self.inner.start().await?;
+            }
             self.inner.wait().await
         }
         .await;
@@ -288,6 +388,7 @@ pub struct DockerContainer {
     env: Vec<String>,
     args: Vec<String>,
     lifecycle: DockerContainerLifecycle,
+    resource_id: String,
 }
 
 impl super::Driver for DockerContainer {
@@ -340,6 +441,7 @@ impl DockerContainer {
             ),
             (String::from(LABEL_BUILDER_NAME), self.name.clone()),
             (String::from(LABEL_STATE_VOLUME), self.state_volume_name()),
+            (String::from(LABEL_RESOURCE_ID), self.resource_id.clone()),
         ])
     }
 
@@ -354,7 +456,71 @@ impl DockerContainer {
         }
     }
 
-    async fn create(&self) -> Result<(), GrpcError> {
+    #[cfg(test)]
+    fn desired_host_config_for_test(&self) -> HostConfig {
+        HostConfig {
+            privileged: Some(true),
+            mounts: Some(vec![Mount {
+                typ: Some(MountType::VOLUME),
+                source: Some(self.state_volume_name()),
+                target: Some(String::from(DEFAULT_STATE_DIR)),
+                ..Default::default()
+            }]),
+            init: Some(true),
+            network_mode: self.net_mode.clone(),
+            restart_policy: self.restart_policy(),
+            ..Default::default()
+        }
+    }
+
+    async fn desired_host_config(&self) -> Result<HostConfig, GrpcError> {
+        let info = self.docker.info().await?;
+        let cgroup_parent = match &info.cgroup_driver {
+            Some(SystemInfoCgroupDriverEnum::CGROUPFS) => Some(
+                self.cgroup_parent
+                    .clone()
+                    .unwrap_or_else(|| String::from("/docker/buildx")),
+            ),
+            _ => None,
+        };
+
+        let userns_mode = info.security_options.as_ref().and_then(|security_options| {
+            security_options
+                .iter()
+                .any(|option| option == "userns")
+                .then(|| String::from("host"))
+        });
+
+        Ok(HostConfig {
+            privileged: Some(true),
+            mounts: Some(vec![Mount {
+                typ: Some(MountType::VOLUME),
+                source: Some(self.state_volume_name()),
+                target: Some(String::from(DEFAULT_STATE_DIR)),
+                ..Default::default()
+            }]),
+            init: Some(true),
+            network_mode: self.net_mode.clone(),
+            cgroup_parent,
+            userns_mode,
+            restart_policy: self.restart_policy(),
+            ..Default::default()
+        })
+    }
+
+    async fn create_volume(&self) -> Result<Volume, GrpcError> {
+        let volume = self
+            .docker
+            .create_volume(VolumeCreateRequest {
+                name: Some(self.state_volume_name()),
+                labels: Some(self.ownership_labels()),
+                ..Default::default()
+            })
+            .await?;
+        Ok(volume)
+    }
+
+    async fn create(&self, host_config: &HostConfig) -> Result<(), GrpcError> {
         let image_name = if let Some(image) = &self.image {
             image
         } else {
@@ -382,52 +548,10 @@ impl DockerContainer {
                 .name(&self.name)
                 .build();
 
-        let info = self.docker.info().await?;
-        let cgroup_parent = match &info.cgroup_driver {
-            Some(SystemInfoCgroupDriverEnum::CGROUPFS) =>
-            // place all buildkit containers into this cgroup
-            {
-                Some(if let Some(cgroup_parent) = &self.cgroup_parent {
-                    String::clone(cgroup_parent)
-                } else {
-                    String::from("/docker/buildx")
-                })
-            }
-            _ => None,
-        };
-
-        let network_mode = self.net_mode.clone();
-
-        let userns_mode = if let Some(security_options) = &info.security_options {
-            if security_options.iter().any(|f| f == "userns") {
-                Some(String::from("host"))
-            } else {
-                None
-            }
-        } else {
-            None
-        };
-
-        let host_config = HostConfig {
-            privileged: Some(true),
-            mounts: Some(vec![Mount {
-                typ: Some(MountType::VOLUME),
-                source: Some(self.state_volume_name()),
-                target: Some(String::from(DEFAULT_STATE_DIR)),
-                ..Default::default()
-            }]),
-            init: Some(true),
-            network_mode,
-            cgroup_parent,
-            userns_mode,
-            restart_policy: self.restart_policy(),
-            ..Default::default()
-        };
-
         let container_config = ContainerCreateBody {
             image: Some(String::from(image_name)),
             env: Some(Vec::clone(&self.env)),
-            host_config: Some(host_config),
+            host_config: Some(host_config.clone()),
             cmd: Some(Vec::clone(&self.args)),
             labels: Some(self.ownership_labels()),
             ..Default::default()
@@ -449,6 +573,12 @@ impl DockerContainer {
             .await?;
 
         Ok(())
+    }
+
+    async fn state(&self) -> Result<Option<ContainerStateStatusEnum>, GrpcError> {
+        Ok(inspect_container(&self.docker, &self.name)
+            .await?
+            .and_then(|container| container.state.and_then(|state| state.status)))
     }
 
     async fn wait(&self) -> Result<(), GrpcError> {
@@ -502,6 +632,310 @@ impl DockerContainer {
                 }
             }
         }
+    }
+}
+
+async fn inspect_container(
+    docker: &Docker,
+    name: &str,
+) -> Result<Option<ContainerInspectResponse>, GrpcError> {
+    match docker.inspect_container(name, None).await {
+        Ok(container) => Ok(Some(container)),
+        Err(crate::errors::Error::DockerResponseServerError {
+            status_code: 404, ..
+        }) => Ok(None),
+        Err(error) => Err(error.into()),
+    }
+}
+
+async fn inspect_volume(docker: &Docker, name: &str) -> Result<Option<Volume>, GrpcError> {
+    match docker.inspect_volume(name).await {
+        Ok(volume) => Ok(Some(volume)),
+        Err(crate::errors::Error::DockerResponseServerError {
+            status_code: 404, ..
+        }) => Ok(None),
+        Err(error) => Err(error.into()),
+    }
+}
+
+fn resource_conflict(resource: &str, name: &str, reason: impl Into<String>) -> GrpcError {
+    GrpcError::DockerContainerResourceConflict {
+        resource: resource.to_string(),
+        name: name.to_string(),
+        reason: reason.into(),
+    }
+}
+
+fn ownership_value<'a>(labels: &'a HashMap<String, String>, key: &str) -> Option<&'a str> {
+    labels.get(key).map(String::as_str)
+}
+
+fn compatible_labels(
+    labels: &HashMap<String, String>,
+    expected: &HashMap<String, String>,
+    resource_id: Option<&str>,
+) -> Result<(), String> {
+    for key in [
+        LABEL_MANAGED,
+        LABEL_DRIVER,
+        LABEL_LIFECYCLE_SCHEMA,
+        LABEL_BUILDER_NAME,
+        LABEL_STATE_VOLUME,
+    ] {
+        if ownership_value(labels, key) != expected.get(key).map(String::as_str) {
+            return Err(format!("ownership label `{key}` does not match"));
+        }
+    }
+
+    let actual_resource_id = ownership_value(labels, LABEL_RESOURCE_ID)
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| String::from("resource ID label is missing"))?;
+    if let Some(resource_id) = resource_id {
+        if actual_resource_id != resource_id {
+            return Err(String::from("resource ID label does not match"));
+        }
+    }
+
+    Ok(())
+}
+
+fn compatible_volume(container: &DockerContainer, volume: &Volume) -> Result<String, GrpcError> {
+    let labels = &volume.labels;
+    if let Err(reason) = compatible_labels(labels, &container.ownership_labels(), None) {
+        return Err(resource_conflict("volume", &volume.name, reason));
+    }
+    if volume.driver != "local" {
+        return Err(resource_conflict(
+            "volume",
+            &volume.name,
+            format!("volume driver `{}` is not `local`", volume.driver),
+        ));
+    }
+
+    Ok(labels
+        .get(LABEL_RESOURCE_ID)
+        .expect("compatible_labels validated the resource ID")
+        .clone())
+}
+
+fn compatible_container(
+    container: &DockerContainer,
+    inspect: &ContainerInspectResponse,
+    host_config: &HostConfig,
+    resource_id: &str,
+) -> Result<(), GrpcError> {
+    let config = inspect.config.as_ref().ok_or_else(|| {
+        resource_conflict("container", &container.name, "container config is missing")
+    })?;
+    if let Err(reason) = compatible_labels(
+        config.labels.as_ref().ok_or_else(|| {
+            resource_conflict("container", &container.name, "container labels are missing")
+        })?,
+        &container.ownership_labels(),
+        Some(resource_id),
+    ) {
+        return Err(resource_conflict("container", &container.name, reason));
+    }
+
+    let expected_image = container.image.as_deref().unwrap_or(DEFAULT_IMAGE);
+    if config.image.as_deref() != Some(expected_image) {
+        return Err(resource_conflict(
+            "container",
+            &container.name,
+            "image reference does not match",
+        ));
+    }
+
+    if config.cmd.as_deref().unwrap_or_default() != container.args.as_slice() {
+        return Err(resource_conflict(
+            "container",
+            &container.name,
+            "BuildKit daemon arguments do not match",
+        ));
+    }
+
+    let existing_env = config.env.as_deref().unwrap_or_default();
+    for requested in &container.env {
+        if let Some((key, _)) = requested.split_once('=') {
+            if !existing_env.iter().any(|entry| entry == requested) {
+                return Err(resource_conflict(
+                    "container",
+                    &container.name,
+                    format!("environment override `{key}` does not match"),
+                ));
+            }
+        } else if existing_env.iter().any(|entry| {
+            entry
+                .split_once('=')
+                .is_some_and(|(key, _)| key == requested)
+        }) {
+            return Err(resource_conflict(
+                "container",
+                &container.name,
+                format!("environment variable `{requested}` was expected to be removed"),
+            ));
+        }
+    }
+
+    let existing_host_config = inspect.host_config.as_ref().ok_or_else(|| {
+        resource_conflict(
+            "container",
+            &container.name,
+            "host configuration is missing",
+        )
+    })?;
+    if existing_host_config.network_mode != host_config.network_mode
+        || existing_host_config.cgroup_parent != host_config.cgroup_parent
+        || existing_host_config.userns_mode != host_config.userns_mode
+    {
+        return Err(resource_conflict(
+            "container",
+            &container.name,
+            "host namespace configuration does not match",
+        ));
+    }
+    if existing_host_config.privileged != Some(true) || existing_host_config.init != Some(true) {
+        return Err(resource_conflict(
+            "container",
+            &container.name,
+            "container must be privileged and use init",
+        ));
+    }
+
+    let expected_restart = host_config
+        .restart_policy
+        .as_ref()
+        .and_then(|policy| policy.name);
+    let actual_restart = existing_host_config
+        .restart_policy
+        .as_ref()
+        .and_then(|policy| policy.name)
+        .filter(|policy| {
+            !matches!(
+                policy,
+                RestartPolicyNameEnum::EMPTY | RestartPolicyNameEnum::NO
+            )
+        });
+    if actual_restart != expected_restart {
+        return Err(resource_conflict(
+            "container",
+            &container.name,
+            "restart policy does not match",
+        ));
+    }
+
+    let matching_mounts = inspect
+        .mounts
+        .as_deref()
+        .unwrap_or_default()
+        .iter()
+        .filter(|mount| {
+            mount.typ.as_deref() == Some("volume")
+                && mount.name.as_deref() == Some(container.state_volume_name().as_str())
+                && mount.destination.as_deref() == Some(DEFAULT_STATE_DIR)
+                && mount.rw != Some(false)
+        })
+        .count();
+    if matching_mounts != 1 {
+        return Err(resource_conflict(
+            "container",
+            &container.name,
+            "state volume mount does not match",
+        ));
+    }
+
+    Ok(())
+}
+
+fn update_cleanup_state(
+    state: &Arc<Mutex<BootstrapCleanupState>>,
+    update: impl FnOnce(&mut BootstrapCleanupState),
+) {
+    if let Ok(mut state) = state.lock() {
+        update(&mut state);
+    }
+}
+
+#[derive(Debug)]
+struct BootstrapCleanupState {
+    enabled: bool,
+    container_created: bool,
+    volume_created: bool,
+    name: String,
+    volume_name: String,
+    resource_id: String,
+}
+
+struct BootstrapTearDownHandler {
+    docker: Docker,
+    state: Arc<Mutex<BootstrapCleanupState>>,
+}
+
+impl super::DriverTearDownHandler for BootstrapTearDownHandler {
+    fn tear_down(&self) -> Pin<Box<dyn Future<Output = Result<(), GrpcError>> + Send + 'static>> {
+        let docker = Docker::clone(&self.docker);
+        let state = Arc::clone(&self.state);
+        Box::pin(async move {
+            let (enabled, container_created, volume_created, name, volume_name, resource_id) = {
+                let state = state
+                    .lock()
+                    .map_err(|_| tonic::Status::internal("bootstrap cleanup state was poisoned"))?;
+                (
+                    state.enabled,
+                    state.container_created,
+                    state.volume_created,
+                    state.name.clone(),
+                    state.volume_name.clone(),
+                    state.resource_id.clone(),
+                )
+            };
+            if !enabled {
+                return Ok(());
+            }
+
+            if container_created {
+                if let Some(container) = inspect_container(&docker, &name).await? {
+                    let owned = container
+                        .config
+                        .as_ref()
+                        .and_then(|config| config.labels.as_ref())
+                        .and_then(|labels| labels.get(LABEL_RESOURCE_ID))
+                        == Some(&resource_id);
+                    if owned {
+                        docker
+                            .remove_container(
+                                &name,
+                                Some(
+                                    bollard_stubs::query_parameters::RemoveContainerOptionsBuilder::default()
+                                        .force(true)
+                                        .build(),
+                                ),
+                            )
+                            .await?;
+                    }
+                }
+            }
+
+            if volume_created {
+                if let Some(volume) = inspect_volume(&docker, &volume_name).await? {
+                    let owned = volume.labels.get(LABEL_RESOURCE_ID) == Some(&resource_id);
+                    if owned {
+                        docker
+                            .remove_volume(
+                                &volume_name,
+                                Some(
+                                    bollard_stubs::query_parameters::RemoveVolumeOptionsBuilder::default()
+                                        .force(true)
+                                        .build(),
+                                ),
+                            )
+                            .await?;
+                    }
+                }
+            }
+
+            Ok(())
+        })
     }
 }
 
@@ -617,6 +1051,7 @@ impl super::Image for DockerContainer {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use bollard_stubs::models::{ContainerConfig, ContainerState, MountPoint};
 
     fn builder() -> DockerContainerBuilder {
         let docker = Docker::connect_with_http_defaults().unwrap();
@@ -700,6 +1135,107 @@ mod tests {
             labels.get(LABEL_STATE_VOLUME),
             Some(&String::from("project-builder_state"))
         );
+        assert_eq!(
+            labels.get(LABEL_RESOURCE_ID),
+            Some(&builder.inner.resource_id)
+        );
+    }
+
+    #[test]
+    fn compatible_labels_require_matching_resource_identity() {
+        let builder = builder();
+        let labels = builder.inner.ownership_labels();
+
+        assert!(compatible_labels(&labels, &labels, Some(&builder.inner.resource_id)).is_ok());
+        assert!(compatible_labels(&labels, &labels, Some("different-resource")).is_err());
+    }
+
+    #[test]
+    fn compatible_volume_requires_bollard_ownership() {
+        let mut builder = builder();
+        builder.name("project-builder");
+        let volume = Volume {
+            name: builder.inner.state_volume_name(),
+            driver: String::from("local"),
+            labels: builder.inner.ownership_labels(),
+            ..Default::default()
+        };
+
+        assert_eq!(
+            compatible_volume(&builder.inner, &volume).unwrap(),
+            builder.inner.resource_id
+        );
+    }
+
+    #[test]
+    fn compatible_container_requires_the_expected_state_mount() {
+        let mut builder = builder();
+        builder.name("project-builder");
+        builder.network("host");
+
+        let host_config = builder.inner.desired_host_config_for_test();
+        let inspect = ContainerInspectResponse {
+            state: Some(ContainerState {
+                status: Some(ContainerStateStatusEnum::RUNNING),
+                ..Default::default()
+            }),
+            host_config: Some(host_config.clone()),
+            config: Some(ContainerConfig {
+                image: Some(String::from(DEFAULT_IMAGE)),
+                cmd: Some(Vec::clone(&builder.inner.args)),
+                env: Some(Vec::clone(&builder.inner.env)),
+                labels: Some(builder.inner.ownership_labels()),
+                ..Default::default()
+            }),
+            mounts: Some(vec![MountPoint {
+                typ: Some(String::from("volume")),
+                name: Some(builder.inner.state_volume_name()),
+                destination: Some(String::from(DEFAULT_STATE_DIR)),
+                rw: Some(true),
+                ..Default::default()
+            }]),
+            ..Default::default()
+        };
+
+        assert!(compatible_container(
+            &builder.inner,
+            &inspect,
+            &host_config,
+            &builder.inner.resource_id
+        )
+        .is_ok());
+    }
+
+    #[test]
+    fn incompatible_container_image_is_rejected() {
+        let mut builder = builder();
+        builder.name("project-builder");
+        let host_config = builder.inner.desired_host_config_for_test();
+        let inspect = ContainerInspectResponse {
+            host_config: Some(host_config.clone()),
+            config: Some(ContainerConfig {
+                image: Some(String::from("moby/buildkit:other")),
+                cmd: Some(Vec::clone(&builder.inner.args)),
+                labels: Some(builder.inner.ownership_labels()),
+                ..Default::default()
+            }),
+            mounts: Some(vec![MountPoint {
+                typ: Some(String::from("volume")),
+                name: Some(builder.inner.state_volume_name()),
+                destination: Some(String::from(DEFAULT_STATE_DIR)),
+                rw: Some(true),
+                ..Default::default()
+            }]),
+            ..Default::default()
+        };
+
+        assert!(compatible_container(
+            &builder.inner,
+            &inspect,
+            &host_config,
+            &builder.inner.resource_id
+        )
+        .is_err());
     }
 
     #[test]

--- a/src/grpc/driver/docker_container.rs
+++ b/src/grpc/driver/docker_container.rs
@@ -84,7 +84,31 @@ impl Service<tonic::transport::Uri> for DockerContainer {
     }
 
     fn call(&mut self, _req: tonic::transport::Uri) -> Self::Future {
-        let client = Docker::clone(&self.docker);
+        DockerContainerConnector {
+            client: Docker::clone(&self.docker),
+            name: String::clone(&self.name),
+        }
+        .call(_req)
+    }
+}
+
+#[derive(Debug, Clone)]
+struct DockerContainerConnector {
+    client: Docker,
+    name: String,
+}
+
+impl Service<tonic::transport::Uri> for DockerContainerConnector {
+    type Response = GrpcFramedTransport;
+    type Error = GrpcError;
+    type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send>>;
+
+    fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn call(&mut self, _req: tonic::transport::Uri) -> Self::Future {
+        let client = Docker::clone(&self.client);
         let name = String::clone(&self.name);
 
         let fut = async move {
@@ -168,7 +192,6 @@ impl DockerContainerBuilder {
             inner: DockerContainer {
                 name: format!("bollard_buildkit_{}", crate::grpc::new_id()),
                 docker: Docker::clone(docker),
-                session_id: String::from(&crate::grpc::new_id()),
                 net_mode: None,
                 image: None,
                 cgroup_parent: None,
@@ -374,14 +397,15 @@ impl DockerContainerBuilder {
 /// Underneath, the `buildkit` CLI will open a stdin/stdout pipe, which we can hook into to call
 /// further GRPC methods.
 ///
-/// Construct a `DockerContainer` using a [`DockerContainerBuilder`].
+/// Construct a `DockerContainer` using a [`DockerContainerBuilder`]. A persistent driver can be
+/// borrowed for multiple solves; each solve opens a fresh Docker exec transport and BuildKit
+/// session while retaining the daemon and state volume.
 ///
 ///
 #[derive(Debug)]
 pub struct DockerContainer {
     name: String,
     docker: Docker,
-    session_id: String,
     net_mode: Option<String>,
     image: Option<String>,
     cgroup_parent: Option<String>,
@@ -393,12 +417,15 @@ pub struct DockerContainer {
 
 impl super::Driver for DockerContainer {
     async fn grpc_handle(
-        self,
+        &self,
         session_id: &str,
         services: Vec<GrpcServer>,
     ) -> Result<ControlClient<InterceptedService<Channel, DriverInterceptor>>, GrpcError> {
         let channel = Endpoint::try_from("http://[::]:50051")?
-            .connect_with_connector(self)
+            .connect_with_connector(DockerContainerConnector {
+                client: Docker::clone(&self.docker),
+                name: String::clone(&self.name),
+            })
             .await?;
 
         let channel = BuildkitChannel::new(channel);
@@ -784,9 +811,12 @@ fn compatible_container(
             "host configuration is missing",
         )
     })?;
-    if existing_host_config.network_mode != host_config.network_mode
-        || existing_host_config.cgroup_parent != host_config.cgroup_parent
-        || existing_host_config.userns_mode != host_config.userns_mode
+    if normalized_host_config_value(existing_host_config.network_mode.as_ref())
+        != normalized_host_config_value(host_config.network_mode.as_ref())
+        || normalized_host_config_value(existing_host_config.cgroup_parent.as_ref())
+            != normalized_host_config_value(host_config.cgroup_parent.as_ref())
+        || normalized_host_config_value(existing_host_config.userns_mode.as_ref())
+            != normalized_host_config_value(host_config.userns_mode.as_ref())
     {
         return Err(resource_conflict(
             "container",
@@ -845,6 +875,10 @@ fn compatible_container(
     }
 
     Ok(())
+}
+
+fn normalized_host_config_value(value: Option<&String>) -> Option<&str> {
+    value.map(String::as_str).filter(|value| !value.is_empty())
 }
 
 fn update_cleanup_state(
@@ -996,7 +1030,7 @@ impl super::DriverTearDownHandler for NoopTearDownHandler {
 
 impl super::Export for DockerContainer {
     async fn export(
-        self,
+        &self,
         exporter_request: ImageExporterEnum,
         frontend_opts: ImageBuildFrontendOptions,
         load_input: ImageBuildLoadInput,
@@ -1025,7 +1059,7 @@ impl super::Export for DockerContainer {
 
 impl super::Image for DockerContainer {
     async fn registry(
-        self,
+        &self,
         output: ImageRegistryOutput,
         frontend_opts: ImageBuildFrontendOptions,
         load_input: ImageBuildLoadInput,
@@ -1174,12 +1208,15 @@ mod tests {
         builder.network("host");
 
         let host_config = builder.inner.desired_host_config_for_test();
+        let mut existing_host_config = host_config.clone();
+        existing_host_config.cgroup_parent = Some(String::new());
+        existing_host_config.userns_mode = Some(String::new());
         let inspect = ContainerInspectResponse {
             state: Some(ContainerState {
                 status: Some(ContainerStateStatusEnum::RUNNING),
                 ..Default::default()
             }),
-            host_config: Some(host_config.clone()),
+            host_config: Some(existing_host_config),
             config: Some(ContainerConfig {
                 image: Some(String::from(DEFAULT_IMAGE)),
                 cmd: Some(Vec::clone(&builder.inner.args)),

--- a/src/grpc/driver/docker_container.rs
+++ b/src/grpc/driver/docker_container.rs
@@ -32,6 +32,7 @@ use tower_service::Service;
 
 use crate::{
     auth::DockerCredentials,
+    container::StopContainerResult,
     exec::{CreateExecOptions, StartExecOptions, StartExecResults},
     grpc::{
         build::{ImageBuildFrontendOptions, ImageBuildLoadInput},
@@ -982,7 +983,9 @@ async fn stop_owned_container(
     );
 
     match stop.await {
-        Ok(()) => Ok(StopResult::Stopped),
+        Ok(StopContainerResult::Stopped | StopContainerResult::AlreadyStopped) => {
+            Ok(StopResult::Stopped)
+        }
         Err(error) if is_not_found_grpc(&error) => Ok(StopResult::Stopped),
         Err(error) if is_operation_timeout(&error) => Ok(StopResult::TimedOut),
         Err(error) => Err(error),

--- a/src/grpc/driver/docker_container.rs
+++ b/src/grpc/driver/docker_container.rs
@@ -53,12 +53,14 @@ const LABEL_BUILDER_NAME: &str = "com.github.fussybeaver.bollard.buildkit.builde
 const LABEL_STATE_VOLUME: &str = "com.github.fussybeaver.bollard.buildkit.state-volume";
 const LABEL_RESOURCE_ID: &str = "com.github.fussybeaver.bollard.buildkit.resource-id";
 const LIFECYCLE_SCHEMA_VERSION: &str = "1";
+const DOCKER_STOP_GRACE_PERIOD: u64 = 10;
+const DOCKER_STOP_TIMEOUT: Duration = Duration::from_secs(15);
 
 /// Controls the lifetime of a Docker container provisioned for BuildKit.
 ///
-/// [`DockerContainerLifecycle::Persistent`] is the default. The stop and remove
-/// policies are retained for ephemeral workflows and will perform their complete
-/// cleanup as the lifecycle management API is expanded.
+/// [`DockerContainerLifecycle::Persistent`] is the default. Persistent builders
+/// remain available until callers explicitly invoke [`DockerContainer::stop`]
+/// or [`DockerContainer::remove`].
 #[non_exhaustive]
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub enum DockerContainerLifecycle {
@@ -72,6 +74,25 @@ pub enum DockerContainerLifecycle {
         /// Keep the state volume when removing the container.
         keep_state: bool,
     },
+}
+
+/// Options for explicitly removing a Docker-container BuildKit builder.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct DockerContainerRemoveOptions {
+    keep_state: bool,
+}
+
+impl DockerContainerRemoveOptions {
+    /// Construct options that remove the builder and its state volume.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Keep the state volume after removing the BuildKit container.
+    pub fn keep_state(mut self, keep_state: bool) -> Self {
+        self.keep_state = keep_state;
+        self
+    }
 }
 
 impl Service<tonic::transport::Uri> for DockerContainer {
@@ -436,11 +457,22 @@ impl super::Driver for DockerContainer {
     fn get_tear_down_handler(&self) -> Box<dyn super::DriverTearDownHandler> {
         match self.lifecycle {
             DockerContainerLifecycle::Persistent => Box::new(NoopTearDownHandler {}),
-            DockerContainerLifecycle::StopAfterSolve
-            | DockerContainerLifecycle::RemoveAfterSolve { .. } => {
+            DockerContainerLifecycle::StopAfterSolve => Box::new(DockerContainerTearDownHandler {
+                name: String::from(&self.name),
+                volume_name: self.state_volume_name(),
+                resource_id: String::clone(&self.resource_id),
+                expected_labels: self.ownership_labels(),
+                docker: Docker::clone(&self.docker),
+                operation: DockerContainerTearDownOperation::Stop,
+            }),
+            DockerContainerLifecycle::RemoveAfterSolve { keep_state } => {
                 Box::new(DockerContainerTearDownHandler {
                     name: String::from(&self.name),
+                    volume_name: self.state_volume_name(),
+                    resource_id: String::clone(&self.resource_id),
+                    expected_labels: self.ownership_labels(),
                     docker: Docker::clone(&self.docker),
+                    operation: DockerContainerTearDownOperation::Remove { keep_state },
                 })
             }
         }
@@ -452,6 +484,44 @@ impl DockerContainer {
     /// intend to run multiple instances building in parallel on the same host.
     pub fn name(&self) -> &str {
         &self.name
+    }
+
+    /// Stop the managed BuildKit container without removing its resources.
+    ///
+    /// The operation is idempotent when the container is already stopped or
+    /// absent. A present container must still carry this driver's ownership
+    /// labels and resource identity.
+    pub async fn stop(&self) -> Result<(), GrpcError> {
+        let expected = self.ownership_labels();
+        let container =
+            inspect_owned_container(&self.docker, &self.name, &expected, &self.resource_id).await?;
+
+        let Some(container) = container else {
+            return Ok(());
+        };
+
+        match stop_owned_container(&self.docker, &self.name, container).await? {
+            StopResult::Stopped => Ok(()),
+            StopResult::TimedOut => Err(operation_timeout("stop", &self.name)),
+        }
+    }
+
+    /// Remove the managed BuildKit container and optionally its state volume.
+    ///
+    /// Removal is idempotent when the requested resources are already absent.
+    /// Ownership is validated before any resource is stopped or removed. The
+    /// container is stopped gracefully when necessary; a forced container
+    /// removal is used only when that bounded stop operation times out.
+    pub async fn remove(&self, options: DockerContainerRemoveOptions) -> Result<(), GrpcError> {
+        remove_owned_resources(
+            &self.docker,
+            &self.name,
+            &self.state_volume_name(),
+            &self.ownership_labels(),
+            &self.resource_id,
+            options.keep_state,
+        )
+        .await
     }
 
     fn state_volume_name(&self) -> String {
@@ -683,6 +753,175 @@ async fn inspect_volume(docker: &Docker, name: &str) -> Result<Option<Volume>, G
         }) => Ok(None),
         Err(error) => Err(error.into()),
     }
+}
+
+async fn inspect_owned_container(
+    docker: &Docker,
+    name: &str,
+    expected_labels: &HashMap<String, String>,
+    resource_id: &str,
+) -> Result<Option<ContainerInspectResponse>, GrpcError> {
+    let Some(container) = inspect_container(docker, name).await? else {
+        return Ok(None);
+    };
+
+    validate_owned_container(&container, name, expected_labels, resource_id)?;
+
+    Ok(Some(container))
+}
+
+fn validate_owned_container(
+    container: &ContainerInspectResponse,
+    name: &str,
+    expected_labels: &HashMap<String, String>,
+    resource_id: &str,
+) -> Result<(), GrpcError> {
+    let labels = container
+        .config
+        .as_ref()
+        .and_then(|config| config.labels.as_ref())
+        .ok_or_else(|| resource_conflict("container", name, "container labels are missing"))?;
+    if let Err(reason) = compatible_labels(labels, expected_labels, Some(resource_id)) {
+        return Err(resource_conflict("container", name, reason));
+    }
+
+    Ok(())
+}
+
+fn validate_owned_volume(
+    volume: &Volume,
+    name: &str,
+    expected_labels: &HashMap<String, String>,
+    resource_id: &str,
+) -> Result<(), GrpcError> {
+    if let Err(reason) = compatible_labels(&volume.labels, expected_labels, Some(resource_id)) {
+        return Err(resource_conflict("volume", name, reason));
+    }
+    if volume.driver != "local" {
+        return Err(resource_conflict(
+            "volume",
+            name,
+            format!("volume driver `{}` is not `local`", volume.driver),
+        ));
+    }
+
+    Ok(())
+}
+
+enum StopResult {
+    Stopped,
+    TimedOut,
+}
+
+async fn stop_owned_container(
+    docker: &Docker,
+    name: &str,
+    container: ContainerInspectResponse,
+) -> Result<StopResult, GrpcError> {
+    if matches!(
+        container.state.as_ref().and_then(|state| state.status),
+        Some(
+            ContainerStateStatusEnum::CREATED
+                | ContainerStateStatusEnum::EXITED
+                | ContainerStateStatusEnum::DEAD
+                | ContainerStateStatusEnum::REMOVING
+        )
+    ) {
+        return Ok(StopResult::Stopped);
+    }
+
+    let container_id = container.id.as_deref().unwrap_or(name);
+    let stop = docker.stop_container(
+        container_id,
+        Some(
+            bollard_stubs::query_parameters::StopContainerOptionsBuilder::default()
+                .t(DOCKER_STOP_GRACE_PERIOD as i32)
+                .build(),
+        ),
+    );
+
+    match tokio::time::timeout(DOCKER_STOP_TIMEOUT, stop).await {
+        Ok(Ok(())) => Ok(StopResult::Stopped),
+        Ok(Err(error)) if is_not_found_docker(&error) => Ok(StopResult::Stopped),
+        Ok(Err(error)) => Err(error.into()),
+        Err(_) => Ok(StopResult::TimedOut),
+    }
+}
+
+async fn remove_owned_resources(
+    docker: &Docker,
+    name: &str,
+    volume_name: &str,
+    expected_labels: &HashMap<String, String>,
+    resource_id: &str,
+    keep_state: bool,
+) -> Result<(), GrpcError> {
+    let container = inspect_owned_container(docker, name, expected_labels, resource_id).await?;
+    let volume = if keep_state {
+        None
+    } else {
+        let volume = inspect_volume(docker, volume_name).await?;
+        if let Some(volume) = &volume {
+            validate_owned_volume(volume, volume_name, expected_labels, resource_id)?;
+        }
+        volume
+    };
+
+    if let Some(container) = container {
+        let container_id = container.id.clone().unwrap_or_else(|| name.to_string());
+        let force = matches!(
+            stop_owned_container(docker, name, container).await?,
+            StopResult::TimedOut
+        );
+        let remove = docker.remove_container(
+            &container_id,
+            Some(
+                bollard_stubs::query_parameters::RemoveContainerOptionsBuilder::default()
+                    .force(force)
+                    .build(),
+            ),
+        );
+        match remove.await {
+            Ok(()) => {}
+            Err(error) if is_not_found_docker(&error) => {}
+            Err(error) => return Err(error.into()),
+        }
+    }
+
+    if volume.is_some() {
+        match docker
+            .remove_volume(
+                volume_name,
+                Some(
+                    bollard_stubs::query_parameters::RemoveVolumeOptionsBuilder::default().build(),
+                ),
+            )
+            .await
+        {
+            Ok(()) => {}
+            Err(error) if is_not_found_docker(&error) => {}
+            Err(error) => return Err(error.into()),
+        }
+    }
+
+    Ok(())
+}
+
+fn operation_timeout(operation: &str, name: &str) -> GrpcError {
+    GrpcError::DockerContainerOperationTimeout {
+        operation: operation.to_string(),
+        name: name.to_string(),
+    }
+}
+
+fn is_not_found_docker(error: &crate::errors::Error) -> bool {
+    matches!(
+        error,
+        crate::errors::Error::DockerResponseServerError {
+            status_code: 404,
+            ..
+        }
+    )
 }
 
 fn resource_conflict(resource: &str, name: &str, reason: impl Into<String>) -> GrpcError {
@@ -999,21 +1238,56 @@ fn validate_container_name(name: &str) -> Result<(), GrpcError> {
 
 struct DockerContainerTearDownHandler {
     name: String,
+    volume_name: String,
+    resource_id: String,
+    expected_labels: HashMap<String, String>,
     docker: Docker,
+    operation: DockerContainerTearDownOperation,
+}
+
+#[derive(Debug, Clone, Copy)]
+enum DockerContainerTearDownOperation {
+    Stop,
+    Remove { keep_state: bool },
 }
 
 impl super::DriverTearDownHandler for DockerContainerTearDownHandler {
     fn tear_down(&self) -> Pin<Box<dyn Future<Output = Result<(), GrpcError>> + Send + 'static>> {
         let docker = Docker::clone(&self.docker);
         let name = String::clone(&self.name);
+        let volume_name = String::clone(&self.volume_name);
+        let resource_id = String::clone(&self.resource_id);
+        let expected_labels = self.expected_labels.clone();
+        let operation = self.operation;
         Box::pin(async move {
-            docker
-                .kill_container(
-                    &name,
-                    None::<bollard_stubs::query_parameters::KillContainerOptions>,
-                )
-                .map_err(GrpcError::from)
-                .await
+            match operation {
+                DockerContainerTearDownOperation::Stop => {
+                    let Some(container) =
+                        inspect_owned_container(&docker, &name, &expected_labels, &resource_id)
+                            .await?
+                    else {
+                        return Ok(());
+                    };
+                    if matches!(
+                        stop_owned_container(&docker, &name, container).await?,
+                        StopResult::TimedOut
+                    ) {
+                        return Err(operation_timeout("stop", &name));
+                    }
+                    Ok(())
+                }
+                DockerContainerTearDownOperation::Remove { keep_state } => {
+                    remove_owned_resources(
+                        &docker,
+                        &name,
+                        &volume_name,
+                        &expected_labels,
+                        &resource_id,
+                        keep_state,
+                    )
+                    .await
+                }
+            }
         })
     }
 }
@@ -1115,6 +1389,16 @@ mod tests {
     }
 
     #[test]
+    fn remove_options_delete_state_by_default() {
+        assert!(!DockerContainerRemoveOptions::new().keep_state);
+        assert!(
+            DockerContainerRemoveOptions::new()
+                .keep_state(true)
+                .keep_state
+        );
+    }
+
+    #[test]
     fn name_setter_updates_container_identity() {
         let mut builder = builder();
 
@@ -1199,6 +1483,57 @@ mod tests {
             compatible_volume(&builder.inner, &volume).unwrap(),
             builder.inner.resource_id
         );
+    }
+
+    #[test]
+    fn explicit_management_requires_matching_volume_identity() {
+        let mut builder = builder();
+        builder.name("project-builder");
+        let mut labels = builder.inner.ownership_labels();
+        labels.insert(
+            String::from(LABEL_RESOURCE_ID),
+            String::from("different-resource"),
+        );
+        let volume = Volume {
+            name: builder.inner.state_volume_name(),
+            driver: String::from("local"),
+            labels,
+            ..Default::default()
+        };
+
+        assert!(validate_owned_volume(
+            &volume,
+            &volume.name,
+            &builder.inner.ownership_labels(),
+            &builder.inner.resource_id,
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn explicit_management_requires_matching_container_identity() {
+        let mut builder = builder();
+        builder.name("project-builder");
+        let mut labels = builder.inner.ownership_labels();
+        labels.insert(
+            String::from(LABEL_RESOURCE_ID),
+            String::from("different-resource"),
+        );
+        let container = ContainerInspectResponse {
+            config: Some(ContainerConfig {
+                labels: Some(labels),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+
+        assert!(validate_owned_container(
+            &container,
+            &builder.inner.name,
+            &builder.inner.ownership_labels(),
+            &builder.inner.resource_id,
+        )
+        .is_err());
     }
 
     #[test]

--- a/src/grpc/driver/docker_container.rs
+++ b/src/grpc/driver/docker_container.rs
@@ -54,7 +54,6 @@ const LABEL_STATE_VOLUME: &str = "com.github.fussybeaver.bollard.buildkit.state-
 const LABEL_RESOURCE_ID: &str = "com.github.fussybeaver.bollard.buildkit.resource-id";
 const LIFECYCLE_SCHEMA_VERSION: &str = "1";
 const DOCKER_STOP_GRACE_PERIOD: u64 = 10;
-const DOCKER_STOP_TIMEOUT: Duration = Duration::from_secs(15);
 
 /// Controls the lifetime of a Docker container provisioned for BuildKit.
 ///
@@ -186,6 +185,9 @@ impl Service<tonic::transport::Uri> for DockerContainerConnector {
 /// a privileged Docker container and a dedicated state volume that remain after
 /// solves until explicitly stopped or removed. Select an ephemeral lifecycle when
 /// the daemon should not remain available after a solve.
+///
+/// Lifecycle operations use the Docker client's configured timeout by default.
+/// Override it with [`Self::timeout`] when a different lifecycle bound is needed.
 ///
 /// <div class="warning">
 ///  Warning: Buildkit features in Bollard are currently in Developer Preview and are intended strictly for feedback purposes only.
@@ -407,6 +409,17 @@ impl DockerContainerBuilder {
         self
     }
 
+    /// Set the timeout used by Docker-container lifecycle operations.
+    ///
+    /// The default is the timeout configured on the [`Docker`] client passed to
+    /// [`Self::new`]. This setting only changes the builder's cloned client and
+    /// does not modify the caller's client. It bounds Docker API and lifecycle
+    /// setup operations, not the duration of an active BuildKit solve.
+    pub fn timeout(&mut self, timeout: Duration) -> &mut DockerContainerBuilder {
+        self.inner.docker.set_timeout(timeout);
+        self
+    }
+
     /// Set the stable name used for the BuildKit container and state volume.
     ///
     /// The name is validated when [`Self::bootstrap`] is called. If this method
@@ -587,7 +600,13 @@ impl DockerContainer {
     }
 
     async fn desired_host_config(&self) -> Result<HostConfig, GrpcError> {
-        let info = self.docker.info().await?;
+        let info = docker_api_call(
+            &self.docker,
+            "inspect daemon",
+            &self.name,
+            self.docker.info(),
+        )
+        .await?;
         let cgroup_parent = match &info.cgroup_driver {
             Some(SystemInfoCgroupDriverEnum::CGROUPFS) => Some(
                 self.cgroup_parent
@@ -622,14 +641,18 @@ impl DockerContainer {
     }
 
     async fn create_volume(&self) -> Result<Volume, GrpcError> {
-        let volume = self
-            .docker
-            .create_volume(VolumeCreateRequest {
-                name: Some(self.state_volume_name()),
+        let volume_name = self.state_volume_name();
+        let volume = docker_api_call(
+            &self.docker,
+            "create volume",
+            &volume_name,
+            self.docker.create_volume(VolumeCreateRequest {
+                name: Some(volume_name.clone()),
                 labels: Some(self.ownership_labels()),
                 ..Default::default()
-            })
-            .await?;
+            }),
+        )
+        .await?;
         Ok(volume)
     }
 
@@ -649,10 +672,15 @@ impl DockerContainer {
                 .from_image(image_name)
                 .build();
 
-        self.docker
-            .create_image(Some(create_image_options), None, None)
-            .try_collect::<Vec<_>>()
-            .await?;
+        docker_api_call(
+            &self.docker,
+            "pull BuildKit image",
+            &self.name,
+            self.docker
+                .create_image(Some(create_image_options), None, None)
+                .try_collect::<Vec<_>>(),
+        )
+        .await?;
 
         debug!("creating container {}", &self.name);
 
@@ -670,20 +698,29 @@ impl DockerContainer {
             ..Default::default()
         };
 
-        self.docker
-            .create_container(Some(container_options), container_config)
-            .await?;
+        docker_api_call(
+            &self.docker,
+            "create container",
+            &self.name,
+            self.docker
+                .create_container(Some(container_options), container_config),
+        )
+        .await?;
 
         Ok(())
     }
 
     async fn start(&self) -> Result<(), GrpcError> {
-        self.docker
-            .start_container(
+        docker_api_call(
+            &self.docker,
+            "start container",
+            &self.name,
+            self.docker.start_container(
                 &self.name,
                 None::<crate::query_parameters::StartContainerOptions>,
-            )
-            .await?;
+            ),
+        )
+        .await?;
 
         Ok(())
     }
@@ -698,9 +735,11 @@ impl DockerContainer {
         let mut attempts = 1;
         let mut stdout = BytesMut::new();
         loop {
-            let exec = self
-                .docker
-                .create_exec(
+            let exec = docker_api_call(
+                &self.docker,
+                "create readiness exec",
+                &self.name,
+                self.docker.create_exec(
                     &self.name,
                     CreateExecOptions {
                         attach_stdout: Some(true),
@@ -708,21 +747,41 @@ impl DockerContainer {
                         cmd: Some(vec!["buildctl", "debug", "workers"]),
                         ..Default::default()
                     },
-                )
-                .await?
-                .id;
+                ),
+            )
+            .await?
+            .id;
 
             if let StartExecResults::Attached {
                 mut output,
                 input: _,
-            } = self.docker.start_exec(&exec, None).await?
+            } = docker_api_call(
+                &self.docker,
+                "start readiness exec",
+                &self.name,
+                self.docker.start_exec(&exec, None),
+            )
+            .await?
             {
-                while let Some(Ok(output)) = output.next().await {
-                    stdout.extend_from_slice(output.into_bytes().as_ref());
+                match tokio::time::timeout(self.docker.timeout(), async {
+                    while let Some(Ok(output)) = output.next().await {
+                        stdout.extend_from_slice(output.into_bytes().as_ref());
+                    }
+                })
+                .await
+                {
+                    Ok(()) => {}
+                    Err(_) => return Err(operation_timeout("readiness exec output", &self.name)),
                 }
             };
 
-            let inspect: ExecInspectResponse = self.docker.inspect_exec(&exec).await?;
+            let inspect: ExecInspectResponse = docker_api_call(
+                &self.docker,
+                "inspect readiness exec",
+                &self.name,
+                self.docker.inspect_exec(&exec),
+            )
+            .await?;
 
             match inspect {
                 ExecInspectResponse {
@@ -752,22 +811,25 @@ async fn inspect_container(
     docker: &Docker,
     name: &str,
 ) -> Result<Option<ContainerInspectResponse>, GrpcError> {
-    match docker.inspect_container(name, None).await {
+    match docker_api_call(
+        docker,
+        "inspect container",
+        name,
+        docker.inspect_container(name, None),
+    )
+    .await
+    {
         Ok(container) => Ok(Some(container)),
-        Err(crate::errors::Error::DockerResponseServerError {
-            status_code: 404, ..
-        }) => Ok(None),
-        Err(error) => Err(error.into()),
+        Err(error) if is_not_found_grpc(&error) => Ok(None),
+        Err(error) => Err(error),
     }
 }
 
 async fn inspect_volume(docker: &Docker, name: &str) -> Result<Option<Volume>, GrpcError> {
-    match docker.inspect_volume(name).await {
+    match docker_api_call(docker, "inspect volume", name, docker.inspect_volume(name)).await {
         Ok(volume) => Ok(Some(volume)),
-        Err(crate::errors::Error::DockerResponseServerError {
-            status_code: 404, ..
-        }) => Ok(None),
-        Err(error) => Err(error.into()),
+        Err(error) if is_not_found_grpc(&error) => Ok(None),
+        Err(error) => Err(error),
     }
 }
 
@@ -847,20 +909,25 @@ async fn stop_owned_container(
     }
 
     let container_id = container.id.as_deref().unwrap_or(name);
-    let stop = docker.stop_container(
-        container_id,
-        Some(
-            bollard_stubs::query_parameters::StopContainerOptionsBuilder::default()
-                .t(DOCKER_STOP_GRACE_PERIOD as i32)
-                .build(),
+    let stop = docker_api_call(
+        docker,
+        "stop container",
+        name,
+        docker.stop_container(
+            container_id,
+            Some(
+                bollard_stubs::query_parameters::StopContainerOptionsBuilder::default()
+                    .t(DOCKER_STOP_GRACE_PERIOD as i32)
+                    .build(),
+            ),
         ),
     );
 
-    match tokio::time::timeout(DOCKER_STOP_TIMEOUT, stop).await {
-        Ok(Ok(())) => Ok(StopResult::Stopped),
-        Ok(Err(error)) if is_not_found_docker(&error) => Ok(StopResult::Stopped),
-        Ok(Err(error)) => Err(error.into()),
-        Err(_) => Ok(StopResult::TimedOut),
+    match stop.await {
+        Ok(()) => Ok(StopResult::Stopped),
+        Err(error) if is_not_found_grpc(&error) => Ok(StopResult::Stopped),
+        Err(error) if is_operation_timeout(&error) => Ok(StopResult::TimedOut),
+        Err(error) => Err(error),
     }
 }
 
@@ -889,34 +956,43 @@ async fn remove_owned_resources(
             stop_owned_container(docker, name, container).await?,
             StopResult::TimedOut
         );
-        let remove = docker.remove_container(
-            &container_id,
-            Some(
-                bollard_stubs::query_parameters::RemoveContainerOptionsBuilder::default()
-                    .force(force)
-                    .build(),
+        let remove = docker_api_call(
+            docker,
+            "remove container",
+            name,
+            docker.remove_container(
+                &container_id,
+                Some(
+                    bollard_stubs::query_parameters::RemoveContainerOptionsBuilder::default()
+                        .force(force)
+                        .build(),
+                ),
             ),
         );
         match remove.await {
             Ok(()) => {}
-            Err(error) if is_not_found_docker(&error) => {}
-            Err(error) => return Err(error.into()),
+            Err(error) if is_not_found_grpc(&error) => {}
+            Err(error) => return Err(error),
         }
     }
 
     if volume.is_some() {
-        match docker
-            .remove_volume(
+        match docker_api_call(
+            docker,
+            "remove volume",
+            volume_name,
+            docker.remove_volume(
                 volume_name,
                 Some(
                     bollard_stubs::query_parameters::RemoveVolumeOptionsBuilder::default().build(),
                 ),
-            )
-            .await
+            ),
+        )
+        .await
         {
             Ok(()) => {}
-            Err(error) if is_not_found_docker(&error) => {}
-            Err(error) => return Err(error.into()),
+            Err(error) if is_not_found_grpc(&error) => {}
+            Err(error) => return Err(error),
         }
     }
 
@@ -930,14 +1006,51 @@ fn operation_timeout(operation: &str, name: &str) -> GrpcError {
     }
 }
 
-fn is_not_found_docker(error: &crate::errors::Error) -> bool {
+async fn docker_api_call<T, F>(
+    docker: &Docker,
+    operation: &str,
+    name: &str,
+    future: F,
+) -> Result<T, GrpcError>
+where
+    F: Future<Output = Result<T, crate::errors::Error>>,
+{
+    docker_api_call_with_timeout(operation, name, docker.timeout(), future).await
+}
+
+async fn docker_api_call_with_timeout<T, F>(
+    operation: &str,
+    name: &str,
+    timeout: Duration,
+    future: F,
+) -> Result<T, GrpcError>
+where
+    F: Future<Output = Result<T, crate::errors::Error>>,
+{
+    match tokio::time::timeout(timeout, future).await {
+        Ok(Ok(result)) => Ok(result),
+        Ok(Err(crate::errors::Error::RequestTimeoutError)) => {
+            Err(operation_timeout(operation, name))
+        }
+        Ok(Err(error)) => Err(error.into()),
+        Err(_) => Err(operation_timeout(operation, name)),
+    }
+}
+
+fn is_not_found_grpc(error: &GrpcError) -> bool {
     matches!(
         error,
-        crate::errors::Error::DockerResponseServerError {
-            status_code: 404,
-            ..
+        GrpcError::DockerError {
+            err: crate::errors::Error::DockerResponseServerError {
+                status_code: 404,
+                ..
+            }
         }
     )
+}
+
+fn is_operation_timeout(error: &GrpcError) -> bool {
+    matches!(error, GrpcError::DockerContainerOperationTimeout { .. })
 }
 
 fn resource_conflict(resource: &str, name: &str, reason: impl Into<String>) -> GrpcError {
@@ -1191,16 +1304,20 @@ impl super::DriverTearDownHandler for BootstrapTearDownHandler {
                         .and_then(|labels| labels.get(LABEL_RESOURCE_ID))
                         == Some(&resource_id);
                     if owned {
-                        docker
-                            .remove_container(
+                        docker_api_call(
+                            &docker,
+                            "remove bootstrap container",
+                            &name,
+                            docker.remove_container(
                                 &name,
                                 Some(
                                     bollard_stubs::query_parameters::RemoveContainerOptionsBuilder::default()
                                         .force(true)
                                         .build(),
                                 ),
-                            )
-                            .await?;
+                            ),
+                        )
+                        .await?;
                     }
                 }
             }
@@ -1209,16 +1326,20 @@ impl super::DriverTearDownHandler for BootstrapTearDownHandler {
                 if let Some(volume) = inspect_volume(&docker, &volume_name).await? {
                     let owned = volume.labels.get(LABEL_RESOURCE_ID) == Some(&resource_id);
                     if owned {
-                        docker
-                            .remove_volume(
+                        docker_api_call(
+                            &docker,
+                            "remove bootstrap volume",
+                            &volume_name,
+                            docker.remove_volume(
                                 &volume_name,
                                 Some(
                                     bollard_stubs::query_parameters::RemoveVolumeOptionsBuilder::default()
                                         .force(true)
                                         .build(),
                                 ),
-                            )
-                            .await?;
+                            ),
+                        )
+                        .await?;
                     }
                 }
             }
@@ -1412,6 +1533,66 @@ mod tests {
                 .keep_state(true)
                 .keep_state
         );
+    }
+
+    #[test]
+    fn timeout_inherits_from_docker_client() {
+        let docker = Docker::connect_with_http_defaults()
+            .unwrap()
+            .with_timeout(Duration::from_secs(7));
+        let builder = DockerContainerBuilder::new(&docker);
+
+        assert_eq!(builder.inner.docker.timeout(), Duration::from_secs(7));
+        assert_eq!(docker.timeout(), Duration::from_secs(7));
+    }
+
+    #[test]
+    fn timeout_override_only_changes_builder_client() {
+        let docker = Docker::connect_with_http_defaults()
+            .unwrap()
+            .with_timeout(Duration::from_secs(7));
+        let mut builder = DockerContainerBuilder::new(&docker);
+
+        builder.timeout(Duration::from_secs(3));
+
+        assert_eq!(builder.inner.docker.timeout(), Duration::from_secs(3));
+        assert_eq!(docker.timeout(), Duration::from_secs(7));
+    }
+
+    #[tokio::test]
+    async fn docker_api_calls_are_bounded() {
+        let error = docker_api_call_with_timeout(
+            "inspect container",
+            "project-builder",
+            Duration::from_millis(1),
+            async {
+                tokio::time::sleep(Duration::from_millis(10)).await;
+                Ok::<(), crate::errors::Error>(())
+            },
+        )
+        .await
+        .unwrap_err();
+
+        assert!(matches!(
+            error,
+            GrpcError::DockerContainerOperationTimeout { operation, name }
+                if operation == "inspect container" && name == "project-builder"
+        ));
+
+        let error = docker_api_call_with_timeout(
+            "remove container",
+            "project-builder",
+            Duration::from_secs(1),
+            async { Err::<(), _>(crate::errors::Error::RequestTimeoutError) },
+        )
+        .await
+        .unwrap_err();
+
+        assert!(matches!(
+            error,
+            GrpcError::DockerContainerOperationTimeout { operation, name }
+                if operation == "remove container" && name == "project-builder"
+        ));
     }
 
     #[test]

--- a/src/grpc/driver/docker_container.rs
+++ b/src/grpc/driver/docker_container.rs
@@ -9,8 +9,8 @@ use std::{
 
 use bollard_buildkit_proto::moby::buildkit::v1::control_client::ControlClient;
 use bollard_stubs::models::{
-    ContainerCreateBody, ExecInspectResponse, HostConfig, Mount, MountType,
-    SystemInfoCgroupDriverEnum,
+    ContainerCreateBody, ExecInspectResponse, HostConfig, Mount, MountType, RestartPolicy,
+    RestartPolicyNameEnum, SystemInfoCgroupDriverEnum,
 };
 use bytes::BytesMut;
 use futures_core::Future;
@@ -44,6 +44,32 @@ use super::{channel::BuildkitChannel, DriverInterceptor, ImageExporterEnum};
 pub const DEFAULT_IMAGE: &str = "moby/buildkit:master";
 const DEFAULT_STATE_DIR: &str = "/var/lib/buildkit";
 const DUPLEX_BUF_SIZE: usize = 8 * 1024;
+const LABEL_MANAGED: &str = "com.github.fussybeaver.bollard.buildkit.managed";
+const LABEL_DRIVER: &str = "com.github.fussybeaver.bollard.buildkit.driver";
+const LABEL_LIFECYCLE_SCHEMA: &str = "com.github.fussybeaver.bollard.buildkit.lifecycle-schema";
+const LABEL_BUILDER_NAME: &str = "com.github.fussybeaver.bollard.buildkit.builder-name";
+const LABEL_STATE_VOLUME: &str = "com.github.fussybeaver.bollard.buildkit.state-volume";
+const LIFECYCLE_SCHEMA_VERSION: &str = "1";
+
+/// Controls the lifetime of a Docker container provisioned for BuildKit.
+///
+/// [`DockerContainerLifecycle::Persistent`] is the default. The stop and remove
+/// policies are retained for ephemeral workflows and will perform their complete
+/// cleanup as the lifecycle management API is expanded.
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum DockerContainerLifecycle {
+    /// Keep the BuildKit container and its state volume after a solve.
+    #[default]
+    Persistent,
+    /// Stop the BuildKit container after a solve while retaining its resources.
+    StopAfterSolve,
+    /// Remove the BuildKit container after a solve, optionally retaining state.
+    RemoveAfterSolve {
+        /// Keep the state volume when removing the container.
+        keep_state: bool,
+    },
+}
 
 impl Service<tonic::transport::Uri> for DockerContainer {
     type Response = GrpcFramedTransport;
@@ -129,7 +155,7 @@ pub struct DockerContainerBuilder {
 
 impl DockerContainerBuilder {
     /// Construct a new `DockerContainerBuilder` to build a [`DockerContainer`].
-    /// The docker context is torn down after solving a build.
+    /// The Docker container remains available after solving a build by default.
     ///
     /// # Arguments
     ///
@@ -145,14 +171,16 @@ impl DockerContainerBuilder {
                 cgroup_parent: None,
                 env: vec![],
                 args: vec![],
-                tear_down: true,
+                lifecycle: DockerContainerLifecycle::Persistent,
             },
         }
     }
 
-    /// Consume this builder to construct a [`DockerContainer`]
+    /// Consume this builder to construct a [`DockerContainer`].
     pub async fn bootstrap(mut self) -> Result<DockerContainer, GrpcError> {
         debug!("booting buildkit");
+
+        validate_container_name(&self.inner.name)?;
 
         if self.inner.net_mode.is_none() {
             self.network("host");
@@ -220,6 +248,26 @@ impl DockerContainerBuilder {
         self.inner.args.push(String::from(arg));
         self
     }
+
+    /// Set the stable name used for the BuildKit container and state volume.
+    ///
+    /// The name is validated when [`Self::bootstrap`] is called. If this method
+    /// is not used, a unique name is generated automatically.
+    pub fn name(&mut self, name: &str) -> &mut DockerContainerBuilder {
+        self.inner.name = String::from(name);
+        self
+    }
+
+    /// Set the lifecycle policy for the BuildKit container.
+    ///
+    /// The default policy is [`DockerContainerLifecycle::Persistent`].
+    pub fn lifecycle(
+        &mut self,
+        lifecycle: DockerContainerLifecycle,
+    ) -> &mut DockerContainerBuilder {
+        self.inner.lifecycle = lifecycle;
+        self
+    }
 }
 
 /// DockerContainer plumbing to communicate with `Buildkit` using an execution pipe.
@@ -239,7 +287,7 @@ pub struct DockerContainer {
     cgroup_parent: Option<String>,
     env: Vec<String>,
     args: Vec<String>,
-    tear_down: bool,
+    lifecycle: DockerContainerLifecycle,
 }
 
 impl super::Driver for DockerContainer {
@@ -258,13 +306,15 @@ impl super::Driver for DockerContainer {
     }
 
     fn get_tear_down_handler(&self) -> Box<dyn super::DriverTearDownHandler> {
-        if self.tear_down {
-            Box::new(DockerContainerTearDownHandler {
-                name: String::from(&self.name),
-                docker: Docker::clone(&self.docker),
-            })
-        } else {
-            Box::new(NoopTearDownHandler {})
+        match self.lifecycle {
+            DockerContainerLifecycle::Persistent => Box::new(NoopTearDownHandler {}),
+            DockerContainerLifecycle::StopAfterSolve
+            | DockerContainerLifecycle::RemoveAfterSolve { .. } => {
+                Box::new(DockerContainerTearDownHandler {
+                    name: String::from(&self.name),
+                    docker: Docker::clone(&self.docker),
+                })
+            }
         }
     }
 }
@@ -274,6 +324,34 @@ impl DockerContainer {
     /// intend to run multiple instances building in parallel on the same host.
     pub fn name(&self) -> &str {
         &self.name
+    }
+
+    fn state_volume_name(&self) -> String {
+        format!("{}_state", &self.name)
+    }
+
+    fn ownership_labels(&self) -> HashMap<String, String> {
+        HashMap::from([
+            (String::from(LABEL_MANAGED), String::from("true")),
+            (String::from(LABEL_DRIVER), String::from("docker-container")),
+            (
+                String::from(LABEL_LIFECYCLE_SCHEMA),
+                String::from(LIFECYCLE_SCHEMA_VERSION),
+            ),
+            (String::from(LABEL_BUILDER_NAME), self.name.clone()),
+            (String::from(LABEL_STATE_VOLUME), self.state_volume_name()),
+        ])
+    }
+
+    fn restart_policy(&self) -> Option<RestartPolicy> {
+        match self.lifecycle {
+            DockerContainerLifecycle::Persistent => Some(RestartPolicy {
+                name: Some(RestartPolicyNameEnum::UNLESS_STOPPED),
+                ..Default::default()
+            }),
+            DockerContainerLifecycle::StopAfterSolve
+            | DockerContainerLifecycle::RemoveAfterSolve { .. } => None,
+        }
     }
 
     async fn create(&self) -> Result<(), GrpcError> {
@@ -334,7 +412,7 @@ impl DockerContainer {
             privileged: Some(true),
             mounts: Some(vec![Mount {
                 typ: Some(MountType::VOLUME),
-                source: Some(format!("{}_state", &self.name)),
+                source: Some(self.state_volume_name()),
                 target: Some(String::from(DEFAULT_STATE_DIR)),
                 ..Default::default()
             }]),
@@ -342,6 +420,7 @@ impl DockerContainer {
             network_mode,
             cgroup_parent,
             userns_mode,
+            restart_policy: self.restart_policy(),
             ..Default::default()
         };
 
@@ -350,6 +429,7 @@ impl DockerContainer {
             env: Some(Vec::clone(&self.env)),
             host_config: Some(host_config),
             cmd: Some(Vec::clone(&self.args)),
+            labels: Some(self.ownership_labels()),
             ..Default::default()
         };
 
@@ -423,6 +503,30 @@ impl DockerContainer {
             }
         }
     }
+}
+
+fn validate_container_name(name: &str) -> Result<(), GrpcError> {
+    if name.chars().count() < 2 {
+        return Err(tonic::Status::invalid_argument(format!(
+            "invalid Docker-container builder name `{name}`: expected [a-zA-Z0-9][a-zA-Z0-9_.-]+"
+        ))
+        .into());
+    }
+
+    let mut characters = name.chars();
+    let first = characters.next().expect("validated container name length");
+
+    if !first.is_ascii_alphanumeric()
+        || !characters
+            .all(|character| character.is_ascii_alphanumeric() || "_.-".contains(character))
+    {
+        return Err(tonic::Status::invalid_argument(format!(
+            "invalid Docker-container builder name `{name}`: expected [a-zA-Z0-9][a-zA-Z0-9_.-]+"
+        ))
+        .into());
+    }
+
+    Ok(())
 }
 
 struct DockerContainerTearDownHandler {
@@ -507,5 +611,118 @@ impl super::Image for DockerContainer {
             build_ref,
         )
         .await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn builder() -> DockerContainerBuilder {
+        let docker = Docker::connect_with_http_defaults().unwrap();
+        DockerContainerBuilder::new(&docker)
+    }
+
+    #[test]
+    fn persistent_is_the_default_lifecycle() {
+        let builder = builder();
+
+        assert_eq!(
+            builder.inner.lifecycle,
+            DockerContainerLifecycle::Persistent
+        );
+    }
+
+    #[test]
+    fn lifecycle_policy_can_be_selected() {
+        let mut builder = builder();
+
+        builder.lifecycle(DockerContainerLifecycle::RemoveAfterSolve { keep_state: true });
+
+        assert_eq!(
+            builder.inner.lifecycle,
+            DockerContainerLifecycle::RemoveAfterSolve { keep_state: true }
+        );
+    }
+
+    #[test]
+    fn name_setter_updates_container_identity() {
+        let mut builder = builder();
+
+        builder.name("project-builder");
+
+        assert_eq!(builder.inner.name, "project-builder");
+        assert_eq!(builder.inner.state_volume_name(), "project-builder_state");
+    }
+
+    #[test]
+    fn valid_container_names_are_accepted() {
+        for name in ["ab", "project-builder", "A_b.c-1"] {
+            assert!(validate_container_name(name).is_ok(), "{name}");
+        }
+    }
+
+    #[test]
+    fn invalid_container_names_are_rejected() {
+        for name in [
+            "",
+            "a",
+            "-builder",
+            ".builder",
+            "builder/name",
+            "builder name",
+            "büilder",
+        ] {
+            assert!(validate_container_name(name).is_err(), "{name}");
+        }
+    }
+
+    #[test]
+    fn ownership_labels_identify_the_builder_and_state_volume() {
+        let mut builder = builder();
+        builder.name("project-builder");
+        let labels = builder.inner.ownership_labels();
+
+        assert_eq!(labels.get(LABEL_MANAGED), Some(&String::from("true")));
+        assert_eq!(
+            labels.get(LABEL_DRIVER),
+            Some(&String::from("docker-container"))
+        );
+        assert_eq!(
+            labels.get(LABEL_LIFECYCLE_SCHEMA),
+            Some(&String::from(LIFECYCLE_SCHEMA_VERSION))
+        );
+        assert_eq!(
+            labels.get(LABEL_BUILDER_NAME),
+            Some(&String::from("project-builder"))
+        );
+        assert_eq!(
+            labels.get(LABEL_STATE_VOLUME),
+            Some(&String::from("project-builder_state"))
+        );
+    }
+
+    #[test]
+    fn persistent_builders_restart_unless_stopped() {
+        let builder = builder();
+
+        assert_eq!(
+            builder
+                .inner
+                .restart_policy()
+                .and_then(|policy| policy.name),
+            Some(RestartPolicyNameEnum::UNLESS_STOPPED)
+        );
+    }
+
+    #[test]
+    fn ephemeral_builders_do_not_restart_automatically() {
+        let mut builder = builder();
+
+        builder.lifecycle(DockerContainerLifecycle::StopAfterSolve);
+        assert!(builder.inner.restart_policy().is_none());
+
+        builder.lifecycle(DockerContainerLifecycle::RemoveAfterSolve { keep_state: false });
+        assert!(builder.inner.restart_policy().is_none());
     }
 }

--- a/src/grpc/driver/moby.rs
+++ b/src/grpc/driver/moby.rs
@@ -117,8 +117,8 @@ impl Driver for Moby {
         Ok(control_client)
     }
 
-    fn get_tear_down_handler(&self) -> Box<dyn super::DriverTearDownHandler> {
-        Box::new(MobyTearDownHandler {})
+    fn begin_solve(&self) -> Result<Box<dyn super::DriverTearDownHandler>, GrpcError> {
+        Ok(Box::new(MobyTearDownHandler {}))
     }
 }
 

--- a/src/grpc/driver/moby.rs
+++ b/src/grpc/driver/moby.rs
@@ -42,7 +42,7 @@ impl Moby {
 
 impl Driver for Moby {
     async fn grpc_handle(
-        self,
+        &self,
         session_id: &str,
         services: Vec<GrpcServer>,
     ) -> Result<ControlClient<InterceptedService<Channel, DriverInterceptor>>, GrpcError> {
@@ -134,7 +134,7 @@ impl super::DriverTearDownHandler for MobyTearDownHandler {
 
 impl super::Build for Moby {
     async fn docker_build(
-        self,
+        &self,
         name: &str,
         frontend_opts: ImageBuildFrontendOptions,
         load_input: ImageBuildLoadInput,

--- a/src/grpc/driver/mod.rs
+++ b/src/grpc/driver/mod.rs
@@ -58,7 +58,7 @@ pub(crate) trait Driver {
         session_id: &str,
         services: Vec<GrpcServer>,
     ) -> Result<ControlClient<InterceptedService<Channel, DriverInterceptor>>, GrpcError>;
-    fn get_tear_down_handler(&self) -> Box<dyn DriverTearDownHandler>;
+    fn begin_solve(&self) -> Result<Box<dyn DriverTearDownHandler>, GrpcError>;
 }
 
 pub(crate) trait DriverTearDownHandler: Send + Sync {
@@ -287,7 +287,7 @@ pub(crate) async fn solve(
         services.push(GrpcServer::FileSend(filesend));
     }
 
-    let tear_down_handler = driver.get_tear_down_handler();
+    let tear_down_handler = driver.begin_solve()?;
 
     let id = build_ref.unwrap_or_default();
 
@@ -431,8 +431,8 @@ mod tests {
             Ok(ControlClient::with_interceptor(channel, interceptor))
         }
 
-        fn get_tear_down_handler(&self) -> Box<dyn DriverTearDownHandler> {
-            Box::new(TestTearDown::default())
+        fn begin_solve(&self) -> Result<Box<dyn DriverTearDownHandler>, GrpcError> {
+            Ok(Box::new(TestTearDown::default()))
         }
     }
 

--- a/src/grpc/driver/mod.rs
+++ b/src/grpc/driver/mod.rs
@@ -54,7 +54,7 @@ pub mod moby;
 
 pub(crate) trait Driver {
     async fn grpc_handle(
-        self,
+        &self,
         session_id: &str,
         services: Vec<GrpcServer>,
     ) -> Result<ControlClient<InterceptedService<Channel, DriverInterceptor>>, GrpcError>;
@@ -180,7 +180,7 @@ pub enum ImageExporterEnum {
 pub trait Export {
     /// Export the container to a tar
     async fn export(
-        self,
+        &self,
         exporter_request: ImageExporterEnum,
         frontend_opts: ImageBuildFrontendOptions,
         load_input: ImageBuildLoadInput,
@@ -193,7 +193,7 @@ pub trait Export {
 pub trait Build {
     /// Build a docker container without exporting
     async fn docker_build(
-        self,
+        &self,
         name: &str,
         frontend_opts: ImageBuildFrontendOptions,
         load_input: ImageBuildLoadInput,
@@ -206,7 +206,7 @@ pub trait Build {
 pub trait Image {
     /// Push a container build to the registry
     async fn registry(
-        self,
+        &self,
         output: ImageRegistryOutput,
         frontend_opts: ImageBuildFrontendOptions,
         load_input: ImageBuildLoadInput,
@@ -220,7 +220,7 @@ pub trait Image {
     reason = "The nature of this function requires many parameters, maybe we can eventually create a Request structure?"
 )]
 pub(crate) async fn solve(
-    driver: impl Driver,
+    driver: &impl Driver,
     exporter: &str,
     exporter_attrs: HashMap<String, String>,
     path: Option<PathBuf>,
@@ -326,7 +326,7 @@ pub(crate) async fn solve(
 }
 
 async fn execute_solve<D: Driver>(
-    driver: D,
+    driver: &D,
     session_id: &str,
     request: SolveRequest,
     services: Vec<GrpcServer>,
@@ -371,7 +371,7 @@ mod tests {
         pin::Pin,
         sync::{
             atomic::{AtomicUsize, Ordering},
-            Arc,
+            Arc, Mutex,
         },
     };
 
@@ -397,17 +397,23 @@ mod tests {
         setup_error: Option<Status>,
         setup_pending: bool,
         setup_panic: bool,
+        session_ids: Arc<Mutex<Vec<String>>>,
     }
 
     impl Driver for TestDriver {
         async fn grpc_handle(
-            self,
+            &self,
             session_id: &str,
             _services: Vec<GrpcServer>,
         ) -> Result<ControlClient<InterceptedService<Channel, DriverInterceptor>>, GrpcError>
         {
-            if let Some(error) = self.setup_error {
-                return Err(error.into());
+            self.session_ids
+                .lock()
+                .expect("session IDs mutex is not poisoned")
+                .push(String::from(session_id));
+
+            if let Some(error) = &self.setup_error {
+                return Err(error.clone().into());
             }
             if self.setup_pending {
                 std::future::pending::<()>().await;
@@ -565,6 +571,7 @@ mod tests {
             setup_error: None,
             setup_pending: false,
             setup_panic: false,
+            session_ids: Arc::new(Mutex::new(Vec::new())),
         }
     }
 
@@ -574,6 +581,7 @@ mod tests {
             setup_error: Some(Status::internal("grpc setup failed")),
             setup_pending: false,
             setup_panic: false,
+            session_ids: Arc::new(Mutex::new(Vec::new())),
         }
     }
 
@@ -583,6 +591,7 @@ mod tests {
             setup_error: None,
             setup_pending: true,
             setup_panic: false,
+            session_ids: Arc::new(Mutex::new(Vec::new())),
         }
     }
 
@@ -592,6 +601,7 @@ mod tests {
             setup_error: None,
             setup_pending: false,
             setup_panic: true,
+            session_ids: Arc::new(Mutex::new(Vec::new())),
         }
     }
 
@@ -610,7 +620,7 @@ mod tests {
     async fn execute_solve_tears_down_after_setup_failure() {
         let calls = Arc::new(AtomicUsize::new(0));
         let result = execute_solve(
-            failing_test_driver(),
+            &failing_test_driver(),
             "session",
             SolveRequest::default(),
             Vec::new(),
@@ -628,7 +638,7 @@ mod tests {
             start_test_server(Some(Status::not_found("solve failed"))).await;
         let calls = Arc::new(AtomicUsize::new(0));
         let result = execute_solve(
-            test_driver(address),
+            &test_driver(address),
             "session",
             SolveRequest::default(),
             Vec::new(),
@@ -646,7 +656,7 @@ mod tests {
         let (address, shutdown_sender, handle) = start_test_server(None).await;
         let calls = Arc::new(AtomicUsize::new(0));
         let result = execute_solve(
-            test_driver(address),
+            &test_driver(address),
             "session",
             SolveRequest::default(),
             Vec::new(),
@@ -664,7 +674,7 @@ mod tests {
         let (address, shutdown_sender, handle) = start_test_server(None).await;
         let calls = Arc::new(AtomicUsize::new(0));
         let result = execute_solve(
-            test_driver(address),
+            &test_driver(address),
             "session",
             SolveRequest::default(),
             Vec::new(),
@@ -678,19 +688,52 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn solve_reuses_a_driver_with_fresh_session_ids() {
+        let (address, shutdown_sender, handle) = start_test_server(None).await;
+        let driver = test_driver(address);
+        let session_ids = Arc::clone(&driver.session_ids);
+
+        for _ in 0..2 {
+            solve(
+                &driver,
+                "moby",
+                HashMap::new(),
+                None,
+                ImageBuildFrontendOptions::default(),
+                ImageBuildLoadInput::Upload(bytes::Bytes::new()),
+                None,
+                None,
+            )
+            .await
+            .unwrap();
+        }
+
+        stop_test_server(shutdown_sender, handle).await;
+
+        let session_ids = session_ids
+            .lock()
+            .expect("session IDs mutex is not poisoned");
+        assert_eq!(session_ids.len(), 2);
+        assert_ne!(session_ids[0], session_ids[1]);
+    }
+
+    #[tokio::test]
     async fn execute_solve_tears_down_after_cancellation() {
         let calls = Arc::new(AtomicUsize::new(0));
-        let task = tokio::spawn(execute_solve(
-            pending_test_driver(),
-            "session",
-            SolveRequest::default(),
-            Vec::new(),
-            teardown(calls.clone(), None),
-        ));
+        let driver = pending_test_driver();
+        let result = tokio::time::timeout(
+            Duration::from_millis(10),
+            execute_solve(
+                &driver,
+                "session",
+                SolveRequest::default(),
+                Vec::new(),
+                teardown(calls.clone(), None),
+            ),
+        )
+        .await;
 
-        tokio::task::yield_now().await;
-        task.abort();
-        let _ = task.await;
+        assert!(result.is_err());
         for _ in 0..10 {
             tokio::task::yield_now().await;
         }
@@ -702,7 +745,7 @@ mod tests {
     async fn execute_solve_tears_down_after_panic() {
         let calls = Arc::new(AtomicUsize::new(0));
         let result = std::panic::AssertUnwindSafe(execute_solve(
-            panicking_test_driver(),
+            &panicking_test_driver(),
             "session",
             SolveRequest::default(),
             Vec::new(),

--- a/src/grpc/error.rs
+++ b/src/grpc/error.rs
@@ -5,6 +5,16 @@ use std::num::TryFromIntError;
 /// Errors related to the Grpc functionality
 #[derive(Debug, thiserror::Error)]
 pub enum GrpcError {
+    /// A Docker-container BuildKit resource exists but does not match the requested builder.
+    #[error("BuildKit Docker-container {resource} `{name}` is incompatible: {reason}")]
+    DockerContainerResourceConflict {
+        /// The conflicting resource kind.
+        resource: String,
+        /// The resource name.
+        name: String,
+        /// The compatibility failure.
+        reason: String,
+    },
     /// The driver teardown task was unavailable when cleanup was requested.
     #[error("driver teardown task was unavailable")]
     TearDownTaskUnavailable,

--- a/src/grpc/error.rs
+++ b/src/grpc/error.rs
@@ -15,6 +15,16 @@ pub enum GrpcError {
         /// The compatibility failure.
         reason: String,
     },
+    /// A Docker-container lifecycle operation exceeded its bounded timeout.
+    #[error(
+        "Docker-container lifecycle operation `{operation}` for `{name}` exceeded its timeout"
+    )]
+    DockerContainerOperationTimeout {
+        /// The lifecycle operation that timed out.
+        operation: String,
+        /// The Docker-container builder name.
+        name: String,
+    },
     /// The driver teardown task was unavailable when cleanup was requested.
     #[error("driver teardown task was unavailable")]
     TearDownTaskUnavailable,

--- a/src/image.rs
+++ b/src/image.rs
@@ -899,7 +899,7 @@ impl Docker {
             services.push(crate::grpc::GrpcServer::Ssh(ssh));
         }
 
-        crate::grpc::driver::Driver::grpc_handle(driver, &id, services).await?;
+        crate::grpc::driver::Driver::grpc_handle(&driver, &id, services).await?;
 
         Ok(())
     }

--- a/tests/export_test.rs
+++ b/tests/export_test.rs
@@ -105,8 +105,56 @@ async fn export_buildkit_oci_test(docker: Docker) -> Result<(), Error> {
     Ok(())
 }
 
+#[cfg(feature = "buildkit_providerless")]
+async fn persistent_builder_reuse_test(docker: Docker) -> Result<(), Error> {
+    use bollard::query_parameters::{RemoveContainerOptionsBuilder, RemoveVolumeOptions};
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    let suffix = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system clock is before the Unix epoch")
+        .as_nanos();
+    let name = format!("bollard_phase_b_{suffix}");
+    let volume_name = format!("{name}_state");
+
+    let result = async {
+        let mut first_builder = DockerContainerBuilder::new(&docker);
+        first_builder.name(&name);
+        let first = first_builder.bootstrap().await.unwrap();
+        let first_inspect = docker.inspect_container(first.name(), None).await?;
+        let first_id = first_inspect.id.clone();
+
+        let mut second_builder = DockerContainerBuilder::new(&docker);
+        second_builder.name(&name);
+        let second = second_builder.bootstrap().await.unwrap();
+        let second_inspect = docker.inspect_container(second.name(), None).await?;
+
+        assert_eq!(first_id, second_inspect.id);
+        assert_eq!(docker.inspect_volume(&volume_name).await?.name, volume_name);
+        Ok::<(), Error>(())
+    }
+    .await;
+
+    let _ = docker
+        .remove_container(
+            &name,
+            Some(RemoveContainerOptionsBuilder::default().force(true).build()),
+        )
+        .await;
+    let _ = docker
+        .remove_volume(&volume_name, None::<RemoveVolumeOptions>)
+        .await;
+    result
+}
+
 #[test]
 #[cfg(feature = "buildkit_providerless")]
 fn integration_test_export_buildkit_oci() {
     connect_to_docker_and_run!(export_buildkit_oci_test);
+}
+
+#[test]
+#[cfg(feature = "buildkit_providerless")]
+fn integration_test_persistent_builder_reuse() {
+    connect_to_docker_and_run!(persistent_builder_reuse_test);
 }

--- a/tests/export_test.rs
+++ b/tests/export_test.rs
@@ -3,7 +3,9 @@
 use bollard::errors::Error;
 use bollard::Docker;
 
-use bollard::grpc::driver::docker_container::DockerContainerBuilder;
+use bollard::grpc::driver::docker_container::{
+    DockerContainerBuilder, DockerContainerLifecycle, DockerContainerRemoveOptions,
+};
 use tokio::runtime::Runtime;
 
 use std::io::Write;
@@ -184,6 +186,222 @@ async fn persistent_builder_multi_solve_test(docker: Docker) -> Result<(), Error
     result
 }
 
+#[cfg(feature = "buildkit_providerless")]
+async fn persistent_builder_management_test(docker: Docker) -> Result<(), Error> {
+    use bollard::query_parameters::{RemoveContainerOptionsBuilder, RemoveVolumeOptionsBuilder};
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    let suffix = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system clock is before the Unix epoch")
+        .as_nanos();
+    let name = format!("bollard_phase_d_{suffix}");
+    let volume_name = format!("{name}_state");
+
+    let result = async {
+        let mut first_builder = DockerContainerBuilder::new(&docker);
+        first_builder.name(&name);
+        let first = first_builder.bootstrap().await.unwrap();
+        let first_id = docker
+            .inspect_container(first.name(), None)
+            .await?
+            .id
+            .expect("bootstrapped container has an ID");
+
+        first.stop().await.unwrap();
+        first.stop().await.unwrap();
+        let stopped = docker.inspect_container(first.name(), None).await?;
+        assert_eq!(
+            stopped.state.and_then(|state| state.status),
+            Some(bollard::models::ContainerStateStatusEnum::EXITED)
+        );
+
+        let mut second_builder = DockerContainerBuilder::new(&docker);
+        second_builder.name(&name);
+        let second = second_builder.bootstrap().await.unwrap();
+        let second_id = docker
+            .inspect_container(second.name(), None)
+            .await?
+            .id
+            .expect("reused container has an ID");
+        assert_eq!(first_id, second_id);
+
+        second
+            .remove(DockerContainerRemoveOptions::new().keep_state(true))
+            .await
+            .unwrap();
+        assert!(docker.inspect_container(&name, None).await.is_err());
+        assert_eq!(docker.inspect_volume(&volume_name).await?.name, volume_name);
+
+        let mut third_builder = DockerContainerBuilder::new(&docker);
+        third_builder.name(&name);
+        let third = third_builder.bootstrap().await.unwrap();
+        let third_id = docker
+            .inspect_container(third.name(), None)
+            .await?
+            .id
+            .expect("recreated container has an ID");
+        assert_ne!(first_id, third_id);
+
+        third
+            .remove(DockerContainerRemoveOptions::new())
+            .await
+            .unwrap();
+        third
+            .remove(DockerContainerRemoveOptions::new())
+            .await
+            .unwrap();
+        assert!(docker.inspect_container(&name, None).await.is_err());
+        assert!(docker.inspect_volume(&volume_name).await.is_err());
+        Ok::<(), Error>(())
+    }
+    .await;
+
+    let _ = docker
+        .remove_container(
+            &name,
+            Some(RemoveContainerOptionsBuilder::default().force(true).build()),
+        )
+        .await;
+    let _ = docker
+        .remove_volume(
+            &volume_name,
+            Some(RemoveVolumeOptionsBuilder::default().build()),
+        )
+        .await;
+    result
+}
+
+#[cfg(feature = "buildkit_providerless")]
+async fn ephemeral_builder_cleanup_test(docker: Docker) -> Result<(), Error> {
+    use bollard::grpc::build::{ImageBuildFrontendOptions, ImageBuildLoadInput};
+    use bollard::grpc::driver::{Export, ImageExporterEnum};
+    use bollard::grpc::export::ImageExporterOutputBuilder;
+    use bollard::query_parameters::{RemoveContainerOptionsBuilder, RemoveVolumeOptionsBuilder};
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    let suffix = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system clock is before the Unix epoch")
+        .as_nanos();
+    let stop_name = format!("bollard_phase_d_stop_{suffix}");
+    let remove_name = format!("bollard_phase_d_remove_{suffix}");
+    let keep_name = format!("bollard_phase_d_keep_{suffix}");
+    let stop_volume = format!("{stop_name}_state");
+    let remove_volume = format!("{remove_name}_state");
+    let keep_volume = format!("{keep_name}_state");
+    let stop_output = std::path::PathBuf::from(format!("/tmp/{stop_name}.tar"));
+    let remove_output = std::path::PathBuf::from(format!("/tmp/{remove_name}.tar"));
+    let keep_output = std::path::PathBuf::from(format!("/tmp/{keep_name}.tar"));
+
+    let result = async {
+        let dockerfile = b"FROM scratch\n";
+        let mut header = tar::Header::new_gnu();
+        header.set_path("Dockerfile").unwrap();
+        header.set_size(dockerfile.len() as u64);
+        header.set_mode(0o755);
+        header.set_cksum();
+        let mut tar = tar::Builder::new(Vec::new());
+        tar.append(&header, dockerfile.as_slice()).unwrap();
+        let uncompressed = tar.into_inner().unwrap();
+        let mut encoder = flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::default());
+        encoder.write_all(&uncompressed).unwrap();
+        let input = bytes::Bytes::from(encoder.finish().unwrap());
+
+        let mut stop_builder = DockerContainerBuilder::new(&docker);
+        stop_builder
+            .name(&stop_name)
+            .lifecycle(DockerContainerLifecycle::StopAfterSolve);
+        let stop_driver = stop_builder.bootstrap().await.unwrap();
+        Export::export(
+            &stop_driver,
+            ImageExporterEnum::OCI(
+                ImageExporterOutputBuilder::new("bollard-phase-d-stop:latest").dest(&stop_output),
+            ),
+            ImageBuildFrontendOptions::default(),
+            ImageBuildLoadInput::Upload(input.clone()),
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+        let stopped = docker.inspect_container(&stop_name, None).await?;
+        assert_eq!(
+            stopped.state.and_then(|state| state.status),
+            Some(bollard::models::ContainerStateStatusEnum::EXITED)
+        );
+        assert_eq!(docker.inspect_volume(&stop_volume).await?.name, stop_volume);
+
+        let mut remove_builder = DockerContainerBuilder::new(&docker);
+        remove_builder
+            .name(&remove_name)
+            .lifecycle(DockerContainerLifecycle::RemoveAfterSolve { keep_state: false });
+        let remove_driver = remove_builder.bootstrap().await.unwrap();
+        Export::export(
+            &remove_driver,
+            ImageExporterEnum::OCI(
+                ImageExporterOutputBuilder::new("bollard-phase-d-remove:latest")
+                    .dest(&remove_output),
+            ),
+            ImageBuildFrontendOptions::default(),
+            ImageBuildLoadInput::Upload(input.clone()),
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+        assert!(docker.inspect_container(&remove_name, None).await.is_err());
+        assert!(docker.inspect_volume(&remove_volume).await.is_err());
+
+        let mut keep_builder = DockerContainerBuilder::new(&docker);
+        keep_builder
+            .name(&keep_name)
+            .lifecycle(DockerContainerLifecycle::RemoveAfterSolve { keep_state: true });
+        let keep_driver = keep_builder.bootstrap().await.unwrap();
+        Export::export(
+            &keep_driver,
+            ImageExporterEnum::OCI(
+                ImageExporterOutputBuilder::new("bollard-phase-d-keep:latest").dest(&keep_output),
+            ),
+            ImageBuildFrontendOptions::default(),
+            ImageBuildLoadInput::Upload(input),
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+        assert!(docker.inspect_container(&keep_name, None).await.is_err());
+        assert_eq!(docker.inspect_volume(&keep_volume).await?.name, keep_volume);
+        keep_driver
+            .remove(DockerContainerRemoveOptions::default())
+            .await
+            .unwrap();
+        assert!(docker.inspect_volume(&keep_volume).await.is_err());
+        Ok::<(), Error>(())
+    }
+    .await;
+
+    for (name, volume) in [
+        (&stop_name, &stop_volume),
+        (&remove_name, &remove_volume),
+        (&keep_name, &keep_volume),
+    ] {
+        let _ = docker
+            .remove_container(
+                name,
+                Some(RemoveContainerOptionsBuilder::default().force(true).build()),
+            )
+            .await;
+        let _ = docker
+            .remove_volume(volume, Some(RemoveVolumeOptionsBuilder::default().build()))
+            .await;
+    }
+    let _ = std::fs::remove_file(&stop_output);
+    let _ = std::fs::remove_file(&remove_output);
+    let _ = std::fs::remove_file(&keep_output);
+    result
+}
+
 #[test]
 #[cfg(feature = "buildkit_providerless")]
 fn integration_test_export_buildkit_oci() {
@@ -194,4 +412,16 @@ fn integration_test_export_buildkit_oci() {
 #[cfg(feature = "buildkit_providerless")]
 fn integration_test_persistent_builder_multi_solve() {
     connect_to_docker_and_run!(persistent_builder_multi_solve_test);
+}
+
+#[test]
+#[cfg(feature = "buildkit_providerless")]
+fn integration_test_persistent_builder_management() {
+    connect_to_docker_and_run!(persistent_builder_management_test);
+}
+
+#[test]
+#[cfg(feature = "buildkit_providerless")]
+fn integration_test_ephemeral_builder_cleanup() {
+    connect_to_docker_and_run!(ephemeral_builder_cleanup_test);
 }

--- a/tests/export_test.rs
+++ b/tests/export_test.rs
@@ -68,7 +68,7 @@ async fn export_buildkit_oci_test(docker: Docker) -> Result<(), Error> {
     creds_hsh.insert("localhost:5000", credentials);
 
     let res = bollard::grpc::driver::Export::export(
-        driver,
+        &driver,
         bollard::grpc::driver::ImageExporterEnum::OCI(output),
         frontend_opts,
         load_input,
@@ -106,7 +106,7 @@ async fn export_buildkit_oci_test(docker: Docker) -> Result<(), Error> {
 }
 
 #[cfg(feature = "buildkit_providerless")]
-async fn persistent_builder_reuse_test(docker: Docker) -> Result<(), Error> {
+async fn persistent_builder_multi_solve_test(docker: Docker) -> Result<(), Error> {
     use bollard::query_parameters::{RemoveContainerOptionsBuilder, RemoveVolumeOptions};
     use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -116,13 +116,48 @@ async fn persistent_builder_reuse_test(docker: Docker) -> Result<(), Error> {
         .as_nanos();
     let name = format!("bollard_phase_b_{suffix}");
     let volume_name = format!("{name}_state");
+    let first_output = std::path::PathBuf::from(format!("/tmp/{name}_first.tar"));
+    let second_output = std::path::PathBuf::from(format!("/tmp/{name}_second.tar"));
 
     let result = async {
+        let dockerfile = b"FROM scratch\n";
+        let mut header = tar::Header::new_gnu();
+        header.set_path("Dockerfile").unwrap();
+        header.set_size(dockerfile.len() as u64);
+        header.set_mode(0o755);
+        header.set_cksum();
+        let mut tar = tar::Builder::new(Vec::new());
+        tar.append(&header, dockerfile.as_slice()).unwrap();
+        let uncompressed = tar.into_inner().unwrap();
+        let mut encoder = flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::default());
+        encoder.write_all(&uncompressed).unwrap();
+        let compressed = encoder.finish().unwrap();
+
         let mut first_builder = DockerContainerBuilder::new(&docker);
         first_builder.name(&name);
         let first = first_builder.bootstrap().await.unwrap();
         let first_inspect = docker.inspect_container(first.name(), None).await?;
         let first_id = first_inspect.id.clone();
+
+        for output_path in [&first_output, &second_output] {
+            let output = bollard::grpc::export::ImageExporterOutputBuilder::new(
+                "bollard-phase-c-scratch:latest",
+            )
+            .dest(output_path);
+            bollard::grpc::driver::Export::export(
+                &first,
+                bollard::grpc::driver::ImageExporterEnum::OCI(output),
+                bollard::grpc::build::ImageBuildFrontendOptions::default(),
+                bollard::grpc::build::ImageBuildLoadInput::Upload(bytes::Bytes::from(
+                    compressed.clone(),
+                )),
+                None,
+                None,
+            )
+            .await
+            .unwrap();
+            assert!(output_path.exists());
+        }
 
         let mut second_builder = DockerContainerBuilder::new(&docker);
         second_builder.name(&name);
@@ -144,6 +179,8 @@ async fn persistent_builder_reuse_test(docker: Docker) -> Result<(), Error> {
     let _ = docker
         .remove_volume(&volume_name, None::<RemoveVolumeOptions>)
         .await;
+    let _ = std::fs::remove_file(&first_output);
+    let _ = std::fs::remove_file(&second_output);
     result
 }
 
@@ -155,6 +192,6 @@ fn integration_test_export_buildkit_oci() {
 
 #[test]
 #[cfg(feature = "buildkit_providerless")]
-fn integration_test_persistent_builder_reuse() {
-    connect_to_docker_and_run!(persistent_builder_reuse_test);
+fn integration_test_persistent_builder_multi_solve() {
+    connect_to_docker_and_run!(persistent_builder_multi_solve_test);
 }

--- a/tests/export_test.rs
+++ b/tests/export_test.rs
@@ -9,10 +9,59 @@ use bollard::grpc::driver::docker_container::{
 use tokio::runtime::Runtime;
 
 use std::io::Write;
+use std::time::{SystemTime, UNIX_EPOCH};
 
 #[macro_use]
 pub mod common;
 use crate::common::*;
+
+#[cfg(feature = "buildkit_providerless")]
+fn unique_builder_name(prefix: &str) -> String {
+    let suffix = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system clock is before the Unix epoch")
+        .as_nanos();
+    format!("{prefix}_{suffix}")
+}
+
+#[cfg(feature = "buildkit_providerless")]
+fn is_not_found(error: &Error) -> bool {
+    matches!(
+        error,
+        Error::DockerResponseServerError {
+            status_code: 404,
+            ..
+        }
+    )
+}
+
+#[cfg(feature = "buildkit_providerless")]
+async fn cleanup_named_builder(docker: &Docker, name: &str, volume_name: &str) {
+    use bollard::query_parameters::{RemoveContainerOptionsBuilder, RemoveVolumeOptionsBuilder};
+
+    if let Err(error) = docker
+        .remove_container(
+            name,
+            Some(RemoveContainerOptionsBuilder::default().force(true).build()),
+        )
+        .await
+    {
+        if !is_not_found(&error) {
+            eprintln!("failed to clean up BuildKit container `{name}`: {error}");
+        }
+    }
+    if let Err(error) = docker
+        .remove_volume(
+            volume_name,
+            Some(RemoveVolumeOptionsBuilder::default().build()),
+        )
+        .await
+    {
+        if !is_not_found(&error) {
+            eprintln!("failed to clean up BuildKit volume `{volume_name}`: {error}");
+        }
+    }
+}
 
 async fn export_buildkit_oci_test(docker: Docker) -> Result<(), Error> {
     let dockerfile = String::from(
@@ -55,68 +104,76 @@ async fn export_buildkit_oci_test(docker: Docker) -> Result<(), Error> {
     .annotation("exporter", "Bollard")
     .dest(dest_path);
 
-    let buildkit_builder = DockerContainerBuilder::new(&docker);
-    let driver = buildkit_builder.bootstrap().await.unwrap();
+    let name = unique_builder_name("bollard_phase_e_oci");
+    let volume_name = format!("{name}_state");
+    let result = async {
+        let mut buildkit_builder = DockerContainerBuilder::new(&docker);
+        buildkit_builder
+            .name(&name)
+            .lifecycle(DockerContainerLifecycle::RemoveAfterSolve { keep_state: false });
+        let driver = buildkit_builder
+            .bootstrap()
+            .await
+            .map_err(|error| Error::IOError {
+                err: std::io::Error::other(format!("BuildKit bootstrap failed: {error}")),
+            })?;
 
-    let load_input =
-        bollard::grpc::build::ImageBuildLoadInput::Upload(bytes::Bytes::from(compressed));
+        let load_input =
+            bollard::grpc::build::ImageBuildLoadInput::Upload(bytes::Bytes::from(compressed));
 
-    let credentials = bollard::auth::DockerCredentials {
-        username: Some("bollard".to_string()),
-        password: std::env::var("REGISTRY_PASSWORD").ok(),
-        ..Default::default()
-    };
-    let mut creds_hsh = std::collections::HashMap::new();
-    creds_hsh.insert("localhost:5000", credentials);
+        let credentials = bollard::auth::DockerCredentials {
+            username: Some("bollard".to_string()),
+            password: std::env::var("REGISTRY_PASSWORD").ok(),
+            ..Default::default()
+        };
+        let mut creds_hsh = std::collections::HashMap::new();
+        creds_hsh.insert("localhost:5000", credentials);
 
-    let res = bollard::grpc::driver::Export::export(
-        &driver,
-        bollard::grpc::driver::ImageExporterEnum::OCI(output),
-        frontend_opts,
-        load_input,
-        Some(creds_hsh),
-        None,
-    )
+        bollard::grpc::driver::Export::export(
+            &driver,
+            bollard::grpc::driver::ImageExporterEnum::OCI(output),
+            frontend_opts,
+            load_input,
+            Some(creds_hsh),
+            None,
+        )
+        .await
+        .map_err(|error| Error::IOError {
+            err: std::io::Error::other(format!("BuildKit solve failed: {error}")),
+        })?;
+
+        assert!(dest_path.exists());
+
+        let oci_file = std::fs::File::open(dest_path)?;
+        let mut oci_archive = tar::Archive::new(oci_file);
+
+        let mut paths = vec![];
+        let iter = oci_archive.entries()?;
+        for entry in iter {
+            let entry = entry?;
+            let path = entry.path()?.display().to_string();
+            paths.push(path);
+        }
+
+        println!("{:#?}", &paths);
+
+        assert!(paths.contains(&String::from("blobs/")));
+        assert!(paths.contains(&String::from("blobs/sha256/")));
+        assert!(paths.contains(&String::from("index.json")));
+        assert!(paths.contains(&String::from("oci-layout")));
+        assert_eq!(paths.len(), 8);
+        Ok::<(), Error>(())
+    }
     .await;
 
-    assert!(res.is_ok());
-
-    assert!(dest_path.exists());
-
-    let oci_file = std::fs::File::open(dest_path)?;
-    let mut oci_archive = tar::Archive::new(oci_file);
-
-    let mut paths = vec![];
-
-    let iter = oci_archive.entries()?;
-    for entry in iter {
-        let entry = entry?;
-        let path = entry.path()?.display().to_string();
-        paths.push(path);
-    }
-
-    println!("{:#?}", &paths);
-
-    assert!(paths.contains(&String::from("blobs/")));
-    assert!(paths.contains(&String::from("blobs/sha256/")));
-    assert!(paths.contains(&String::from("index.json")));
-    assert!(paths.contains(&String::from("oci-layout")));
-
-    assert_eq!(paths.len(), 8);
-
-    Ok(())
+    cleanup_named_builder(&docker, &name, &volume_name).await;
+    let _ = std::fs::remove_file(dest_path);
+    result
 }
 
 #[cfg(feature = "buildkit_providerless")]
 async fn persistent_builder_multi_solve_test(docker: Docker) -> Result<(), Error> {
-    use bollard::query_parameters::{RemoveContainerOptionsBuilder, RemoveVolumeOptions};
-    use std::time::{SystemTime, UNIX_EPOCH};
-
-    let suffix = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .expect("system clock is before the Unix epoch")
-        .as_nanos();
-    let name = format!("bollard_phase_b_{suffix}");
+    let name = unique_builder_name("bollard_phase_e_multi");
     let volume_name = format!("{name}_state");
     let first_output = std::path::PathBuf::from(format!("/tmp/{name}_first.tar"));
     let second_output = std::path::PathBuf::from(format!("/tmp/{name}_second.tar"));
@@ -172,30 +229,173 @@ async fn persistent_builder_multi_solve_test(docker: Docker) -> Result<(), Error
     }
     .await;
 
-    let _ = docker
-        .remove_container(
-            &name,
-            Some(RemoveContainerOptionsBuilder::default().force(true).build()),
-        )
-        .await;
-    let _ = docker
-        .remove_volume(&volume_name, None::<RemoveVolumeOptions>)
-        .await;
+    cleanup_named_builder(&docker, &name, &volume_name).await;
     let _ = std::fs::remove_file(&first_output);
     let _ = std::fs::remove_file(&second_output);
     result
 }
 
 #[cfg(feature = "buildkit_providerless")]
-async fn persistent_builder_management_test(docker: Docker) -> Result<(), Error> {
-    use bollard::query_parameters::{RemoveContainerOptionsBuilder, RemoveVolumeOptionsBuilder};
-    use std::time::{SystemTime, UNIX_EPOCH};
+fn oci_manifest_digest(path: &std::path::Path) -> Result<String, Error> {
+    use std::io::Read;
 
-    let suffix = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .expect("system clock is before the Unix epoch")
-        .as_nanos();
-    let name = format!("bollard_phase_d_{suffix}");
+    let file = std::fs::File::open(path)?;
+    let mut archive = tar::Archive::new(file);
+    let mut index = String::new();
+    for entry in archive.entries()? {
+        let mut entry = entry?;
+        if entry.path()?.to_string_lossy() == "index.json" {
+            entry.read_to_string(&mut index)?;
+            break;
+        }
+    }
+
+    let index: serde_json::Value = serde_json::from_str(&index)?;
+    index
+        .get("manifests")
+        .and_then(serde_json::Value::as_array)
+        .and_then(|manifests| manifests.first())
+        .and_then(|manifest| manifest.get("digest"))
+        .and_then(serde_json::Value::as_str)
+        .map(String::from)
+        .ok_or_else(|| Error::IOError {
+            err: std::io::Error::other("OCI index does not contain a manifest digest"),
+        })
+}
+
+#[cfg(feature = "buildkit_providerless")]
+async fn persistent_builder_cache_repeatability_test(docker: Docker) -> Result<(), Error> {
+    use bollard::grpc::build::{ImageBuildFrontendOptions, ImageBuildLoadInput};
+    use bollard::grpc::driver::{Export, ImageExporterEnum};
+    use bollard::grpc::export::ImageExporterOutputBuilder;
+
+    let name = unique_builder_name("bollard_phase_e_cache");
+    let volume_name = format!("{name}_state");
+    let output_root = tempfile::tempdir()?;
+    let first_output = output_root.path().join("first.tar");
+    let second_output = output_root.path().join("second.tar");
+    let dockerfile = "FROM localhost:5000/alpine\nRUN date +%s > /cache-proof\nFROM scratch\nCOPY --from=0 /cache-proof /cache-proof\n";
+
+    let result = async {
+        let mut header = tar::Header::new_gnu();
+        header.set_path("Dockerfile").unwrap();
+        header.set_size(dockerfile.len() as u64);
+        header.set_mode(0o755);
+        header.set_cksum();
+        let mut tar = tar::Builder::new(Vec::new());
+        tar.append(&header, dockerfile.as_bytes()).unwrap();
+        let uncompressed = tar.into_inner().unwrap();
+        let mut encoder = flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::default());
+        encoder.write_all(&uncompressed).unwrap();
+        let input = bytes::Bytes::from(encoder.finish().unwrap());
+
+        let mut first_builder = DockerContainerBuilder::new(&docker);
+        first_builder.name(&name);
+        let first = first_builder
+            .bootstrap()
+            .await
+            .map_err(|error| Error::IOError {
+                err: std::io::Error::other(format!("first BuildKit bootstrap failed: {error}")),
+            })?;
+        let first_id = docker
+            .inspect_container(first.name(), None)
+            .await?
+            .id
+            .expect("bootstrapped container has an ID");
+
+        let credentials = bollard::auth::DockerCredentials {
+            username: Some("bollard".to_string()),
+            password: std::env::var("REGISTRY_PASSWORD").ok(),
+            ..Default::default()
+        };
+        let mut credentials_by_host = std::collections::HashMap::new();
+        credentials_by_host.insert("localhost:5000", credentials);
+        Export::export(
+            &first,
+            ImageExporterEnum::OCI(
+                ImageExporterOutputBuilder::new("bollard-phase-e-cache:latest").dest(&first_output),
+            ),
+            ImageBuildFrontendOptions::builder().pull(true).build(),
+            ImageBuildLoadInput::Upload(input.clone()),
+            Some(credentials_by_host),
+            None,
+        )
+        .await
+        .map_err(|error| Error::IOError {
+            err: std::io::Error::other(format!("first BuildKit solve failed: {error}")),
+        })?;
+        let first_digest = oci_manifest_digest(&first_output)?;
+
+        first
+            .remove(DockerContainerRemoveOptions::new().keep_state(true))
+            .await
+            .map_err(|error| Error::IOError {
+                err: std::io::Error::other(format!("failed to remove first builder: {error}")),
+            })?;
+        assert!(docker.inspect_container(&name, None).await.is_err());
+        assert_eq!(docker.inspect_volume(&volume_name).await?.name, volume_name);
+
+        // If the RUN step executes again, its timestamp and resulting layer digest change.
+        tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+
+        let mut second_builder = DockerContainerBuilder::new(&docker);
+        second_builder.name(&name);
+        let second = second_builder
+            .bootstrap()
+            .await
+            .map_err(|error| Error::IOError {
+                err: std::io::Error::other(format!("second BuildKit bootstrap failed: {error}")),
+            })?;
+        let second_id = docker
+            .inspect_container(second.name(), None)
+            .await?
+            .id
+            .expect("rebootstrapped container has an ID");
+        assert_ne!(first_id, second_id);
+
+        let credentials = bollard::auth::DockerCredentials {
+            username: Some("bollard".to_string()),
+            password: std::env::var("REGISTRY_PASSWORD").ok(),
+            ..Default::default()
+        };
+        let mut credentials_by_host = std::collections::HashMap::new();
+        credentials_by_host.insert("localhost:5000", credentials);
+        Export::export(
+            &second,
+            ImageExporterEnum::OCI(
+                ImageExporterOutputBuilder::new("bollard-phase-e-cache:latest")
+                    .dest(&second_output),
+            ),
+            ImageBuildFrontendOptions::builder().pull(true).build(),
+            ImageBuildLoadInput::Upload(input),
+            Some(credentials_by_host),
+            None,
+        )
+        .await
+        .map_err(|error| Error::IOError {
+            err: std::io::Error::other(format!("second BuildKit solve failed: {error}")),
+        })?;
+        let second_digest = oci_manifest_digest(&second_output)?;
+        assert_eq!(first_digest, second_digest);
+
+        second
+            .remove(DockerContainerRemoveOptions::default())
+            .await
+            .map_err(|error| Error::IOError {
+                err: std::io::Error::other(format!("failed to remove second builder: {error}")),
+            })?;
+        assert!(docker.inspect_volume(&volume_name).await.is_err());
+        Ok::<(), Error>(())
+    }
+    .await;
+
+    cleanup_named_builder(&docker, &name, &volume_name).await;
+    result
+}
+
+#[cfg(feature = "buildkit_providerless")]
+async fn persistent_builder_management_test(docker: Docker) -> Result<(), Error> {
+    let name = unique_builder_name("bollard_phase_e_management");
     let volume_name = format!("{name}_state");
 
     let result = async {
@@ -257,18 +457,7 @@ async fn persistent_builder_management_test(docker: Docker) -> Result<(), Error>
     }
     .await;
 
-    let _ = docker
-        .remove_container(
-            &name,
-            Some(RemoveContainerOptionsBuilder::default().force(true).build()),
-        )
-        .await;
-    let _ = docker
-        .remove_volume(
-            &volume_name,
-            Some(RemoveVolumeOptionsBuilder::default().build()),
-        )
-        .await;
+    cleanup_named_builder(&docker, &name, &volume_name).await;
     result
 }
 
@@ -277,16 +466,9 @@ async fn ephemeral_builder_cleanup_test(docker: Docker) -> Result<(), Error> {
     use bollard::grpc::build::{ImageBuildFrontendOptions, ImageBuildLoadInput};
     use bollard::grpc::driver::{Export, ImageExporterEnum};
     use bollard::grpc::export::ImageExporterOutputBuilder;
-    use bollard::query_parameters::{RemoveContainerOptionsBuilder, RemoveVolumeOptionsBuilder};
-    use std::time::{SystemTime, UNIX_EPOCH};
-
-    let suffix = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .expect("system clock is before the Unix epoch")
-        .as_nanos();
-    let stop_name = format!("bollard_phase_d_stop_{suffix}");
-    let remove_name = format!("bollard_phase_d_remove_{suffix}");
-    let keep_name = format!("bollard_phase_d_keep_{suffix}");
+    let stop_name = unique_builder_name("bollard_phase_e_stop");
+    let remove_name = unique_builder_name("bollard_phase_e_remove");
+    let keep_name = unique_builder_name("bollard_phase_e_keep");
     let stop_volume = format!("{stop_name}_state");
     let remove_volume = format!("{remove_name}_state");
     let keep_volume = format!("{keep_name}_state");
@@ -386,15 +568,7 @@ async fn ephemeral_builder_cleanup_test(docker: Docker) -> Result<(), Error> {
         (&remove_name, &remove_volume),
         (&keep_name, &keep_volume),
     ] {
-        let _ = docker
-            .remove_container(
-                name,
-                Some(RemoveContainerOptionsBuilder::default().force(true).build()),
-            )
-            .await;
-        let _ = docker
-            .remove_volume(volume, Some(RemoveVolumeOptionsBuilder::default().build()))
-            .await;
+        cleanup_named_builder(&docker, name, volume).await;
     }
     let _ = std::fs::remove_file(&stop_output);
     let _ = std::fs::remove_file(&remove_output);
@@ -418,6 +592,12 @@ fn integration_test_persistent_builder_multi_solve() {
 #[cfg(feature = "buildkit_providerless")]
 fn integration_test_persistent_builder_management() {
     connect_to_docker_and_run!(persistent_builder_management_test);
+}
+
+#[test]
+#[cfg(feature = "buildkit_providerless")]
+fn integration_test_persistent_builder_cache_repeatability() {
+    connect_to_docker_and_run!(persistent_builder_cache_repeatability_test);
 }
 
 #[test]

--- a/tests/image_test.rs
+++ b/tests/image_test.rs
@@ -733,7 +733,7 @@ COPY --from=builder1 /token /",
     creds_hsh.insert("localhost:5000", credentials);
 
     let res = bollard::grpc::driver::Build::docker_build(
-        driver,
+        &driver,
         name,
         frontend_opts,
         load_input,
@@ -861,7 +861,7 @@ RUN touch bollard.txt
     creds_hsh.insert("localhost:5000", credentials);
 
     let res = bollard::grpc::driver::Build::docker_build(
-        driver,
+        &driver,
         name,
         frontend_opts,
         load_input,
@@ -926,7 +926,7 @@ async fn build_buildkit_named_context_test(docker: Docker) -> Result<(), Error> 
     creds_hsh.insert("localhost:5000", credentials);
 
     let res = bollard::grpc::driver::Build::docker_build(
-        driver,
+        &driver,
         name,
         frontend_opts,
         load_input,
@@ -1050,7 +1050,7 @@ RUN --mount=type=ssh git clone ssh://git@{}:{}/srv/git/config.git /config
     creds_hsh.insert("localhost:5000", credentials);
 
     let res = bollard::grpc::driver::Build::docker_build(
-        driver,
+        &driver,
         name,
         frontend_opts,
         load_input,
@@ -1176,7 +1176,7 @@ ENTRYPOINT ls buildkit-bollard.txt
     creds_hsh.insert("localhost:5000", credentials);
 
     let res = bollard::grpc::driver::Build::docker_build(
-        driver,
+        &driver,
         name,
         frontend_opts,
         load_input,
@@ -1275,7 +1275,7 @@ RUN touch bollard.txt
         bollard::grpc::build::ImageBuildLoadInput::Upload(bytes::Bytes::from(compressed));
 
     let res = bollard::grpc::driver::Build::docker_build(
-        driver,
+        &driver,
         name,
         frontend_opts,
         load_input,


### PR DESCRIPTION
- Named Docker-container BuildKit builders are now persistent by default, with explicit stop and remove operations and configurable timeouts.
- Ownership-labelled resources are identified, validated, and reused across solves; unmanaged existing resources are never silently adopted or destroyed.
- Ephemeral StopAfterSolve and RemoveAfterSolve policies provide one-shot and panic-safe cleanup coverage.