### PR TITLE
fix(deps) make ureq dependency actually rustls-no-provider - stop pulling in `ring`

### DIFF
--- a/codegen/proto/Cargo.toml
+++ b/codegen/proto/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2021"
 [features]
 default = ["fetch"]
 build = ["tonic-prost-build"]
-fetch = ["ureq", "ureq/rustls"]
+fetch = ["ureq"]
 
 [[bin]]
 name = "gen"


### PR DESCRIPTION
we have a cargo deny ban for the `ring` crate to avoid build-time issues with both `ring` and `aws-lc-rs` tls providers available to rustls. when testcontainers-rs [updated to bollard 0.21](https://github.com/testcontainers/testcontainers-rs/pull/943) in 0.28, this started pulling `ring` back into our transitive dependencies. while the main `bollard` crate has provision for choosing tls provider, the `bollard-buildkit-proto` didn't - in the optional dependency declaration of `ureq`, `rustls-no-provider` is declared, but when the dependency is brought in with the `fetch` feature, it was enabling `rustls` directly, the only effect of which is to add `ring` to the build path.