### PR TITLE
buildkit: transplant registry-backed Phase F FileSync

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,9 +10,9 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.4"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+checksum = "c982642fa9e8606056828ee9a8505737230110bb1099153c79efe865c59d12ba"
 dependencies = [
  "memchr",
 ]
@@ -25,9 +25,9 @@ checksum = "e9d4ee0d472d1cd2e28c97dfa124b3d8d992e10eb0a035f33f5d12e3a177ba3b"
 
 [[package]]
 name = "android_system_properties"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+checksum = "ae221649c9976a6f6c56ae1facf410f3ddb33cc661c4b7b61020a912d4237fbc"
 dependencies = [
  "libc",
 ]
@@ -57,18 +57,18 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "async-trait"
-version = "0.1.89"
+version = "0.1.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+checksum = "82f6aeea286b8eb4dd3431a1be1b59d290ace00f5bfd8e2a159bc2a05e2c1667"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -85,9 +85,9 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.17.1"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4342d8937fc7e5dd9b1c60292261c0670c882a2cd1719cfc11b1af41731e32ad"
+checksum = "ce2b2dcc879c3bae0d371e77c99f2238400ef24ec001394befa67b6e543add9e"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -95,9 +95,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.42.0"
+version = "0.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d9ceb1da931507a12f4fccea479dccd00da1943e1b4ae72d8e502d707361444"
+checksum = "f09fae7be8bb3174e05c6afdb34199e6dc0c7c04ba9fa237b1967adfbde27483"
 dependencies = [
  "cc",
  "cmake",
@@ -201,6 +201,7 @@ dependencies = [
  "flate2",
  "futures-core",
  "futures-util",
+ "glob",
  "hex",
  "home",
  "http",
@@ -217,6 +218,7 @@ dependencies = [
  "pin-project-lite",
  "prost",
  "rand",
+ "regex",
  "rustls",
  "rustls-native-certs",
  "rustls-pki-types",
@@ -224,7 +226,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "serde_urlencoded",
- "sha2",
+ "sha2 0.10.9",
  "tar",
  "tempfile",
  "termion",
@@ -238,6 +240,7 @@ dependencies = [
  "tower-service",
  "url",
  "webpki-roots",
+ "xattr",
  "yup-hyper-mock",
 ]
 
@@ -321,9 +324,9 @@ checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
 name = "cap-fs-ext"
-version = "4.0.2"
+version = "4.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d78e5a3368ae89b7cb68186411452b4b9fac8b41be9c19bf3f47c2d2c8e36e6b"
+checksum = "56ff379b70af8e08307a8f65e7040c7301cb4a572538ade16b4984f0da77847f"
 dependencies = [
  "cap-primitives",
  "cap-std",
@@ -333,9 +336,9 @@ dependencies = [
 
 [[package]]
 name = "cap-primitives"
-version = "4.0.2"
+version = "4.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdadbd7c002d3a484b35243669abdae85a0ebaded5a61117169dc3400f9a7ff0"
+checksum = "8b5f74729fd2f44701d1a8eb47e906cdb3ccd9ec0f02baad85a744b791940b18"
 dependencies = [
  "ambient-authority",
  "fs-set-times",
@@ -351,9 +354,9 @@ dependencies = [
 
 [[package]]
 name = "cap-std"
-version = "4.0.2"
+version = "4.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7281235d6e96d3544ca18bba9049be92f4190f8d923e3caef1b5f66cfa752608"
+checksum = "c1ec78e242cfa2cfe276807ac2ecc00315a6c97786977414bcd1c3963b6c91b8"
 dependencies = [
  "cap-primitives",
  "io-extras",
@@ -363,9 +366,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.67"
+version = "1.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e17dd265a7d0f31ef544e1b20e03add05d3b45b491b633b10d67145d2acc1a38"
+checksum = "0ad534f4357a5264cce5019c989cf66a4f0dc4e0d1b1d15f8aacec0ff7360273"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -453,9 +456,9 @@ dependencies = [
 
 [[package]]
 name = "crc32fast"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+checksum = "8498c871161e1742aaa9d52551b2d6ebdd4c3d45a3be423e3728f33b955be550"
 dependencies = [
  "cfg-if",
 ]
@@ -481,9 +484,9 @@ dependencies = [
 
 [[package]]
 name = "data-encoding"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
+checksum = "4583a4551df46e2792f82ceeac45e850d2e2d5debba0b91f102385cda5b11f06"
 
 [[package]]
 name = "deranged"
@@ -517,13 +520,13 @@ dependencies = [
 
 [[package]]
 name = "displaydoc"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
+checksum = "c6232dd377dcc64799954cbd3a9bb882e9cdc1308ccd87b1c098f1fb2eaf82a8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -534,9 +537,9 @@ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "either"
-version = "1.16.0"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
+checksum = "252afb9ae5eaa683babdc6a068b3f5726eb19e05070c731f9b2a23a7c3e8ed34"
 
 [[package]]
 name = "equivalent"
@@ -556,9 +559,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.4.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
 name = "filetime"
@@ -572,9 +575,9 @@ dependencies = [
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.9"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+checksum = "d45db016d36b838f563236e9193d0ee6ce38f3f68b6c94e914b4929c96bbb890"
 
 [[package]]
 name = "fixedbitset"
@@ -621,7 +624,7 @@ checksum = "94e7099f6313ecacbe1256e8ff9d617b75d1bcb16a6fddef94866d225a01a14a"
 dependencies = [
  "io-lifetimes 2.0.4",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -632,9 +635,9 @@ checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futures"
-version = "0.3.32"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+checksum = "9a31d2a3fbaaeb2af2368bbdd904aa8e812d3c04a1ee10d3171f52d556e5d0a3"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -663,9 +666,9 @@ checksum = "92d699e522242e69e3003b94ecc1f960f3a5e015aa7c5d7486e65ad01dd94f5e"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.32"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+checksum = "031b47cf1a3c6cc8bc2fc76cd437f521619387907d469316e7c0bc278f1f5432"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -686,7 +689,7 @@ checksum = "9fb9654ba8355388abeb8dcb4fc62f511300867002afc858860463bdd9fe0c44"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -752,6 +755,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "glob"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4eba85ea1d0a966a983acd07deee566e67395d2d96b6fb39e62b5a833f1eb0b"
+
+[[package]]
 name = "gomod-parser"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -762,9 +771,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.15"
+version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+checksum = "ef8e5e5a340588f4452631496976cf8636d4a7ecf600239fdc27615d2530bc16"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -862,9 +871,9 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
+checksum = "707114b52a152fa7bdb290cd7cd5912d9467273b6d74e21b8d81aca1f8533f6b"
 dependencies = [
  "typenum",
 ]
@@ -994,9 +1003,9 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
+checksum = "fa68d21081c4a05d5a901a1c62add574c77048b6a1c67be3b50ce0b60d4ca513"
 dependencies = [
  "displaydoc",
  "potential_utf",
@@ -1008,9 +1017,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locale_core"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
+checksum = "d56e28588da92eee5c3201a6eff33fabdd49b62269c8938d4ff050ce4d900deb"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -1021,9 +1030,9 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
+checksum = "12f9cf5f235641ed274641dd81c3f28d870e276763d0797aeeab72317b1c646f"
 dependencies = [
  "icu_collections",
  "icu_normalizer_data",
@@ -1035,16 +1044,17 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
+checksum = "1563da1ed3e0b3bf3d74c9b85917ac9c56464d2f57242270c09c9e752f8021a0"
 
 [[package]]
 name = "icu_properties"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
+checksum = "7e7ca276ad3145661a65914e6daf131ca5120cd3dcee8f8f3214b8875184a148"
 dependencies = [
+ "displaydoc",
  "icu_collections",
  "icu_locale_core",
  "icu_properties_data",
@@ -1055,15 +1065,15 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
+checksum = "e590f038c1464a96894fd6d10127e90a8be4509f56ff7ecef851b15cee0b7caa"
 
 [[package]]
 name = "icu_provider"
-version = "2.2.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
+checksum = "d27bbb9d3abbefac45d55f647c9de1d44aafcd1186eb91879afef17c396c3e73"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
@@ -1112,7 +1122,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20fd6de4ccfcc187e38bc21cfa543cb5a302cb86a8b114eb7f0bf0dc9f8ac00f"
 dependencies = [
  "io-lifetimes 3.0.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1129,9 +1139,9 @@ checksum = "2f0fb0570afe1fed943c5c3d4102d5358592d8625fda6a0007fdbe65a92fba96"
 
 [[package]]
 name = "ipnet"
-version = "2.12.0"
+version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+checksum = "6a756c3fac73139e83f14c2d742155dd2b78d3ee56597b419a0579b7bdd6dd78"
 
 [[package]]
 name = "itertools"
@@ -1160,9 +1170,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.103"
+version = "0.3.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
+checksum = "0e0c1080212aad755ea003d18543e8768dd432c48819efd73a7bf1e39b7a5a3a"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -1171,9 +1181,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.186"
+version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "linux-raw-sys"
@@ -1183,15 +1193,15 @@ checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
+checksum = "47d9d19d1d6efa0109d2f65ff4c85cddd50bd572e5a00127ab10987290bcefae"
 
 [[package]]
 name = "log"
-version = "0.4.33"
+version = "0.4.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
+checksum = "f9f8bd3e56ce4dfc153cf470fffbfa98c7620958b312ca5c3a4b8d5181fd13c6"
 
 [[package]]
 name = "matchit"
@@ -1285,9 +1295,9 @@ checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-integer"
-version = "0.1.46"
+version = "0.1.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+checksum = "7ce2d95d4b3734dc35aa2f45e1aa22cd416814592a4f9d9205e11affd5b8e10b"
 dependencies = [
  "num-traits",
 ]
@@ -1388,7 +1398,7 @@ checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1399,15 +1409,15 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+checksum = "f6b464fbc74e149a392436b17d523f769e057cb6877f6a5c4618bc6f11800548"
 
 [[package]]
 name = "potential_utf"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+checksum = "d83eb9bc6d8e5cf568e7a1101d60ee05e81ed50ea106026f3d18deeb046d7661"
 dependencies = [
  "zerovec",
 ]
@@ -1425,14 +1435,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.106"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
+checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
 dependencies = [
  "unicode-ident",
 ]
@@ -1464,7 +1474,7 @@ dependencies = [
  "pulldown-cmark",
  "pulldown-cmark-to-cmark",
  "regex",
- "syn 2.0.118",
+ "syn 2.0.119",
  "tempfile",
 ]
 
@@ -1478,7 +1488,7 @@ dependencies = [
  "itertools",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1567,18 +1577,18 @@ dependencies = [
 
 [[package]]
 name = "pulldown-cmark-to-cmark"
-version = "22.0.0"
+version = "22.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50793def1b900256624a709439404384204a5dc3a6ec580281bfaac35e882e90"
+checksum = "ab1ad36992cead65f02aa399a373a42730922f1525d988172634fdefdecb8a60"
 dependencies = [
  "pulldown-cmark",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.46"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
+checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
 dependencies = [
  "proc-macro2",
 ]
@@ -1608,9 +1618,9 @@ checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "regex"
-version = "1.13.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a0e75113e14dc5acb068cd0786884f214f1312650a3d36d269f5c4f3cdee8a2"
+checksum = "f020237b6c8eed93db2e2cb53c00c60a8e1bc73da7d073199a1180401450218d"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1620,9 +1630,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.15"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f388202e4b80542a0921078cc23b6333bcf1409c1e3f86404cae4766a6131db"
+checksum = "ad8553b9b26413251cbf30e620595c7a41b3887f03da04579c0e6b0d6a06b4b2"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1720,9 +1730,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.13"
+version = "0.103.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+checksum = "f3c3cf1d8b1e7d4927e2d154c3fcb02979afb9939629c62cd9048d4f07b60ac2"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -1807,7 +1817,7 @@ checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -1831,7 +1841,7 @@ checksum = "8d3b1629de253c70a0508c3899572da79ca359fdab27c7920ff00406df418906"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -1884,8 +1894,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -1912,9 +1922,9 @@ dependencies = [
 
 [[package]]
 name = "simd-adler32"
-version = "0.3.9"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
 
 [[package]]
 name = "slab"
@@ -1930,9 +1940,9 @@ checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "socket2"
-version = "0.6.4"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
+checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
@@ -1952,9 +1962,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.118"
+version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
+checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1963,9 +1973,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "3.0.3"
+version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
+checksum = "e6275cddf4610d1775e6d1fe9469b2e77d0f39fd98fb7450901b821e0c53649f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1986,7 +1996,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2040,7 +2050,7 @@ checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -2075,9 +2085,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
+checksum = "b1e27c91459209c2986af3dcf603a5a74a4368754ce37414f59acc971167f643"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -2101,13 +2111,13 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.7.0"
+version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
+checksum = "78773a2a397f451582ce068015985c33193cf6dea8b74d2a639fe457b2f07b0e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -2234,7 +2244,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2259,7 +2269,7 @@ dependencies = [
  "prost-build",
  "prost-types",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
  "tempfile",
  "tonic-build",
 ]
@@ -2314,7 +2324,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2447,9 +2457,9 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.126"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
+checksum = "1b70935747edd64d89de3efa29d73789b806c15798f8e7dca4d8ac356b50ce70"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -2460,9 +2470,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.126"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
+checksum = "77775f8f3f7217702089053b94958f8f54061a3f663417df76e19cbdcca29bc1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2470,22 +2480,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.126"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
+checksum = "e11d33f857dc2fb11b8bc75aee111aa9cbeb12cd9f25efd3d4c2a3dd4e235284"
 dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.126"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
+checksum = "7ef64dbcc55df09c7e5a46182d181c2cfa3e925f3da937ea764728b4bbb9dcbf"
 dependencies = [
  "unicode-ident",
 ]
@@ -2520,7 +2530,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2531,7 +2541,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2564,7 +2574,25 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
 ]
 
 [[package]]
@@ -2582,14 +2610,31 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -2599,10 +2644,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2611,10 +2668,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -2623,10 +2692,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -2635,10 +2716,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
@@ -2656,14 +2749,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f3fd376f71958b862e7afb20cfe5a22830e1963462f3a17f49d82a6c1d1f42d"
 dependencies = [
  "bitflags",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "writeable"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+checksum = "3ad82d2a33cdc9674dc7465672f271e096168fcdbe0f799d9e6db8c5892679dc"
 
 [[package]]
 name = "xattr"
@@ -2689,7 +2782,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.11.0",
  "tempfile",
  "toml",
  "tonic-prost-build",
@@ -2716,7 +2809,7 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
  "synstructure",
 ]
 
@@ -2752,7 +2845,7 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
  "synstructure",
 ]
 
@@ -2764,9 +2857,9 @@ checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 
 [[package]]
 name = "zerotrie"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
+checksum = "4ea269c3bd32f0a32c321907a2ae912ba6f4649bb0fc764a15627e99a7095a3f"
 dependencies = [
  "displaydoc",
  "yoke",
@@ -2775,9 +2868,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.6"
+version = "0.11.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
+checksum = "bb0464e17806c1d976d5cba29399c7f08e516e279e2ba493f63123b5fca67dd8"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -2786,13 +2879,13 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.3"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
+checksum = "34df6fc39dbd26ddc9c10e6a2984476e13acce22e64e4487636ef494369225da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 3.0.4",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -169,6 +169,15 @@ checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
 name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "block-buffer"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
@@ -214,6 +223,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "serde_urlencoded",
+ "sha2",
  "tar",
  "tempfile",
  "termion",
@@ -363,7 +373,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.3.0",
  "rand_core",
 ]
 
@@ -412,6 +422,15 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
@@ -426,6 +445,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
 ]
 
 [[package]]
@@ -454,13 +483,23 @@ dependencies = [
 
 [[package]]
 name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer 0.10.4",
+ "crypto-common 0.1.7",
+]
+
+[[package]]
+name = "digest"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
- "block-buffer",
+ "block-buffer 0.12.1",
  "const-oid",
- "crypto-common",
+ "crypto-common 0.2.2",
 ]
 
 [[package]]
@@ -664,6 +703,16 @@ dependencies = [
  "memchr",
  "pin-project-lite",
  "slab",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -1800,8 +1849,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -2350,6 +2410,12 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "want"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -195,6 +195,7 @@ dependencies = [
  "bollard-buildkit-proto 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bollard-stubs 1.53.1-rc.29.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes",
+ "cap-fs-ext",
  "cap-std",
  "chrono",
  "flate2",
@@ -317,6 +318,18 @@ name = "bytes"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
+
+[[package]]
+name = "cap-fs-ext"
+version = "4.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d78e5a3368ae89b7cb68186411452b4b9fac8b41be9c19bf3f47c2d2c8e36e6b"
+dependencies = [
+ "cap-primitives",
+ "cap-std",
+ "io-lifetimes 3.0.1",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "cap-primitives"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ members = [
 default = ["http", "pipe"]
 # Enable Buildkit-enabled docker image building
 buildkit = ["buildkit_providerless", "ssl"]
-buildkit_providerless = ["num", "rand", "tokio/fs", "tokio-stream", "tokio-util/io", "tonic", "tower-service", "ssl_providerless", "bollard-stubs/buildkit", "bollard-buildkit-proto", "dep:async-stream", "dep:bitflags", "dep:cap-std", "dep:cap-fs-ext"]
+buildkit_providerless = ["num", "rand", "tokio/fs", "tokio-stream", "tokio-util/io", "tonic", "tower-service", "ssl_providerless", "bollard-stubs/buildkit", "bollard-buildkit-proto", "dep:async-stream", "dep:bitflags", "dep:cap-std", "dep:cap-fs-ext", "dep:glob", "dep:regex", "dep:xattr"]
 # Enable tests specifically for the http connector
 test_http = []
 # Enable tests specifically for the ssh connector
@@ -102,6 +102,8 @@ async-stream = { version = "0.3.5", optional = true }
 bitflags = { version = "2.6.0", optional = true }
 cap-std = { version = "4.0", optional = true }
 cap-fs-ext = { version = "4.0", optional = true }
+glob = { version = "0.3", optional = true }
+regex = { version = "1.13", optional = true }
 
 [dev-dependencies]
 flate2 = "1.0"
@@ -115,6 +117,7 @@ once_cell = "1.19"
 tempfile = "3.27.0"
 
 [target.'cfg(unix)'.dependencies]
+xattr = { version = "1.6", optional = true }
 hyperlocal = { version = "0.9.0", optional = true }
 
 [target.'cfg(unix)'.dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ members = [
 default = ["http", "pipe"]
 # Enable Buildkit-enabled docker image building
 buildkit = ["buildkit_providerless", "ssl"]
-buildkit_providerless = ["num", "rand", "tokio/fs", "tokio-stream", "tokio-util/io", "tonic", "tower-service", "ssl_providerless", "bollard-stubs/buildkit", "bollard-buildkit-proto", "dep:async-stream", "dep:bitflags", "dep:cap-std"]
+buildkit_providerless = ["num", "rand", "tokio/fs", "tokio-stream", "tokio-util/io", "tonic", "tower-service", "ssl_providerless", "bollard-stubs/buildkit", "bollard-buildkit-proto", "dep:async-stream", "dep:bitflags", "dep:cap-std", "dep:cap-fs-ext"]
 # Enable tests specifically for the http connector
 test_http = []
 # Enable tests specifically for the ssh connector
@@ -101,6 +101,7 @@ webpki-roots = { version = "1.0", optional = true }
 async-stream = { version = "0.3.5", optional = true }
 bitflags = { version = "2.6.0", optional = true }
 cap-std = { version = "4.0", optional = true }
+cap-fs-ext = { version = "4.0", optional = true }
 
 [dev-dependencies]
 flate2 = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,6 +105,7 @@ cap-std = { version = "4.0", optional = true }
 [dev-dependencies]
 flate2 = "1.0"
 prost = "0.14"
+sha2 = "0.10"
 tar = "0.4"
 tokio = { version = "1.38", features = ["fs", "rt-multi-thread", "macros"] }
 tokio-util = { version = "0.7", features = ["io"] }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -76,6 +76,7 @@ test_script:
   - ps: Set-Item -path env:RUST_BACKTRACE -value 1
   - ps: Set-Item -path env:RUST_LOG -value "hyper=trace,bollard=debug"
   - ps: Set-Item -path env:REGISTRY_HTTP_ADDR -value localhost:5000
+  - cargo test --features buildkit_providerless,chrono --lib -- --nocapture --test-threads 1
   - cargo test --verbose --tests -- --nocapture --test-threads 1
   - ps: Set-Item -path env:DOCKER_HOST -value npipe:////./pipe/docker_engine
   - cargo test --verbose --tests -- --nocapture --test-threads 1 --test test_connect_with_defaults

--- a/src/grpc/build.rs
+++ b/src/grpc/build.rs
@@ -195,12 +195,13 @@ pub struct ImageBuildPlatform {
 
 impl Display for ImageBuildPlatform {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let prefix = Path::new(&self.os).join(Path::new(&self.architecture));
+        // OCI platform strings are always forward-slash separated, regardless
+        // of the host path separator.
+        write!(f, "{}/{}", self.os, self.architecture)?;
         if let Some(variant) = &self.variant {
-            write!(f, "{}", prefix.join(Path::new(&variant)).display())
-        } else {
-            write!(f, "{}", prefix.display())
+            write!(f, "/{variant}")?;
         }
+        Ok(())
     }
 }
 

--- a/src/grpc/driver/mod.rs
+++ b/src/grpc/driver/mod.rs
@@ -208,11 +208,19 @@ pub enum ImageExporterEnum {
 }
 
 /// Exporter selection for a direct LLB definition solve.
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 #[non_exhaustive]
 pub enum DefinitionExporter {
     /// Export the solved filesystem into a local directory.
     Local(PathBuf),
+}
+
+impl std::fmt::Debug for DefinitionExporter {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Local(_) => formatter.write_str("DefinitionExporter::Local(..)"),
+        }
+    }
 }
 
 /// Options for a direct LLB definition solve.
@@ -1406,6 +1414,27 @@ mod tests {
         assert!(!rendered.contains("registry.example"));
         assert!(rendered.contains("credential_count: 1"));
         assert!(rendered.contains("secret_count: 1"));
+    }
+
+    #[test]
+    fn definition_solve_request_debug_redacts_definition_and_export_path() {
+        let request = DefinitionSolveRequest::new(
+            bollard_buildkit_proto::pb::Definition {
+                def: vec![b"embedded command and environment".to_vec()],
+                metadata: [(String::from("private-metadata"), Default::default())]
+                    .into_iter()
+                    .collect(),
+                ..Default::default()
+            },
+            DefinitionExporter::Local(PathBuf::from("/private/export")),
+        );
+
+        let rendered = format!("{request:?}");
+        assert!(!rendered.contains("embedded command"));
+        assert!(!rendered.contains("private-metadata"));
+        assert!(!rendered.contains("/private/export"));
+        assert!(rendered.contains("definition_ops: 1"));
+        assert!(rendered.contains("definition_metadata: 1"));
     }
 
     #[test]

--- a/src/grpc/driver/mod.rs
+++ b/src/grpc/driver/mod.rs
@@ -1348,10 +1348,10 @@ mod tests {
             assert!(!rendered.contains("/sensitive-export-path"));
         }
 
-        assert!(builder_debug.contains("credentials: 1"));
-        assert!(builder_debug.contains("secrets: 1"));
-        assert!(options_debug.contains("credentials: 1"));
-        assert!(options_debug.contains("secrets: 1"));
+        assert!(builder_debug.contains("credential_count: 1"));
+        assert!(builder_debug.contains("secret_count: 1"));
+        assert!(options_debug.contains("credential_count: 1"));
+        assert!(options_debug.contains("secret_count: 1"));
         assert!(request_debug.contains("definition_ops: 1"));
         assert!(request_debug.contains("exporter: \"local\""));
         assert!(request_debug.contains("has_build_ref: false"));
@@ -1423,7 +1423,6 @@ mod tests {
         assert!(!rendered.contains("private-metadata"));
         assert!(!rendered.contains("/private/export"));
         assert!(rendered.contains("definition_ops: 1"));
-        assert!(rendered.contains("definition_metadata: 1"));
     }
 
     #[test]

--- a/src/grpc/driver/mod.rs
+++ b/src/grpc/driver/mod.rs
@@ -1328,6 +1328,9 @@ mod tests {
         let request = DefinitionSolveRequest::new(
             bollard_buildkit_proto::pb::Definition {
                 def: vec![b"sensitive-definition-bytes".to_vec()],
+                metadata: [(String::from("private-metadata"), Default::default())]
+                    .into_iter()
+                    .collect(),
                 ..Default::default()
             },
             DefinitionExporter::Local(PathBuf::from("/sensitive-export-path")),
@@ -1345,6 +1348,7 @@ mod tests {
             assert!(!rendered.contains("sensitive-secret-id"));
             assert!(!rendered.contains("sensitive-secret-source"));
             assert!(!rendered.contains("sensitive-definition-bytes"));
+            assert!(!rendered.contains("private-metadata"));
             assert!(!rendered.contains("/sensitive-export-path"));
         }
 
@@ -1381,48 +1385,6 @@ mod tests {
         assert!(options.ssh);
         assert_eq!(options.timeout, Some(Duration::from_secs(3)));
         assert_eq!(options.file_transfer_limits.max_files, Some(2));
-    }
-
-    #[test]
-    fn definition_options_debug_redacts_credentials_and_secrets() {
-        let options = DefinitionSolveOptionsBuilder::new()
-            .credential(
-                "registry.example",
-                DockerCredentials {
-                    username: Some(String::from("user")),
-                    password: Some(String::from("super-secret-password")),
-                    auth: Some(String::from("super-secret-auth")),
-                    ..Default::default()
-                },
-            )
-            .secret("token", SecretSource::Env(String::from("super-secret-env")))
-            .build();
-
-        let rendered = format!("{options:?}");
-        assert!(!rendered.contains("super-secret"));
-        assert!(!rendered.contains("registry.example"));
-        assert!(rendered.contains("credential_count: 1"));
-        assert!(rendered.contains("secret_count: 1"));
-    }
-
-    #[test]
-    fn definition_solve_request_debug_redacts_definition_and_export_path() {
-        let request = DefinitionSolveRequest::new(
-            bollard_buildkit_proto::pb::Definition {
-                def: vec![b"embedded command and environment".to_vec()],
-                metadata: [(String::from("private-metadata"), Default::default())]
-                    .into_iter()
-                    .collect(),
-                ..Default::default()
-            },
-            DefinitionExporter::Local(PathBuf::from("/private/export")),
-        );
-
-        let rendered = format!("{request:?}");
-        assert!(!rendered.contains("embedded command"));
-        assert!(!rendered.contains("private-metadata"));
-        assert!(!rendered.contains("/private/export"));
-        assert!(rendered.contains("definition_ops: 1"));
     }
 
     #[test]
@@ -1494,55 +1456,41 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn definition_solve_registers_shared_services_without_upload() {
-        let driver = failing_test_driver();
-        let service_names = Arc::clone(&driver.service_names);
-        let request = DefinitionSolveRequest::new(
-            bollard_buildkit_proto::pb::Definition::default(),
-            DefinitionExporter::Local(PathBuf::from("/out")),
-        )
-        .with_options(
-            DefinitionSolveOptionsBuilder::new()
-                .enable_ssh(true)
-                .build(),
-        );
+    async fn definition_solve_registers_expected_services() {
+        for with_local_mount in [false, true] {
+            let root = tempdir().expect("temporary local mount exists");
+            let driver = failing_test_driver();
+            let service_names = Arc::clone(&driver.service_names);
+            let mut options = DefinitionSolveOptionsBuilder::new().enable_ssh(true);
+            if with_local_mount {
+                options = options
+                    .local_mount("context", root.path())
+                    .expect("local mount opens");
+            }
+            let request = DefinitionSolveRequest::new(
+                bollard_buildkit_proto::pb::Definition::default(),
+                DefinitionExporter::Local(PathBuf::from("/out")),
+            )
+            .with_options(options.build());
 
-        assert!(solve_definition(&driver, request).await.is_err());
-        let names = service_names.lock().unwrap();
-        assert!(names.iter().any(|name| name.contains("credentials")));
-        assert!(names.iter().any(|name| name.contains("GetSecret")));
-        assert!(names.iter().any(|name| name.contains("ForwardAgent")));
-        assert!(names.iter().any(|name| name.contains("diffcopy")));
-        assert!(!names.iter().any(|name| name.contains("upload")));
-        assert!(!names
-            .iter()
-            .any(|name| name == "/moby.filesync.v1.FileSync/DiffCopy"));
-    }
-
-    #[tokio::test]
-    async fn definition_solve_registers_filesync_for_local_mounts() {
-        let root = tempdir().expect("temporary local mount exists");
-        let driver = failing_test_driver();
-        let service_names = Arc::clone(&driver.service_names);
-        let request = DefinitionSolveRequest::new(
-            bollard_buildkit_proto::pb::Definition::default(),
-            DefinitionExporter::Local(PathBuf::from("/out")),
-        )
-        .with_options(
-            DefinitionSolveOptionsBuilder::new()
-                .local_mount("context", root.path())
-                .expect("local mount opens")
-                .build(),
-        );
-
-        assert!(solve_definition(&driver, request).await.is_err());
-        let names = service_names.lock().unwrap();
-        assert!(names
-            .iter()
-            .any(|name| name == "/moby.filesync.v1.FileSync/DiffCopy"));
-        assert!(!names
-            .iter()
-            .any(|name| name == "/moby.filesync.v1.FileSync/TarStream"));
+            assert!(solve_definition(&driver, request).await.is_err());
+            let names = service_names.lock().unwrap();
+            assert!(names.iter().any(|name| name.contains("credentials")));
+            assert!(names.iter().any(|name| name.contains("GetSecret")));
+            assert!(names.iter().any(|name| name.contains("ForwardAgent")));
+            assert!(names.iter().any(|name| name.contains("diffcopy")));
+            assert!(!names.iter().any(|name| name.contains("upload")));
+            assert_eq!(
+                names
+                    .iter()
+                    .filter(|name| name.as_str() == "/moby.filesync.v1.FileSync/DiffCopy")
+                    .count(),
+                usize::from(with_local_mount)
+            );
+            assert!(!names
+                .iter()
+                .any(|name| name == "/moby.filesync.v1.FileSync/TarStream"));
+        }
     }
 
     #[tokio::test]

--- a/src/grpc/driver/mod.rs
+++ b/src/grpc/driver/mod.rs
@@ -267,21 +267,6 @@ impl std::fmt::Debug for LocalMount {
     }
 }
 
-impl fmt::Debug for DefinitionSolveOptions {
-    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        formatter
-            .debug_struct("DefinitionSolveOptions")
-            .field("cache_to", &self.cache_to.len())
-            .field("cache_from", &self.cache_from.len())
-            .field("credentials", &self.credentials.len())
-            .field("secrets", &self.secrets.len())
-            .field("ssh", &self.ssh)
-            .field("timeout", &self.timeout)
-            .field("file_transfer_limits", &self.file_transfer_limits)
-            .finish()
-    }
-}
-
 impl Default for DefinitionSolveOptions {
     fn default() -> Self {
         Self {

--- a/src/grpc/driver/mod.rs
+++ b/src/grpc/driver/mod.rs
@@ -8,7 +8,10 @@ use bollard_buildkit_proto::moby::{
     },
     filesync::{
         packet::file_send_server::FileSendServer as FileSendPacketServer,
-        v1::{auth_server::AuthServer, file_send_server::FileSendServer},
+        v1::{
+            auth_server::AuthServer, file_send_server::FileSendServer,
+            file_sync_server::FileSyncServer,
+        },
     },
     sshforward::v1::ssh_server::SshServer,
     upload::v1::upload_server::UploadServer,
@@ -235,6 +238,22 @@ pub struct DefinitionSolveOptions {
     ssh: bool,
     timeout: Option<Duration>,
     file_transfer_limits: FileTransferLimits,
+    local_mounts: HashMap<String, LocalMount>,
+}
+
+#[derive(Clone)]
+pub(crate) struct LocalMount {
+    pub(crate) root: Arc<cap_std::fs::Dir>,
+    pub(crate) path: PathBuf,
+}
+
+impl std::fmt::Debug for LocalMount {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("LocalMount")
+            .field("path", &self.path)
+            .finish_non_exhaustive()
+    }
 }
 
 impl fmt::Debug for DefinitionSolveOptions {
@@ -262,6 +281,7 @@ impl Default for DefinitionSolveOptions {
             ssh: false,
             timeout: Some(DEFAULT_DEFINITION_SOLVE_TIMEOUT),
             file_transfer_limits: FileTransferLimits::default(),
+            local_mounts: HashMap::new(),
         }
     }
 }
@@ -332,6 +352,39 @@ impl DefinitionSolveOptionsBuilder {
     pub fn max_bytes(mut self, max_bytes: u64) -> Self {
         self.options.file_transfer_limits.max_bytes = Some(max_bytes);
         self
+    }
+
+    /// Expose a host directory under a BuildKit `local://` source name.
+    pub fn local_mount(
+        mut self,
+        name: impl Into<String>,
+        path: impl Into<PathBuf>,
+    ) -> Result<Self, GrpcError> {
+        let name = name.into();
+        let path = path.into();
+        if name.is_empty() {
+            return Err(GrpcError::InvalidLocalMount {
+                name,
+                path,
+                reason: String::from("mount name must not be empty"),
+            });
+        }
+
+        let root = cap_std::fs::Dir::open_ambient_dir(&path, cap_std::ambient_authority())
+            .map_err(|error| GrpcError::InvalidLocalMount {
+                name: name.clone(),
+                path: path.clone(),
+                reason: error.to_string(),
+            })?;
+
+        self.options.local_mounts.insert(
+            name,
+            LocalMount {
+                root: Arc::new(root),
+                path,
+            },
+        );
+        Ok(self)
     }
 
     /// Consume the builder and return immutable solve options.
@@ -650,6 +703,18 @@ pub(crate) async fn solve_definition(
         services.push(GrpcServer::Ssh(ssh));
     }
 
+    if !options.local_mounts.is_empty() {
+        let mounts = options
+            .local_mounts
+            .iter()
+            .map(|(name, mount)| (name.clone(), Arc::clone(&mount.root)))
+            .collect();
+        let filesync = FileSyncServer::new(super::filesync::FileSyncImpl::new(mounts))
+            .max_decoding_message_size(DEFAULT_MAX_RECV_MSG_SIZE)
+            .max_encoding_message_size(DEFAULT_MAX_SEND_MSG_SIZE);
+        services.push(GrpcServer::FileSync(filesync));
+    }
+
     match &exporter {
         DefinitionExporter::Local(path) => {
             let filesend = FileSendPacketServer::new(super::FileSendPacketImpl::with_limits(
@@ -837,6 +902,7 @@ mod tests {
         UpdateBuildHistoryResponse, UsageRecord,
     };
     use futures_util::{stream::Empty, FutureExt};
+    use tempfile::tempdir;
     use tokio::{
         net::TcpListener,
         sync::{oneshot, Notify},
@@ -1318,6 +1384,45 @@ mod tests {
     }
 
     #[test]
+    fn definition_options_open_and_retain_local_mount_capabilities() {
+        let root = tempdir().expect("temporary local mount exists");
+        let path = root.path().to_path_buf();
+        let options = DefinitionSolveOptionsBuilder::new()
+            .local_mount("context", &path)
+            .expect("local mount opens")
+            .build();
+
+        let mount = options
+            .local_mounts
+            .get("context")
+            .expect("local mount is stored");
+        assert_eq!(mount.path, path);
+        assert!(mount.root.open_dir(".").is_ok());
+    }
+
+    #[test]
+    fn local_mount_rejects_empty_missing_and_non_directory_paths() {
+        let root = tempdir().expect("temporary local mount exists");
+        let file = root.path().join("file");
+        std::fs::write(&file, b"not a directory").expect("temporary file is created");
+
+        let empty_name = DefinitionSolveOptionsBuilder::new()
+            .local_mount("", root.path())
+            .expect_err("empty mount names are rejected");
+        assert!(matches!(empty_name, GrpcError::InvalidLocalMount { .. }));
+
+        let missing_path = DefinitionSolveOptionsBuilder::new()
+            .local_mount("context", root.path().join("missing"))
+            .expect_err("missing mount paths are rejected");
+        assert!(matches!(missing_path, GrpcError::InvalidLocalMount { .. }));
+
+        let regular_file = DefinitionSolveOptionsBuilder::new()
+            .local_mount("context", &file)
+            .expect_err("regular files are rejected as mount roots");
+        assert!(matches!(regular_file, GrpcError::InvalidLocalMount { .. }));
+    }
+
+    #[test]
     fn definition_options_have_a_bounded_default_timeout() {
         assert_eq!(
             DefinitionSolveOptions::default().timeout,
@@ -1367,6 +1472,32 @@ mod tests {
         assert!(names.iter().any(|name| name.contains("ForwardAgent")));
         assert!(names.iter().any(|name| name.contains("diffcopy")));
         assert!(!names.iter().any(|name| name.contains("upload")));
+    }
+
+    #[tokio::test]
+    async fn definition_solve_registers_filesync_for_local_mounts() {
+        let root = tempdir().expect("temporary local mount exists");
+        let driver = failing_test_driver();
+        let service_names = Arc::clone(&driver.service_names);
+        let request = DefinitionSolveRequest::new(
+            bollard_buildkit_proto::pb::Definition::default(),
+            DefinitionExporter::Local(PathBuf::from("/out")),
+        )
+        .with_options(
+            DefinitionSolveOptionsBuilder::new()
+                .local_mount("context", root.path())
+                .expect("local mount opens")
+                .build(),
+        );
+
+        assert!(solve_definition(&driver, request).await.is_err());
+        let names = service_names.lock().unwrap();
+        assert!(names
+            .iter()
+            .any(|name| name == "/moby.filesync.v1.FileSync/DiffCopy"));
+        assert!(!names
+            .iter()
+            .any(|name| name == "/moby.filesync.v1.FileSync/TarStream"));
     }
 
     #[tokio::test]

--- a/src/grpc/driver/mod.rs
+++ b/src/grpc/driver/mod.rs
@@ -72,6 +72,12 @@ pub(crate) trait Driver {
     fn begin_solve(&self) -> Result<Box<dyn DriverTearDownHandler>, GrpcError>;
 }
 
+/// Cleans up driver resources created for a solve.
+///
+/// Implementations must be idempotent: when a solve future is cancelled while
+/// teardown is in flight, the guard retries teardown once from a fresh
+/// runtime, so `tear_down` may observe partially torn-down state or run more
+/// than once for the same solve.
 pub(crate) trait DriverTearDownHandler: Send + Sync {
     fn tear_down(
         &self,
@@ -80,11 +86,9 @@ pub(crate) trait DriverTearDownHandler: Send + Sync {
 
 struct TearDownGuard {
     handler: Arc<dyn DriverTearDownHandler>,
-    runtime: tokio::runtime::Handle,
-    task: Option<tokio::task::JoinHandle<Result<(), GrpcError>>>,
     timeout: Duration,
     armed: bool,
-    started: bool,
+    completed: bool,
 }
 
 impl TearDownGuard {
@@ -95,11 +99,9 @@ impl TearDownGuard {
     fn with_timeout(handler: Box<dyn DriverTearDownHandler>, timeout: Duration) -> Self {
         Self {
             handler: Arc::from(handler),
-            runtime: tokio::runtime::Handle::current(),
-            task: None,
             timeout,
             armed: true,
-            started: false,
+            completed: false,
         }
     }
 
@@ -107,27 +109,13 @@ impl TearDownGuard {
         self.armed = false;
     }
 
-    fn start(&mut self) {
-        if self.started {
-            return;
-        }
-
-        self.started = true;
-        let handler = Arc::clone(&self.handler);
-        self.task = Some(self.runtime.spawn(run_tear_down(handler, self.timeout)));
-    }
-
     async fn tear_down(&mut self) -> Result<(), GrpcError> {
-        self.start();
-        let result = {
-            let task = self
-                .task
-                .as_mut()
-                .ok_or_else(|| GrpcError::TearDownTaskUnavailable)?;
-            task.await
-        };
-        self.task.take();
-        result.map_err(|error| tonic::Status::internal(format!("teardown task failed: {error}")))?
+        if self.completed {
+            return Err(GrpcError::TearDownTaskUnavailable);
+        }
+        let result = run_tear_down(Arc::clone(&self.handler), self.timeout).await;
+        self.completed = true;
+        result
     }
 }
 
@@ -135,17 +123,11 @@ async fn run_tear_down(
     handler: Arc<dyn DriverTearDownHandler>,
     timeout: Duration,
 ) -> Result<(), GrpcError> {
-    let mut task = tokio::spawn(async move { handler.tear_down().await });
-    match tokio::time::timeout(timeout, &mut task).await {
-        Ok(result) => result
-            .map_err(|error| tonic::Status::internal(format!("teardown task failed: {error}")))?,
-        Err(_) => {
-            task.abort();
-            let _ = task.await;
-            Err(GrpcError::from(tonic::Status::deadline_exceeded(
-                "driver teardown exceeded its timeout",
-            )))
-        }
+    match tokio::time::timeout(timeout, handler.tear_down()).await {
+        Ok(result) => result,
+        Err(_) => Err(GrpcError::from(tonic::Status::deadline_exceeded(
+            "driver teardown exceeded its timeout",
+        ))),
     }
 }
 
@@ -155,28 +137,33 @@ impl Drop for TearDownGuard {
             return;
         }
 
-        if let Some(task) = self.task.take() {
-            self.runtime.spawn(async move {
-                match task.await {
-                    Ok(Ok(())) => {}
-                    Ok(Err(error)) => {
-                        warn!("failed to tear down BuildKit driver after cancellation: {error}");
+        if self.completed {
+            return;
+        }
+
+        let handler = Arc::clone(&self.handler);
+        let timeout = self.timeout;
+        let thread = std::thread::Builder::new()
+            .name(String::from("bollard-buildkit-teardown"))
+            .spawn(move || {
+                let runtime = tokio::runtime::Builder::new_current_thread()
+                    .enable_all()
+                    .build();
+                match runtime {
+                    Ok(runtime) => {
+                        if let Err(error) = runtime.block_on(run_tear_down(handler, timeout)) {
+                            warn!(
+                                "failed to tear down BuildKit driver after cancellation: {error}"
+                            );
+                        }
                     }
                     Err(error) => {
-                        warn!(
-                            "failed to join BuildKit driver teardown after cancellation: {error}"
-                        );
+                        warn!("failed to create BuildKit teardown runtime: {error}");
                     }
                 }
             });
-        } else if !self.started {
-            let handler = Arc::clone(&self.handler);
-            let timeout = self.timeout;
-            self.runtime.spawn(async move {
-                if let Err(error) = run_tear_down(handler, timeout).await {
-                    warn!("failed to tear down BuildKit driver after cancellation: {error}");
-                }
-            });
+        if let Err(error) = thread {
+            warn!("failed to spawn BuildKit teardown thread: {error}");
         }
     }
 }
@@ -239,6 +226,22 @@ pub struct DefinitionSolveOptions {
     timeout: Option<Duration>,
     file_transfer_limits: FileTransferLimits,
     local_mounts: HashMap<String, LocalMount>,
+}
+
+impl std::fmt::Debug for DefinitionSolveOptions {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("DefinitionSolveOptions")
+            .field("cache_to_count", &self.cache_to.len())
+            .field("cache_from_count", &self.cache_from.len())
+            .field("credential_count", &self.credentials.len())
+            .field("secret_count", &self.secrets.len())
+            .field("ssh", &self.ssh)
+            .field("timeout", &self.timeout)
+            .field("file_transfer_limits", &self.file_transfer_limits)
+            .field("local_mount_count", &self.local_mounts.len())
+            .finish()
+    }
 }
 
 #[derive(Clone)]
@@ -1384,6 +1387,28 @@ mod tests {
     }
 
     #[test]
+    fn definition_options_debug_redacts_credentials_and_secrets() {
+        let options = DefinitionSolveOptionsBuilder::new()
+            .credential(
+                "registry.example",
+                DockerCredentials {
+                    username: Some(String::from("user")),
+                    password: Some(String::from("super-secret-password")),
+                    auth: Some(String::from("super-secret-auth")),
+                    ..Default::default()
+                },
+            )
+            .secret("token", SecretSource::Env(String::from("super-secret-env")))
+            .build();
+
+        let rendered = format!("{options:?}");
+        assert!(!rendered.contains("super-secret"));
+        assert!(!rendered.contains("registry.example"));
+        assert!(rendered.contains("credential_count: 1"));
+        assert!(rendered.contains("secret_count: 1"));
+    }
+
+    #[test]
     fn definition_options_open_and_retain_local_mount_capabilities() {
         let root = tempdir().expect("temporary local mount exists");
         let path = root.path().to_path_buf();
@@ -1615,6 +1640,66 @@ mod tests {
         assert!(session_ids[..2]
             .iter()
             .all(|session_id| !session_ids[2..].contains(session_id)));
+    }
+
+    #[test]
+    fn teardown_guard_drop_survives_runtime_shutdown() {
+        let calls = Arc::new(AtomicUsize::new(0));
+        let guard = {
+            let runtime = tokio::runtime::Runtime::new().unwrap();
+            runtime.block_on(async {
+                TearDownGuard::new(Box::new(TestTearDown {
+                    calls: Arc::clone(&calls),
+                    error: None,
+                    started: None,
+                }))
+            })
+        };
+
+        drop(guard);
+        let deadline = std::time::Instant::now() + Duration::from_secs(1);
+        while std::time::Instant::now() < deadline {
+            if calls.load(Ordering::SeqCst) == 1 {
+                return;
+            }
+            std::thread::sleep(Duration::from_millis(10));
+        }
+        panic!("teardown cleanup did not start after runtime shutdown");
+    }
+
+    #[tokio::test]
+    async fn teardown_guard_retries_cleanup_cancelled_in_progress() {
+        let calls = Arc::new(AtomicUsize::new(0));
+        let started = Arc::new(Notify::new());
+        let guard = TearDownGuard::with_timeout(
+            Box::new(BlockingTearDown {
+                calls: Arc::clone(&calls),
+                started: Arc::clone(&started),
+                cancelled: Arc::new(AtomicBool::new(false)),
+            }),
+            Duration::from_millis(10),
+        );
+        let task = tokio::spawn(async move {
+            let mut guard = guard;
+            let _ = guard.tear_down().await;
+        });
+
+        tokio::time::timeout(Duration::from_secs(1), started.notified())
+            .await
+            .expect("initial teardown starts");
+        task.abort();
+        let _ = task.await;
+
+        tokio::time::timeout(Duration::from_secs(1), async {
+            loop {
+                if calls.load(Ordering::SeqCst) == 2 {
+                    break;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("cancelled teardown is retried once");
     }
 
     #[tokio::test]

--- a/src/grpc/driver/mod.rs
+++ b/src/grpc/driver/mod.rs
@@ -1497,6 +1497,9 @@ mod tests {
         assert!(names.iter().any(|name| name.contains("ForwardAgent")));
         assert!(names.iter().any(|name| name.contains("diffcopy")));
         assert!(!names.iter().any(|name| name.contains("upload")));
+        assert!(!names
+            .iter()
+            .any(|name| name == "/moby.filesync.v1.FileSync/DiffCopy"));
     }
 
     #[tokio::test]

--- a/src/grpc/driver/mod.rs
+++ b/src/grpc/driver/mod.rs
@@ -1483,7 +1483,7 @@ mod tests {
             assert_eq!(
                 names
                     .iter()
-                    .filter(|name| name.as_str() == "/moby.filesync.v1.FileSync/DiffCopy")
+                    .filter(|name| name.as_str() == "/moby.filesync.v1.FileSync/diffcopy")
                     .count(),
                 usize::from(with_local_mount)
             );

--- a/src/grpc/driver/mod.rs
+++ b/src/grpc/driver/mod.rs
@@ -366,6 +366,10 @@ impl DefinitionSolveOptionsBuilder {
     }
 
     /// Expose a host directory under a BuildKit `local://` source name.
+    ///
+    /// On Windows, local-source paths remain subject to the host's long-path
+    /// configuration and the underlying filesystem runtime. Enable Windows
+    /// long-path support when exposing deeply nested directories.
     pub fn local_mount(
         mut self,
         name: impl Into<String>,

--- a/src/grpc/error.rs
+++ b/src/grpc/error.rs
@@ -35,8 +35,8 @@ pub enum GrpcError {
         /// The Docker-container builder name.
         name: String,
     },
-    /// The driver teardown task was unavailable when cleanup was requested.
-    #[error("driver teardown task was unavailable")]
+    /// The driver teardown already ran when cleanup was requested again.
+    #[error("driver teardown was already completed")]
     TearDownTaskUnavailable,
     /// Generic error emitted by the bollard codebase.
     #[error(transparent)]

--- a/src/grpc/error.rs
+++ b/src/grpc/error.rs
@@ -1,10 +1,20 @@
 #![cfg(feature = "buildkit_providerless")]
 
-use std::num::TryFromIntError;
+use std::{num::TryFromIntError, path::PathBuf};
 
 /// Errors related to the Grpc functionality
 #[derive(Debug, thiserror::Error)]
 pub enum GrpcError {
+    /// A named local source mount could not be opened as a directory.
+    #[error("invalid local mount `{name}` at `{path}`: {reason}")]
+    InvalidLocalMount {
+        /// The BuildKit local source name.
+        name: String,
+        /// The path supplied by the caller.
+        path: PathBuf,
+        /// The validation or opening failure.
+        reason: String,
+    },
     /// A Docker-container BuildKit resource exists but does not match the requested builder.
     #[error("BuildKit Docker-container {resource} `{name}` is incompatible: {reason}")]
     DockerContainerResourceConflict {

--- a/src/grpc/filesync.rs
+++ b/src/grpc/filesync.rs
@@ -1577,98 +1577,6 @@ use tokio_stream::wrappers::{ReceiverStream, TcpListenerStream};
 use tonic::transport::Server;
 
 #[cfg(test)]
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub(crate) struct ContractEntry {
-    pub(crate) path: &'static str,
-    pub(crate) regular: bool,
-}
-
-#[cfg(test)]
-#[derive(Clone, Debug)]
-pub(crate) struct PacketContract {
-    entries: Vec<ContractEntry>,
-}
-
-#[cfg(test)]
-impl PacketContract {
-    pub(crate) fn new(entries: impl IntoIterator<Item = ContractEntry>) -> Self {
-        Self {
-            entries: entries.into_iter().collect(),
-        }
-    }
-
-    pub(crate) fn stat_packets(&self) -> Vec<Packet> {
-        self.entries
-            .iter()
-            .map(|entry| stat_packet(entry.path))
-            .chain(std::iter::once(stat_packet_without_entry()))
-            .collect()
-    }
-
-    pub(crate) fn validate_stat_packets(&self, packets: &[Packet]) -> Result<(), String> {
-        if packets.len() != self.entries.len() + 1 {
-            return Err(format!(
-                "expected {} STAT packets, got {}",
-                self.entries.len() + 1,
-                packets.len()
-            ));
-        }
-
-        for (index, (packet, expected)) in packets.iter().zip(self.entries.iter()).enumerate() {
-            if packet.r#type != PacketType::PacketStat as i32 {
-                return Err(format!("packet {index} is not PACKET_STAT"));
-            }
-            if packet.id != 0 {
-                return Err(format!("packet {index} has non-zero STAT ID"));
-            }
-            if packet.stat.as_ref().map(|stat| stat.path.as_str()) != Some(expected.path) {
-                return Err(format!("packet {index} has the wrong path"));
-            }
-        }
-
-        let terminator = packets.last().expect("length checked above");
-        if terminator.r#type != PacketType::PacketStat as i32
-            || terminator.id != 0
-            || terminator.stat.is_some()
-        {
-            return Err(String::from("STAT terminator is malformed"));
-        }
-        Ok(())
-    }
-
-    pub(crate) fn regular_ids(&self) -> HashSet<u32> {
-        self.entries
-            .iter()
-            .enumerate()
-            .filter_map(|(index, entry)| entry.regular.then_some(index as u32))
-            .collect()
-    }
-}
-
-#[cfg(test)]
-#[derive(Debug)]
-pub(crate) struct RequestLedger {
-    available: HashSet<u32>,
-}
-
-#[cfg(test)]
-impl RequestLedger {
-    pub(crate) fn new(contract: &PacketContract) -> Self {
-        Self {
-            available: contract.regular_ids(),
-        }
-    }
-
-    pub(crate) fn accept(&mut self, id: u32) -> Result<(), String> {
-        if self.available.remove(&id) {
-            Ok(())
-        } else {
-            Err(format!("invalid or repeated file request {id}"))
-        }
-    }
-}
-
-#[cfg(test)]
 pub(crate) fn stat_packet(path: &'static str) -> Packet {
     Packet {
         r#type: PacketType::PacketStat as i32,
@@ -1676,14 +1584,6 @@ pub(crate) fn stat_packet(path: &'static str) -> Packet {
             path: path.to_owned(),
             ..Default::default()
         }),
-        ..Default::default()
-    }
-}
-
-#[cfg(test)]
-pub(crate) fn stat_packet_without_entry() -> Packet {
-    Packet {
-        r#type: PacketType::PacketStat as i32,
         ..Default::default()
     }
 }
@@ -1744,44 +1644,6 @@ pub(crate) fn collect_file_data(packets: &[Packet], id: u32) -> Result<Vec<u8>, 
         Ok(data)
     } else {
         Err(format!("file {id} has no DATA EOF"))
-    }
-}
-
-#[cfg(test)]
-pub(crate) struct ScriptedPeer {
-    requests: mpsc::Sender<Packet>,
-    responses: Pin<Box<dyn Stream<Item = Result<Packet, Status>> + Send>>,
-}
-
-#[cfg(test)]
-impl ScriptedPeer {
-    pub(crate) fn new(
-        responses: impl Stream<Item = Result<Packet, Status>> + Send + 'static,
-    ) -> (Self, ReceiverStream<Packet>) {
-        let (requests, receiver) = mpsc::channel(OUTPUT_QUEUE_CAPACITY);
-        (
-            Self {
-                requests,
-                responses: Box::pin(responses),
-            },
-            ReceiverStream::new(receiver),
-        )
-    }
-
-    pub(crate) async fn send(&self, packet: Packet) -> Result<(), String> {
-        self.requests
-            .send(packet)
-            .await
-            .map_err(|_| String::from("scripted peer request channel closed"))
-    }
-
-    pub(crate) async fn next(&mut self) -> Option<Result<Packet, Status>> {
-        futures_util::StreamExt::next(&mut self.responses).await
-    }
-
-    pub(crate) fn close(self) {
-        drop(self.requests);
-        drop(self.responses);
     }
 }
 
@@ -1939,7 +1801,6 @@ async fn expect_protocol_error(responses: &mut Streaming<Packet>) -> tonic::Stat
 #[cfg(test)]
 mod tests {
     use super::*;
-    use futures_util::StreamExt;
     use tempfile::tempdir;
 
     fn open_mount(path: &Path) -> Arc<cap_std::fs::Dir> {
@@ -1961,94 +1822,6 @@ mod tests {
             .expect("fixture scanner joins")
             .expect("fixture scanner succeeds");
         entries
-    }
-
-    fn sample_contract() -> PacketContract {
-        PacketContract::new([
-            ContractEntry {
-                path: "directory",
-                regular: false,
-            },
-            ContractEntry {
-                path: "directory/input.txt",
-                regular: true,
-            },
-            ContractEntry {
-                path: "link",
-                regular: false,
-            },
-            ContractEntry {
-                path: "empty.txt",
-                regular: true,
-            },
-        ])
-    }
-
-    #[test]
-    fn contract_tracks_positional_regular_file_ids() {
-        let contract = sample_contract();
-        contract
-            .validate_stat_packets(&contract.stat_packets())
-            .expect("fixture STAT packets are valid");
-        assert_eq!(contract.regular_ids(), HashSet::from([1, 3]));
-    }
-
-    #[test]
-    fn contract_requires_zero_stat_packet_ids() {
-        let contract = sample_contract();
-        let mut packets = contract.stat_packets();
-        packets[1].id = 1;
-        assert!(contract.validate_stat_packets(&packets).is_err());
-    }
-
-    #[test]
-    fn request_ledger_rejects_duplicate_unknown_and_non_regular_ids() {
-        let contract = sample_contract();
-        let mut ledger = RequestLedger::new(&contract);
-        assert!(ledger.accept(1).is_ok());
-        assert!(ledger.accept(1).is_err());
-        assert!(ledger.accept(0).is_err());
-        assert!(ledger.accept(99).is_err());
-    }
-
-    #[test]
-    fn data_collection_requires_one_empty_eof_packet() {
-        let packets = [
-            data_packet(1, b"first".to_vec()),
-            data_packet(3, b"other".to_vec()),
-            data_packet(1, b"second".to_vec()),
-            data_packet(1, Vec::new()),
-            data_packet(3, Vec::new()),
-        ];
-        assert_eq!(collect_file_data(&packets, 1).unwrap(), b"firstsecond");
-        assert_eq!(collect_file_data(&packets, 3).unwrap(), b"other");
-    }
-
-    #[test]
-    fn protocol_bounds_are_fixed_before_sender_implementation() {
-        assert_eq!(ENTRY_QUEUE_CAPACITY, 128);
-        assert_eq!(FILE_JOB_QUEUE_CAPACITY, 128);
-        assert_eq!(OUTPUT_QUEUE_CAPACITY, 16);
-        assert_eq!(FILE_WORKER_COUNT, 4);
-        assert_eq!(FILE_READ_BUFFER_SIZE, 32 * 1024);
-    }
-
-    #[tokio::test]
-    async fn scripted_peer_uses_bounded_request_and_response_channels() {
-        let (mut peer, mut requests) =
-            ScriptedPeer::new(stream::iter([Ok(data_packet(1, b"response".to_vec()))]));
-        peer.send(request_packet(1))
-            .await
-            .expect("scripted peer accepts requests");
-        assert_eq!(requests.next().await, Some(request_packet(1)));
-        assert_eq!(
-            peer.next()
-                .await
-                .expect("scripted response exists")
-                .unwrap(),
-            data_packet(1, b"response".to_vec())
-        );
-        peer.close();
     }
 
     #[tokio::test]
@@ -2337,15 +2110,6 @@ mod tests {
         );
     }
 
-    #[cfg(unix)]
-    #[test]
-    fn scanner_filters_privileged_xattr_names() {
-        assert!(super::super::fsutil::is_transferable_xattr("user.bollard"));
-        assert!(!super::super::fsutil::is_transferable_xattr(
-            "security.capability"
-        ));
-    }
-
     #[test]
     fn metadata_decodes_encoded_values() {
         let mut metadata = MetadataMap::new();
@@ -2627,86 +2391,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn diff_copy_accepts_pipelined_requests() {
-        let root = tempdir().expect("temporary directory is created");
-        std::fs::write(root.path().join("a"), b"a").expect("a is created");
-        std::fs::write(root.path().join("b"), b"b").expect("b is created");
-        let (sender, mut responses, shutdown, server) =
-            open_filesync_transfer(open_mount(root.path())).await;
-        let stats = read_stat_terminator(&mut responses).await;
-        assert_eq!(stats.len(), 3);
-        sender.send(request_packet(0)).await.expect("request sends");
-        sender.send(request_packet(1)).await.expect("request sends");
-        sender.send(fin_packet()).await.expect("FIN sends");
-        let mut data = Vec::new();
-        let mut eof = HashSet::new();
-        while eof.len() < 2 {
-            let packet = responses
-                .message()
-                .await
-                .expect("DATA succeeds")
-                .expect("DATA exists");
-            assert_eq!(packet.r#type, PacketType::PacketData as i32);
-            if packet.data.is_empty() {
-                eof.insert(packet.id);
-            } else {
-                data.push(packet);
-            }
-        }
-        assert_eq!(data.len(), 2);
-        assert_eq!(
-            responses.message().await.unwrap().unwrap().r#type,
-            PacketType::PacketFin as i32
-        );
-        let _ = shutdown.send(());
-        let _ = server.await;
-    }
-
-    #[tokio::test]
-    async fn diff_copy_reports_peer_protocol_errors() {
-        let root = tempdir().expect("temporary directory is created");
-        std::fs::write(root.path().join("input"), b"source").expect("source is created");
-        let (sender, mut responses, shutdown, server) =
-            open_filesync_transfer(open_mount(root.path())).await;
-        read_stat_terminator(&mut responses).await;
-        sender
-            .send(err_packet("peer failure"))
-            .await
-            .expect("ERR sends");
-        assert_eq!(
-            expect_protocol_error(&mut responses).await.code(),
-            tonic::Code::Aborted
-        );
-        let _ = shutdown.send(());
-        let _ = server.await;
-    }
-
-    #[tokio::test]
-    async fn diff_copy_streams_data_and_fin() {
-        let root = tempdir().expect("temporary directory is created");
-        std::fs::write(root.path().join("input"), b"source").expect("source is created");
-        let (sender, mut responses, shutdown, server) =
-            open_filesync_transfer(open_mount(root.path())).await;
-        read_stat_terminator(&mut responses).await;
-        sender.send(request_packet(0)).await.expect("request sends");
-        assert_eq!(
-            responses.message().await.unwrap().unwrap(),
-            data_packet(0, b"source".to_vec())
-        );
-        assert_eq!(
-            responses.message().await.unwrap().unwrap(),
-            data_packet(0, Vec::new())
-        );
-        sender.send(fin_packet()).await.expect("FIN sends");
-        assert_eq!(
-            responses.message().await.unwrap().unwrap().r#type,
-            PacketType::PacketFin as i32
-        );
-        let _ = shutdown.send(());
-        let _ = server.await;
-    }
-
-    #[tokio::test]
     async fn diff_copy_terminates_empty_files() {
         let root = tempdir().expect("temporary directory is created");
         std::fs::write(root.path().join("empty"), b"").expect("empty file is created");
@@ -2853,83 +2537,31 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn diff_copy_waits_for_accepted_jobs_before_fin() {
-        let root = tempdir().expect("temporary directory is created");
-        std::fs::write(root.path().join("input"), b"source").expect("source is created");
-        let (sender, mut responses, shutdown, server) =
-            open_filesync_transfer(open_mount(root.path())).await;
-        read_stat_terminator(&mut responses).await;
-        sender.send(request_packet(0)).await.expect("request sends");
-        sender.send(fin_packet()).await.expect("FIN sends");
-        let data = responses.message().await.unwrap().unwrap();
-        assert_eq!(data.r#type, PacketType::PacketData as i32);
-        assert!(!data.data.is_empty());
-        assert_eq!(
-            responses.message().await.unwrap().unwrap(),
-            data_packet(0, Vec::new())
-        );
-        assert_eq!(
-            responses.message().await.unwrap().unwrap().r#type,
-            PacketType::PacketFin as i32
-        );
-        let _ = shutdown.send(());
-        let _ = server.await;
-    }
-
-    #[tokio::test]
-    async fn diff_copy_cancels_owned_tasks_when_response_is_dropped() {
-        let root = tempdir().expect("temporary directory is created");
-        std::fs::write(root.path().join("input"), b"source").expect("source is created");
-        let (sender, mut responses, shutdown, server) =
-            open_filesync_transfer(open_mount(root.path())).await;
-        let _ = responses.message().await;
-        drop(sender);
-        drop(responses);
-        let _ = shutdown.send(());
-        tokio::time::timeout(std::time::Duration::from_secs(1), server)
-            .await
-            .expect("FileSync server shuts down after cancellation")
-            .expect("FileSync server joins");
-    }
-
-    #[tokio::test]
-    async fn diff_copy_reports_worker_errors() {
-        let root = tempdir().expect("temporary directory is created");
-        std::fs::write(root.path().join("input"), b"source").expect("source is created");
-        let (sender, mut responses, shutdown, server) =
-            open_filesync_transfer(open_mount(root.path())).await;
-        read_stat_terminator(&mut responses).await;
-        std::fs::remove_file(root.path().join("input")).expect("source is removed");
-        sender.send(request_packet(0)).await.expect("request sends");
-        assert_eq!(
-            expect_protocol_error(&mut responses).await.code(),
-            tonic::Code::Internal
-        );
-        let _ = shutdown.send(());
-        let _ = server.await;
-    }
-
-    #[tokio::test]
-    async fn diff_copy_reports_worker_panics() {
-        let root = tempdir().expect("temporary directory is created");
-        std::fs::write(root.path().join("input"), b"source").expect("source is created");
-        let (sender, mut responses, shutdown, server) = open_filesync_transfer_with_metadata(
-            open_mount(root.path()),
-            "context",
-            FaultInjection {
-                panic_worker: true,
-                ..Default::default()
-            },
-        )
-        .await;
-        read_stat_terminator(&mut responses).await;
-        sender.send(request_packet(0)).await.expect("request sends");
-        assert_eq!(
-            expect_protocol_error(&mut responses).await.code(),
-            tonic::Code::Internal
-        );
-        let _ = shutdown.send(());
-        let _ = server.await;
+    async fn diff_copy_reports_worker_failures() {
+        for panic_worker in [false, true] {
+            let root = tempdir().expect("temporary directory is created");
+            std::fs::write(root.path().join("input"), b"source").expect("source is created");
+            let (sender, mut responses, shutdown, server) = open_filesync_transfer_with_metadata(
+                open_mount(root.path()),
+                "context",
+                FaultInjection {
+                    panic_worker,
+                    ..Default::default()
+                },
+            )
+            .await;
+            read_stat_terminator(&mut responses).await;
+            if !panic_worker {
+                std::fs::remove_file(root.path().join("input")).expect("source is removed");
+            }
+            sender.send(request_packet(0)).await.expect("request sends");
+            assert_eq!(
+                expect_protocol_error(&mut responses).await.code(),
+                tonic::Code::Internal
+            );
+            let _ = shutdown.send(());
+            let _ = server.await;
+        }
     }
 
     #[cfg(unix)]
@@ -3020,6 +2652,7 @@ mod tests {
                 ..Default::default()
             },
             stat_packet("unexpected"),
+            data_packet(0, b"unexpected".to_vec()),
         ] {
             let root = tempdir().expect("temporary directory is created");
             std::fs::write(root.path().join("input"), b"source").expect("source is created");
@@ -3267,50 +2900,44 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn diff_copy_cancellation_stops_a_delayed_scanner() {
-        let root = tempdir().expect("temporary directory is created");
-        for index in 0..16 {
-            std::fs::write(root.path().join(format!("entry-{index}")), b"entry")
-                .expect("entry is created");
+    async fn diff_copy_cancellation_stops_blocked_tasks() {
+        for backpressured in [false, true] {
+            let root = tempdir().expect("temporary directory is created");
+            let (sender, mut responses, shutdown, server) = if backpressured {
+                std::fs::write(
+                    root.path().join("input"),
+                    vec![b'x'; FILE_READ_BUFFER_SIZE * OUTPUT_QUEUE_CAPACITY * 2],
+                )
+                .expect("source is created");
+                open_filesync_transfer(open_mount(root.path())).await
+            } else {
+                for index in 0..16 {
+                    std::fs::write(root.path().join(format!("entry-{index}")), b"entry")
+                        .expect("entry is created");
+                }
+                open_filesync_transfer_with_metadata(
+                    open_mount(root.path()),
+                    "context",
+                    FaultInjection {
+                        delay_scan: true,
+                        ..Default::default()
+                    },
+                )
+                .await
+            };
+            if backpressured {
+                read_stat_terminator(&mut responses).await;
+                sender.send(request_packet(0)).await.expect("request sends");
+            } else {
+                let _ = responses.message().await;
+            }
+            drop(sender);
+            drop(responses);
+            let _ = shutdown.send(());
+            tokio::time::timeout(std::time::Duration::from_secs(1), server)
+                .await
+                .expect("blocked FileSync service shuts down")
+                .expect("blocked FileSync service joins");
         }
-        let (sender, mut responses, shutdown, server) = open_filesync_transfer_with_metadata(
-            open_mount(root.path()),
-            "context",
-            FaultInjection {
-                delay_scan: true,
-                ..Default::default()
-            },
-        )
-        .await;
-        let _ = responses.message().await;
-        drop(sender);
-        drop(responses);
-        let _ = shutdown.send(());
-        tokio::time::timeout(std::time::Duration::from_secs(1), server)
-            .await
-            .expect("delayed scanner service shuts down")
-            .expect("delayed scanner service joins");
-    }
-
-    #[tokio::test]
-    async fn diff_copy_cancellation_stops_a_worker_under_output_backpressure() {
-        let root = tempdir().expect("temporary directory is created");
-        std::fs::write(
-            root.path().join("input"),
-            vec![b'x'; FILE_READ_BUFFER_SIZE * OUTPUT_QUEUE_CAPACITY * 2],
-        )
-        .expect("source is created");
-        let (sender, responses, shutdown, server) =
-            open_filesync_transfer(open_mount(root.path())).await;
-        let mut responses = responses;
-        read_stat_terminator(&mut responses).await;
-        sender.send(request_packet(0)).await.expect("request sends");
-        drop(sender);
-        drop(responses);
-        let _ = shutdown.send(());
-        tokio::time::timeout(std::time::Duration::from_secs(1), server)
-            .await
-            .expect("backpressured service shuts down")
-            .expect("backpressured service joins");
     }
 }

--- a/src/grpc/filesync.rs
+++ b/src/grpc/filesync.rs
@@ -1455,7 +1455,7 @@ fn entry_xattrs(
         let Some(name_str) = name.to_str() else {
             continue;
         };
-        if name_str.starts_with("com.apple.") || !super::fsutil::is_transferable_xattr(name_str) {
+        if !super::fsutil::is_transferable_xattr(name_str) {
             continue;
         }
         if let Some(value) = file

--- a/src/grpc/filesync.rs
+++ b/src/grpc/filesync.rs
@@ -5,6 +5,7 @@ use std::{
     path::{Path, PathBuf},
     pin::Pin,
     sync::Arc,
+    thread::JoinHandle,
     time::Duration,
 };
 
@@ -105,16 +106,30 @@ impl FaultInjection {
 
 struct FileSyncSession {
     cancellation: CancellationToken,
-    scanner: Option<tokio::task::JoinHandle<()>>,
+    scanner: Option<ScannerHandle>,
     workers: tokio::task::JoinSet<()>,
+}
+
+struct ScannerHandle {
+    completion: tokio::sync::oneshot::Receiver<Result<(), Status>>,
+    thread: Option<JoinHandle<()>>,
+}
+
+impl ScannerHandle {
+    async fn join(mut self) -> Result<(), Status> {
+        self.completion
+            .await
+            .map_err(|_| Status::internal("FileSync scanner task failed"))??;
+        if let Some(thread) = self.thread.take() {
+            let _ = thread.join();
+        }
+        Ok(())
+    }
 }
 
 impl Drop for FileSyncSession {
     fn drop(&mut self) {
         self.cancellation.cancel();
-        if let Some(scanner) = self.scanner.take() {
-            scanner.abort();
-        }
         self.workers.abort_all();
     }
 }
@@ -131,21 +146,30 @@ impl FileSyncSession {
         let (jobs_sender, jobs_receiver) = mpsc::channel(FILE_JOB_QUEUE_CAPACITY);
         let (output_sender, output_receiver) = mpsc::channel(OUTPUT_QUEUE_CAPACITY);
         let scanner_cancellation = cancellation.clone();
-        let scanner = tokio::task::spawn_blocking(move || {
-            if faults.panic_scanner {
-                panic!("injected FileSync scanner panic");
-            }
-            let result = scan_entries_with_selection(
-                scanner_root,
-                entries_sender.clone(),
-                selection,
-                scanner_cancellation,
-                faults,
-            );
-            if let Err(error) = result {
-                let _ = entries_sender.blocking_send(Err(error));
-            }
-        });
+        let (completion_sender, completion_receiver) = tokio::sync::oneshot::channel();
+        let scanner_thread = std::thread::Builder::new()
+            .name(String::from("bollard-filesync-scanner"))
+            .spawn(move || {
+                let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                    if faults.panic_scanner {
+                        panic!("injected FileSync scanner panic");
+                    }
+                    let result = scan_entries_with_selection(
+                        scanner_root,
+                        entries_sender.clone(),
+                        selection,
+                        scanner_cancellation,
+                        faults,
+                    );
+                    if let Err(error) = result {
+                        let _ = entries_sender.blocking_send(Err(error));
+                    }
+                }));
+                let result = result.map_err(|_| Status::internal("FileSync scanner panicked"));
+                let _ = completion_sender.send(result);
+            })
+            .map_err(|error| Status::internal(format!("FileSync scanner task failed: {error}")))
+            .expect("FileSync scanner thread starts");
 
         let jobs_receiver = Arc::new(Mutex::new(jobs_receiver));
         let mut workers = tokio::task::JoinSet::new();
@@ -179,7 +203,10 @@ impl FileSyncSession {
         (
             Self {
                 cancellation,
-                scanner: Some(scanner),
+                scanner: Some(ScannerHandle {
+                    completion: completion_receiver,
+                    thread: Some(scanner_thread),
+                }),
                 workers,
             },
             entries_receiver,
@@ -200,15 +227,11 @@ impl FileSyncSession {
         jobs.take();
 
         let result = tokio::time::timeout(FILESYNC_SHUTDOWN_TIMEOUT, async {
-            let scanner_result = if let Some(scanner) = self.scanner.as_mut() {
-                scanner.await.map_err(|error| {
-                    Status::internal(format!("FileSync scanner task failed: {error}"))
-                })
+            let scanner_result = if let Some(scanner) = self.scanner.take() {
+                scanner.join().await
             } else {
                 Ok(())
             };
-            self.scanner.take();
-
             self.workers.abort_all();
             let mut worker_error = None;
             while let Some(result) = self.workers.join_next().await {
@@ -228,9 +251,6 @@ impl FileSyncSession {
         match result {
             Ok(result) => result,
             Err(_) => {
-                if let Some(scanner) = self.scanner.as_ref() {
-                    scanner.abort();
-                }
                 self.workers.abort_all();
                 Err(Status::deadline_exceeded(
                     "FileSync session cleanup exceeded its timeout",
@@ -489,7 +509,7 @@ impl FileSync for FileSyncImpl {
                         }
                         None => {
                             if let Some(scanner) = session.scanner.take() {
-                                if let Err(join_error) = scanner.await {
+                                if let Err(join_error) = scanner.join().await {
                                     fail!(Status::internal(format!(
                                         "FileSync scanner task failed: {join_error}"
                                     )));
@@ -803,8 +823,7 @@ fn resolve_follow_paths(root: &cap_std::fs::Dir, paths: &[String]) -> Result<Vec
         if path == "." {
             return Ok(vec![String::from(".")]);
         }
-        budget.resolve(Path::new(path))?;
-        resolved.push(path.clone());
+        resolved.push(budget.resolve(Path::new(path))?);
         let components = path.split('/').map(str::to_owned).collect::<Vec<_>>();
         if components.len() > MAX_FOLLOW_DEPTH {
             return Err(Status::resource_exhausted(
@@ -823,7 +842,17 @@ fn resolve_follow_paths(root: &cap_std::fs::Dir, paths: &[String]) -> Result<Vec
     }
     resolved.sort_unstable();
     resolved.dedup();
-    Ok(resolved)
+    let mut deduped = Vec::with_capacity(resolved.len());
+    for path in resolved {
+        if deduped.last().is_some_and(|parent: &String| {
+            path.strip_prefix(parent)
+                .is_some_and(|suffix| suffix.starts_with('/'))
+        }) {
+            continue;
+        }
+        deduped.push(path);
+    }
+    Ok(deduped)
 }
 
 fn resolve_follow_components(
@@ -860,7 +889,7 @@ fn resolve_follow_components(
         };
         let directory = match directory {
             Ok(directory) => directory,
-            Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+            Err(error) if is_followpath_not_found(&error) => return Ok(()),
             Err(error) => {
                 return Err(filesystem_error(
                     "open followpaths directory",
@@ -881,7 +910,10 @@ fn resolve_follow_components(
         }
         names.sort_unstable();
         for name in names {
-            let Some(name) = name.to_str() else { continue };
+            let Some(name) = name.to_str() else {
+                log::debug!("skipping non-UTF-8 followpath entry: {name:?}");
+                continue;
+            };
             if component_pattern.matches(name) {
                 resolve_follow_entry(
                     root,
@@ -924,7 +956,7 @@ fn resolve_follow_entry(
     let next = current.join(name);
     let metadata = match root.symlink_metadata(&next) {
         Ok(metadata) => metadata,
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(error) if is_followpath_not_found(&error) => return Ok(()),
         Err(error) => return Err(filesystem_error("stat followpaths entry", &next, error)),
     };
     let next_string = path_string(&next)?;
@@ -981,16 +1013,40 @@ fn normalize_follow_target(parent: &Path, link: &Path) -> Option<PathBuf> {
     for component in link.components() {
         match component {
             std::path::Component::RootDir | std::path::Component::CurDir => {}
+            // Match fsutil's filepath.Join(root, target) behavior: a link
+            // that climbs above the mount root remains clamped at the root.
             std::path::Component::ParentDir => {
-                if !result.pop() {
-                    return None;
-                }
+                result.pop();
             }
             std::path::Component::Normal(value) => result.push(value),
+            #[cfg(windows)]
+            std::path::Component::Prefix(prefix) => match prefix.kind() {
+                std::path::Prefix::Disk(_) | std::path::Prefix::VerbatimDisk(_) => {
+                    // fsutil strips a Windows drive prefix before resolving
+                    // an absolute link target relative to the mount root.
+                    result = PathBuf::new();
+                }
+                _ => return None,
+            },
+            #[cfg(not(windows))]
             std::path::Component::Prefix(_) => return None,
         }
     }
     Some(result)
+}
+
+fn is_followpath_not_found(error: &std::io::Error) -> bool {
+    if error.kind() == std::io::ErrorKind::NotFound {
+        return true;
+    }
+    #[cfg(windows)]
+    {
+        return error.raw_os_error() == Some(123);
+    }
+    #[cfg(not(windows))]
+    {
+        false
+    }
 }
 
 fn contains_wildcard(value: &str) -> bool {
@@ -1080,11 +1136,12 @@ fn scan_entries(
     root: Arc<cap_std::fs::Dir>,
     sender: tokio::sync::mpsc::Sender<Result<SourceEntry, Status>>,
 ) -> Result<(), Status> {
+    let cancellation = CancellationToken::new();
     scan_entries_with_selection(
         root,
         sender,
         ScanSelection::All,
-        CancellationToken::new(),
+        cancellation,
         FaultInjection::default(),
     )
 }
@@ -1100,7 +1157,7 @@ fn scan_entries_with_selection(
         Status::internal(format!("failed to retain local source root: {error}"))
     })?;
     let mut budget = ScanBudget { inspected: 0 };
-    let names = sorted_names(&root, &mut budget)?;
+    let names = sorted_names(&root, &mut budget, &cancellation)?;
     let mut frames = vec![ScanFrame {
         relative: PathBuf::new(),
         directory: root,
@@ -1153,7 +1210,7 @@ fn scan_entries_with_selection(
                 frames.push(frame);
                 frames.push(ScanFrame {
                     relative,
-                    names: sorted_names(&directory, &mut budget)?,
+                    names: sorted_names(&directory, &mut budget, &cancellation)?,
                     directory,
                     next_name: 0,
                     pending: true,
@@ -1174,6 +1231,7 @@ fn scan_entries_with_selection(
             if matches!(
                 emit_source_entry(
                     &sender,
+                    &cancellation,
                     &mut position,
                     pending_entry.stat,
                     pending_entry.regular,
@@ -1185,7 +1243,14 @@ fn scan_entries_with_selection(
             }
         }
         if matches!(
-            emit_source_entry(&sender, &mut position, stat, regular, relative.clone())?,
+            emit_source_entry(
+                &sender,
+                &cancellation,
+                &mut position,
+                stat,
+                regular,
+                relative.clone(),
+            )?,
             EmitResult::ReceiverClosed
         ) {
             return Ok(());
@@ -1199,7 +1264,7 @@ fn scan_entries_with_selection(
                 .map_err(|error| filesystem_error("open directory", &relative, error))?;
             Some(ScanFrame {
                 relative,
-                names: sorted_names(&directory, &mut budget)?,
+                names: sorted_names(&directory, &mut budget, &cancellation)?,
                 directory,
                 next_name: 0,
                 pending: false,
@@ -1219,6 +1284,7 @@ fn scan_entries_with_selection(
 
 fn emit_source_entry(
     sender: &tokio::sync::mpsc::Sender<Result<SourceEntry, Status>>,
+    cancellation: &CancellationToken,
     position: &mut u32,
     stat: Stat,
     regular: bool,
@@ -1233,16 +1299,26 @@ fn emit_source_entry(
     *position = position
         .checked_add(1)
         .ok_or_else(|| Status::resource_exhausted("local source entry ID exhausted"))?;
-    if sender
-        .blocking_send(Ok(SourceEntry {
-            stat,
-            position: current_position,
-            regular,
-            relative,
-        }))
-        .is_err()
-    {
-        return Ok(EmitResult::ReceiverClosed);
+    let mut entry = Some(Ok(SourceEntry {
+        stat,
+        position: current_position,
+        regular,
+        relative,
+    }));
+    loop {
+        if cancellation.is_cancelled() {
+            return Ok(EmitResult::ReceiverClosed);
+        }
+        match sender.try_send(entry.take().expect("entry is available")) {
+            Ok(()) => break,
+            Err(tokio::sync::mpsc::error::TrySendError::Closed(_)) => {
+                return Ok(EmitResult::ReceiverClosed)
+            }
+            Err(tokio::sync::mpsc::error::TrySendError::Full(value)) => {
+                entry = Some(value);
+                std::thread::sleep(Duration::from_millis(1));
+            }
+        }
     }
     Ok(EmitResult::Sent)
 }
@@ -1250,23 +1326,21 @@ fn emit_source_entry(
 fn sorted_names(
     directory: &cap_std::fs::Dir,
     budget: &mut ScanBudget,
+    cancellation: &CancellationToken,
 ) -> Result<Vec<OsString>, Status> {
-    let mut names = directory
-        .entries()
-        .map_err(|error| {
-            Status::internal(format!("failed to read local source directory: {error}"))
-        })?
-        .map(|entry| {
-            entry
-                .map(|entry| {
-                    budget.inspect()?;
-                    Ok(entry.file_name())
-                })
-                .map_err(|error| {
-                    Status::internal(format!("failed to read local source entry: {error}"))
-                })?
-        })
-        .collect::<Result<Vec<_>, Status>>()?;
+    let mut names = Vec::new();
+    for entry in directory.entries().map_err(|error| {
+        Status::internal(format!("failed to read local source directory: {error}"))
+    })? {
+        if cancellation.is_cancelled() {
+            return Ok(names);
+        }
+        let entry = entry.map_err(|error| {
+            Status::internal(format!("failed to read local source entry: {error}"))
+        })?;
+        budget.inspect()?;
+        names.push(entry.file_name());
+    }
     names.sort_unstable();
     Ok(names)
 }
@@ -1384,16 +1458,17 @@ fn entry_xattrs(
     };
     let mut xattrs = HashMap::new();
     for name in names {
-        if name.to_string_lossy().starts_with("com.apple.") {
+        let Some(name_str) = name.to_str() else {
+            continue;
+        };
+        if name_str.starts_with("com.apple.") || !super::fsutil::is_transferable_xattr(name_str) {
             continue;
         }
         if let Some(value) = file
             .get_xattr(&name)
             .map_err(|error| filesystem_error("read xattr", Path::new(&name), error))?
         {
-            if let Some(name) = name.to_str() {
-                xattrs.insert(name.to_owned(), value);
-            }
+            xattrs.insert(name_str.to_owned(), value);
         }
     }
     Ok(xattrs)
@@ -2016,6 +2091,39 @@ mod tests {
             .all(|entry| entry.stat.path.len() <= MAX_PATH_LENGTH));
     }
 
+    #[cfg(windows)]
+    #[tokio::test]
+    async fn scanner_maps_windows_metadata_contract() {
+        let root = tempdir().expect("temporary directory is created");
+        std::fs::create_dir(root.path().join("nested")).expect("nested directory is created");
+        std::fs::write(root.path().join("nested/input.txt"), b"source")
+            .expect("source file is created");
+
+        let entries = scan_fixture(open_mount(root.path())).await;
+        assert!(entries.iter().all(|entry| !entry.stat.path.contains('\\')));
+
+        let directory = entries
+            .iter()
+            .find(|entry| entry.stat.path == "nested")
+            .expect("nested directory stat exists");
+        assert_ne!(
+            directory.stat.mode & super::super::fsutil::FileMode::Dir.bits(),
+            0
+        );
+        assert_eq!(directory.stat.mode & 0o777, 0o755);
+        assert_eq!(directory.stat.uid, 0);
+        assert_eq!(directory.stat.gid, 0);
+
+        let file = entries
+            .iter()
+            .find(|entry| entry.stat.path == "nested/input.txt")
+            .expect("nested file stat exists");
+        assert_eq!(file.stat.mode & 0o777, 0o755);
+        assert_eq!(file.stat.uid, 0);
+        assert_eq!(file.stat.gid, 0);
+        assert!(file.stat.mod_time > 0);
+    }
+
     #[tokio::test]
     async fn scanner_emits_regular_and_symlink_metadata() {
         let root = tempdir().expect("temporary directory is created");
@@ -2235,6 +2343,15 @@ mod tests {
         );
     }
 
+    #[cfg(unix)]
+    #[test]
+    fn scanner_filters_privileged_xattr_names() {
+        assert!(super::super::fsutil::is_transferable_xattr("user.bollard"));
+        assert!(!super::super::fsutil::is_transferable_xattr(
+            "security.capability"
+        ));
+    }
+
     #[test]
     fn metadata_decodes_encoded_values() {
         let mut metadata = MetadataMap::new();
@@ -2260,8 +2377,9 @@ mod tests {
         let mut budget = ScanBudget {
             inspected: MAX_ENTRIES - 1,
         };
+        let cancellation = CancellationToken::new();
         assert_eq!(
-            sorted_names(&directory, &mut budget)
+            sorted_names(&directory, &mut budget, &cancellation)
                 .expect_err("directory budget is enforced")
                 .code(),
             tonic::Code::ResourceExhausted
@@ -2373,6 +2491,23 @@ mod tests {
                 .expect_err("deep followpaths are rejected")
                 .code(),
             tonic::Code::ResourceExhausted
+        );
+    }
+
+    #[test]
+    fn normalize_follow_target_clamps_at_mount_root() {
+        assert_eq!(
+            normalize_follow_target(Path::new("dir"), Path::new("../../target")),
+            Some(PathBuf::from("target"))
+        );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn normalize_follow_target_resolves_drive_absolute_targets() {
+        assert_eq!(
+            normalize_follow_target(Path::new("dir"), Path::new(r"C:\target\input")),
+            Some(PathBuf::from(r"target\input"))
         );
     }
 

--- a/src/grpc/filesync.rs
+++ b/src/grpc/filesync.rs
@@ -15,6 +15,7 @@ use bollard_buildkit_proto::{
 use cap_fs_ext::{FollowSymlinks, OpenOptionsFollowExt};
 use futures_core::Stream;
 use futures_util::{FutureExt, StreamExt};
+use log::warn;
 use tokio::io::AsyncReadExt;
 use tokio::sync::{mpsc, Mutex};
 use tokio_util::sync::CancellationToken;
@@ -295,6 +296,11 @@ struct PendingEntry {
     relative: PathBuf,
 }
 
+enum EmitResult {
+    Sent,
+    ReceiverClosed,
+}
+
 struct ScanBudget {
     inspected: usize,
 }
@@ -436,9 +442,12 @@ impl FileSync for FileSyncImpl {
                 ($error:expr) => {{
                     let error = $error;
                     yield Ok(error_packet(&error));
-                    let _ = session
+                    if let Err(cleanup_error) = session
                         .shutdown(&mut entries_receiver, &mut jobs_sender, &mut output_receiver)
-                        .await;
+                        .await
+                    {
+                        warn!("FileSync cleanup failed after protocol error: {cleanup_error}");
+                    }
                     yield Err(error);
                     break;
                 }};
@@ -630,6 +639,7 @@ async fn worker_loop(
     cancellation: CancellationToken,
     faults: FaultInjection,
 ) {
+    let mut buffer = vec![0_u8; FILE_READ_BUFFER_SIZE];
     loop {
         let job = {
             let mut jobs = jobs.lock().await;
@@ -651,7 +661,6 @@ async fn worker_loop(
             }
         };
         let mut file = file;
-        let mut buffer = vec![0_u8; FILE_READ_BUFFER_SIZE];
         loop {
             if cancellation.is_cancelled() {
                 return;
@@ -1162,15 +1171,25 @@ fn scan_entries_with_selection(
             &mut seen_hardlinks,
         )?;
         for pending_entry in pending.drain(..) {
-            emit_source_entry(
-                &sender,
-                &mut position,
-                pending_entry.stat,
-                pending_entry.regular,
-                pending_entry.relative,
-            )?;
+            if matches!(
+                emit_source_entry(
+                    &sender,
+                    &mut position,
+                    pending_entry.stat,
+                    pending_entry.regular,
+                    pending_entry.relative,
+                )?,
+                EmitResult::ReceiverClosed
+            ) {
+                return Ok(());
+            }
         }
-        emit_source_entry(&sender, &mut position, stat, regular, relative.clone())?;
+        if matches!(
+            emit_source_entry(&sender, &mut position, stat, regular, relative.clone())?,
+            EmitResult::ReceiverClosed
+        ) {
+            return Ok(());
+        }
 
         let file_type = metadata.file_type();
         let child = if file_type.is_dir() {
@@ -1204,7 +1223,7 @@ fn emit_source_entry(
     stat: Stat,
     regular: bool,
     relative: PathBuf,
-) -> Result<(), Status> {
+) -> Result<EmitResult, Status> {
     if *position as usize >= MAX_ENTRIES {
         return Err(Status::resource_exhausted(
             "local source has too many entries",
@@ -1223,9 +1242,9 @@ fn emit_source_entry(
         }))
         .is_err()
     {
-        return Ok(());
+        return Ok(EmitResult::ReceiverClosed);
     }
-    Ok(())
+    Ok(EmitResult::Sent)
 }
 
 fn sorted_names(

--- a/src/grpc/filesync.rs
+++ b/src/grpc/filesync.rs
@@ -364,6 +364,12 @@ impl FollowPathBudget {
     }
 }
 
+struct FollowPathContext {
+    visited: HashSet<String>,
+    resolved: Vec<String>,
+    budget: FollowPathBudget,
+}
+
 enum SessionEvent {
     Entry(Option<Result<SourceEntry, Status>>),
     Packet(Option<Result<Packet, Status>>),
@@ -813,37 +819,33 @@ fn resolve_follow_paths(root: &cap_std::fs::Dir, paths: &[String]) -> Result<Vec
             "FileSync request contains too many followpaths",
         ));
     }
-    let mut resolved = Vec::new();
-    let mut budget = FollowPathBudget {
-        inspected: 0,
-        resolved: 0,
+    let mut context = FollowPathContext {
+        visited: HashSet::new(),
+        resolved: Vec::new(),
+        budget: FollowPathBudget {
+            inspected: 0,
+            resolved: 0,
+        },
     };
-    let mut visited = HashSet::new();
     for path in paths {
         if path == "." {
             return Ok(vec![String::from(".")]);
         }
-        resolved.push(budget.resolve(Path::new(path))?);
+        context
+            .resolved
+            .push(context.budget.resolve(Path::new(path))?);
         let components = path.split('/').map(str::to_owned).collect::<Vec<_>>();
         if components.len() > MAX_FOLLOW_DEPTH {
             return Err(Status::resource_exhausted(
                 "FileSync followpaths path is too deep",
             ));
         }
-        resolve_follow_components(
-            root,
-            Path::new(""),
-            &components,
-            &mut visited,
-            &mut resolved,
-            &mut budget,
-            0,
-        )?;
+        resolve_follow_components(root, Path::new(""), &components, &mut context, 0)?;
     }
-    resolved.sort_unstable();
-    resolved.dedup();
-    let mut deduped = Vec::with_capacity(resolved.len());
-    for path in resolved {
+    context.resolved.sort_unstable();
+    context.resolved.dedup();
+    let mut deduped = Vec::with_capacity(context.resolved.len());
+    for path in context.resolved {
         if deduped.last().is_some_and(|parent: &String| {
             path.strip_prefix(parent)
                 .is_some_and(|suffix| suffix.starts_with('/'))
@@ -859,9 +861,7 @@ fn resolve_follow_components(
     root: &cap_std::fs::Dir,
     current: &Path,
     components: &[String],
-    visited: &mut HashSet<String>,
-    resolved: &mut Vec<String>,
-    budget: &mut FollowPathBudget,
+    context: &mut FollowPathContext,
     depth: usize,
 ) -> Result<(), Status> {
     if depth > MAX_FOLLOW_DEPTH {
@@ -871,7 +871,7 @@ fn resolve_follow_components(
     }
     let Some(component) = components.first() else {
         if !current.as_os_str().is_empty() {
-            resolved.push(budget.resolve(current)?);
+            context.resolved.push(context.budget.resolve(current)?);
         }
         return Ok(());
     };
@@ -903,7 +903,7 @@ fn resolve_follow_components(
             .entries()
             .map_err(|error| filesystem_error("read followpaths directory", current, error))?
         {
-            budget.inspect()?;
+            context.budget.inspect()?;
             let entry = entry
                 .map_err(|error| filesystem_error("read followpaths entry", current, error))?;
             names.push(entry.file_name());
@@ -915,30 +915,19 @@ fn resolve_follow_components(
                 continue;
             };
             if component_pattern.matches(name) {
-                resolve_follow_entry(
-                    root,
-                    current,
-                    name,
-                    &components[1..],
-                    visited,
-                    resolved,
-                    budget,
-                    depth + 1,
-                )?;
+                resolve_follow_entry(root, current, name, &components[1..], context, depth + 1)?;
             }
         }
         return Ok(());
     }
 
-    budget.inspect()?;
+    context.budget.inspect()?;
     resolve_follow_entry(
         root,
         current,
         component,
         &components[1..],
-        visited,
-        resolved,
-        budget,
+        context,
         depth + 1,
     )
 }
@@ -948,9 +937,7 @@ fn resolve_follow_entry(
     current: &Path,
     name: &str,
     remaining: &[String],
-    visited: &mut HashSet<String>,
-    resolved: &mut Vec<String>,
-    budget: &mut FollowPathBudget,
+    context: &mut FollowPathContext,
     depth: usize,
 ) -> Result<(), Status> {
     let next = current.join(name);
@@ -961,10 +948,10 @@ fn resolve_follow_entry(
     };
     let next_string = path_string(&next)?;
     if metadata.file_type().is_symlink() {
-        if !visited.insert(next_string.clone()) {
+        if !context.visited.insert(next_string.clone()) {
             return Ok(());
         }
-        resolved.push(budget.resolve(&next)?);
+        context.resolved.push(context.budget.resolve(&next)?);
         let parent = next.parent().unwrap_or_else(|| Path::new(""));
         let link = root
             .read_link_contents(&next)
@@ -973,7 +960,7 @@ fn resolve_follow_entry(
             return Ok(());
         };
         if target.as_os_str().is_empty() {
-            resolved.push(String::from("."));
+            context.resolved.push(String::from("."));
             return Ok(());
         }
         let mut target_components = target
@@ -988,18 +975,16 @@ fn resolve_follow_entry(
             root,
             Path::new(""),
             &target_components,
-            visited,
-            resolved,
-            budget,
+            context,
             depth + 1,
         );
     }
     if remaining.is_empty() {
-        resolved.push(budget.resolve(&next)?);
+        context.resolved.push(context.budget.resolve(&next)?);
     } else if !metadata.file_type().is_dir() {
         return Ok(());
     } else {
-        resolve_follow_components(root, &next, remaining, visited, resolved, budget, depth)?;
+        resolve_follow_components(root, &next, remaining, context, depth)?;
     }
     Ok(())
 }

--- a/src/grpc/filesync.rs
+++ b/src/grpc/filesync.rs
@@ -1,0 +1,2048 @@
+use std::{
+    collections::HashMap,
+    ffi::{OsStr, OsString},
+    panic::AssertUnwindSafe,
+    path::{Path, PathBuf},
+    pin::Pin,
+    sync::Arc,
+};
+
+use bollard_buildkit_proto::{
+    fsutil::types::{packet::PacketType, Packet, Stat},
+    moby::filesync::v1::file_sync_server::FileSync,
+};
+use futures_core::Stream;
+use futures_util::{FutureExt, StreamExt};
+use tokio::io::AsyncReadExt;
+use tokio::sync::{mpsc, Mutex};
+use tokio_util::sync::CancellationToken;
+use tonic::{metadata::MetadataMap, Request, Response, Status, Streaming};
+
+#[cfg(unix)]
+use cap_std::fs::MetadataExt;
+#[cfg(not(unix))]
+use std::time::UNIX_EPOCH;
+
+const DIR_NAME_METADATA: &str = "dir-name";
+const INCLUDE_PATTERNS_METADATA: &str = "include-patterns";
+const EXCLUDE_PATTERNS_METADATA: &str = "exclude-patterns";
+const FOLLOW_PATHS_METADATA: &str = "followpaths";
+const MAX_ENTRIES: usize = 100_000;
+const MAX_PATH_LENGTH: usize = 4096;
+const MAX_LINKNAME_LENGTH: usize = 4096;
+const ENTRY_QUEUE_CAPACITY: usize = 128;
+const FILE_JOB_QUEUE_CAPACITY: usize = 128;
+const OUTPUT_QUEUE_CAPACITY: usize = 16;
+const FILE_WORKER_COUNT: usize = 4;
+const FILE_READ_BUFFER_SIZE: usize = 32 * 1024;
+
+type EntryReceiver = tokio::sync::mpsc::Receiver<Result<SourceEntry, Status>>;
+type JobSender = tokio::sync::mpsc::Sender<FileJob>;
+type OutputReceiver = tokio::sync::mpsc::Receiver<Result<Packet, Status>>;
+type FileSyncStart = (FileSyncSession, EntryReceiver, JobSender, OutputReceiver);
+
+#[cfg(test)]
+use bollard_buildkit_proto::moby::filesync::v1::file_sync_server::FileSyncServer;
+
+#[derive(Clone)]
+pub(crate) struct FileSyncImpl {
+    mounts: HashMap<String, Arc<cap_std::fs::Dir>>,
+}
+
+#[derive(Debug)]
+struct SourceEntry {
+    stat: Stat,
+    position: u32,
+    regular: bool,
+    relative: PathBuf,
+}
+
+#[derive(Clone, Debug)]
+struct FileJob {
+    id: u32,
+    relative: PathBuf,
+}
+
+#[derive(Debug)]
+struct FileTarget {
+    regular: bool,
+    relative: PathBuf,
+}
+
+struct FileSyncSession {
+    cancellation: CancellationToken,
+    scanner: Option<tokio::task::JoinHandle<()>>,
+    workers: tokio::task::JoinSet<()>,
+}
+
+impl Drop for FileSyncSession {
+    fn drop(&mut self) {
+        self.cancellation.cancel();
+        if let Some(scanner) = self.scanner.take() {
+            scanner.abort();
+        }
+        self.workers.abort_all();
+    }
+}
+
+impl FileSyncSession {
+    fn start(
+        root: Arc<cap_std::fs::Dir>,
+        selection: ScanSelection,
+        test_panic_worker: bool,
+        test_delay_scan: bool,
+    ) -> FileSyncStart {
+        let cancellation = CancellationToken::new();
+        let scanner_root = root.clone();
+        let (entries_sender, entries_receiver) = mpsc::channel(ENTRY_QUEUE_CAPACITY);
+        let (jobs_sender, jobs_receiver) = mpsc::channel(FILE_JOB_QUEUE_CAPACITY);
+        let (output_sender, output_receiver) = mpsc::channel(OUTPUT_QUEUE_CAPACITY);
+        let scanner_cancellation = cancellation.clone();
+        let scanner = tokio::task::spawn_blocking(move || {
+            let result = scan_entries_with_selection(
+                scanner_root,
+                entries_sender.clone(),
+                selection,
+                scanner_cancellation,
+                test_delay_scan,
+            );
+            if let Err(error) = result {
+                let _ = entries_sender.blocking_send(Err(error));
+            }
+        });
+
+        let jobs_receiver = Arc::new(Mutex::new(jobs_receiver));
+        let mut workers = tokio::task::JoinSet::new();
+        for _ in 0..FILE_WORKER_COUNT {
+            let worker_jobs = Arc::clone(&jobs_receiver);
+            let worker_output = output_sender.clone();
+            let worker_root = root.clone();
+            let worker_cancellation = cancellation.clone();
+            workers.spawn(async move {
+                let result = AssertUnwindSafe(async {
+                    worker_loop(
+                        worker_root,
+                        worker_jobs,
+                        worker_output.clone(),
+                        worker_cancellation,
+                        test_panic_worker,
+                    )
+                    .await;
+                })
+                .catch_unwind()
+                .await;
+                if result.is_err() {
+                    let _ = worker_output
+                        .send(Err(Status::internal("FileSync worker panicked")))
+                        .await;
+                }
+            });
+        }
+        drop(output_sender);
+
+        (
+            Self {
+                cancellation,
+                scanner: Some(scanner),
+                workers,
+            },
+            entries_receiver,
+            jobs_sender,
+            output_receiver,
+        )
+    }
+
+    async fn shutdown(
+        &mut self,
+        entries: &mut tokio::sync::mpsc::Receiver<Result<SourceEntry, Status>>,
+        jobs: &mut Option<tokio::sync::mpsc::Sender<FileJob>>,
+        output: &mut tokio::sync::mpsc::Receiver<Result<Packet, Status>>,
+    ) -> Result<(), Status> {
+        self.cancellation.cancel();
+        entries.close();
+        output.close();
+        jobs.take();
+
+        if let Some(scanner) = self.scanner.take() {
+            scanner.await.map_err(|error| {
+                Status::internal(format!("FileSync scanner task failed: {error}"))
+            })?;
+        }
+        self.workers.abort_all();
+        while let Some(result) = self.workers.join_next().await {
+            if let Err(error) = result {
+                if !error.is_cancelled() {
+                    return Err(Status::internal(format!(
+                        "FileSync worker task failed: {error}"
+                    )));
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+#[derive(Clone, Debug)]
+enum ScanSelection {
+    All,
+    Paths(Vec<PathBuf>),
+}
+
+struct ScanFrame {
+    relative: PathBuf,
+    directory: cap_std::fs::Dir,
+    names: Vec<OsString>,
+    next_name: usize,
+}
+
+enum SessionEvent {
+    Entry(Option<Result<SourceEntry, Status>>),
+    Packet(Option<Result<Packet, Status>>),
+    Output(Option<Result<Packet, Status>>),
+    Job(Result<FileJob, FileJob>),
+}
+
+async fn next_session_event(
+    entries: &mut tokio::sync::mpsc::Receiver<Result<SourceEntry, Status>>,
+    input: &mut Pin<Box<Streaming<Packet>>>,
+    output: &mut tokio::sync::mpsc::Receiver<Result<Packet, Status>>,
+    jobs: Option<&tokio::sync::mpsc::Sender<FileJob>>,
+    queued_job: Option<&FileJob>,
+    enumeration_finished: bool,
+) -> SessionEvent {
+    if let (Some(sender), Some(job)) = (jobs, queued_job) {
+        let job = job.clone();
+        let sent_job = job.clone();
+        tokio::select! {
+            biased;
+            result = sender.send(job) => {
+                match result {
+                    Ok(()) => SessionEvent::Job(Ok(sent_job)),
+                    Err(error) => SessionEvent::Job(Err(error.0)),
+                }
+            }
+            event = entries.recv(), if !enumeration_finished => SessionEvent::Entry(event),
+            packet = output.recv() => SessionEvent::Output(packet),
+        }
+    } else {
+        tokio::select! {
+            biased;
+            packet = input.next() => SessionEvent::Packet(packet),
+            event = entries.recv(), if !enumeration_finished => SessionEvent::Entry(event),
+            packet = output.recv() => SessionEvent::Output(packet),
+        }
+    }
+}
+
+impl FileSyncImpl {
+    pub(crate) fn new(mounts: HashMap<String, Arc<cap_std::fs::Dir>>) -> Self {
+        Self { mounts }
+    }
+}
+
+impl std::fmt::Debug for FileSyncImpl {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("FileSyncImpl")
+            .field("mounts", &self.mounts.keys().collect::<Vec<_>>())
+            .finish()
+    }
+}
+
+#[tonic::async_trait]
+impl FileSync for FileSyncImpl {
+    type DiffCopyStream = Pin<Box<dyn Stream<Item = Result<Packet, Status>> + Send>>;
+    type TarStreamStream = futures_util::stream::Empty<Result<Packet, Status>>;
+
+    async fn diff_copy(
+        &self,
+        request: Request<Streaming<Packet>>,
+    ) -> Result<Response<Self::DiffCopyStream>, Status> {
+        let name = mount_name(request.metadata())?;
+        let root = lookup_mount(&self.mounts, &name)?;
+        let selection = scan_selection(request.metadata())?;
+        #[cfg(test)]
+        let test_panic_worker = request.metadata().contains_key("x-test-panic-worker");
+        #[cfg(not(test))]
+        let test_panic_worker = false;
+        #[cfg(test)]
+        let test_delay_scan = request.metadata().contains_key("x-test-delay-scan");
+        #[cfg(not(test))]
+        let test_delay_scan = false;
+        let (mut session, mut entries_receiver, jobs_sender, mut output_receiver) =
+            FileSyncSession::start(root, selection, test_panic_worker, test_delay_scan);
+        let mut jobs_sender = Some(jobs_sender);
+        let mut input = Box::pin(request.into_inner());
+
+        let output = async_stream::stream! {
+            let mut positions = HashMap::<u32, FileTarget>::new();
+            let mut pending_jobs = HashMap::<u32, ()>::new();
+            let mut queued_job = None::<FileJob>;
+            let mut enumeration_finished = false;
+            let mut fin_requested = false;
+
+            macro_rules! fail {
+                ($error:expr) => {{
+                    let error = $error;
+                    yield Ok(error_packet(&error));
+                    let _ = session
+                        .shutdown(&mut entries_receiver, &mut jobs_sender, &mut output_receiver)
+                        .await;
+                    yield Err(error);
+                    break;
+                }};
+            }
+
+            loop {
+                let event = next_session_event(
+                    &mut entries_receiver,
+                    &mut input,
+                    &mut output_receiver,
+                    jobs_sender.as_ref(),
+                    queued_job.as_ref(),
+                    enumeration_finished,
+                ).await;
+                match event {
+                    SessionEvent::Job(job) => match job {
+                        Ok(job) => {
+                            queued_job = None;
+                            pending_jobs.insert(job.id, ());
+                        }
+                        Err(job) => fail!(Status::internal(format!(
+                            "FileSync file-job queue closed for request {}",
+                            job.id
+                        ))),
+                    },
+                    SessionEvent::Entry(event) => match event {
+                        Some(Ok(entry)) => {
+                            let SourceEntry {
+                                stat,
+                                position,
+                                regular,
+                                relative,
+                            } = entry;
+                            positions.insert(position, FileTarget { regular, relative });
+                            yield Ok(stat_entry_packet(stat));
+                        }
+                        Some(Err(error)) => {
+                            fail!(error);
+                        }
+                        None => {
+                            if let Some(scanner) = session.scanner.take() {
+                                if let Err(join_error) = scanner.await {
+                                    fail!(Status::internal(format!(
+                                        "FileSync scanner task failed: {join_error}"
+                                    )));
+                                }
+                            }
+                            yield Ok(stat_terminator());
+                            enumeration_finished = true;
+                            if fin_requested && pending_jobs.is_empty() {
+                                yield Ok(fin_response_packet());
+                                match session
+                                    .shutdown(&mut entries_receiver, &mut jobs_sender, &mut output_receiver)
+                                    .await
+                                {
+                                    Ok(()) => break,
+                                    Err(error) => fail!(error),
+                                }
+                            }
+                        }
+                    },
+                    SessionEvent::Packet(packet) => {
+                        let packet = match packet {
+                            Some(Ok(packet)) => packet,
+                            Some(Err(error)) => fail!(error),
+                            None => fail!(Status::failed_precondition(
+                                "FileSync stream ended before PACKET_FIN",
+                            )),
+                        };
+                        let packet_type = match PacketType::try_from(packet.r#type) {
+                            Ok(packet_type) => packet_type,
+                            Err(_) => fail!(Status::invalid_argument(
+                                "unknown FileSync packet type",
+                            )),
+                        };
+                        match packet_type {
+                            PacketType::PacketErr => {
+                                fail!(Status::aborted(
+                                    "BuildKit aborted the FileSync transfer",
+                                ));
+                            }
+                            PacketType::PacketReq => {
+                                if fin_requested {
+                                    fail!(Status::failed_precondition(
+                                        "FileSync received PACKET_REQ after PACKET_FIN",
+                                    ));
+                                }
+                                let target = positions.remove(&packet.id).ok_or_else(|| {
+                                    Status::invalid_argument("invalid or repeated FileSync request ID")
+                                });
+                                let target = match target {
+                                    Ok(target) if target.regular => target,
+                                    Ok(_) => {
+                                        fail!(Status::invalid_argument(
+                                            "FileSync request does not identify a regular file",
+                                        ));
+                                    }
+                                    Err(error) => {
+                                        fail!(error);
+                                    }
+                                };
+                                let job = FileJob {
+                                    id: packet.id,
+                                    relative: target.relative,
+                                };
+                                if jobs_sender.is_some() {
+                                    queued_job = Some(job);
+                                } else {
+                                    fail!(Status::failed_precondition(
+                                        "FileSync session is shutting down",
+                                    ));
+                                }
+                            }
+                            PacketType::PacketFin => {
+                                if !enumeration_finished {
+                                    fail!(Status::failed_precondition(
+                                        "FileSync received PACKET_FIN before STAT termination",
+                                    ));
+                                }
+                                fin_requested = true;
+                                if pending_jobs.is_empty() {
+                                    yield Ok(fin_response_packet());
+                                    match session
+                                        .shutdown(&mut entries_receiver, &mut jobs_sender, &mut output_receiver)
+                                        .await
+                                    {
+                                        Ok(()) => break,
+                                        Err(error) => fail!(error),
+                                    }
+                                }
+                            }
+                            PacketType::PacketStat | PacketType::PacketData => {
+                                fail!(Status::invalid_argument(
+                                    "unexpected packet type from FileSync receiver",
+                                ));
+                            }
+                        }
+                    }
+                    SessionEvent::Output(output) => match output {
+                        Some(Ok(packet)) => {
+                            let eof = packet.r#type == PacketType::PacketData as i32
+                                && packet.data.is_empty();
+                            if eof && pending_jobs.remove(&packet.id).is_none() {
+                                fail!(Status::internal(
+                                    "FileSync worker emitted an unexpected EOF",
+                                ));
+                            }
+                            yield Ok(packet);
+                            if fin_requested && enumeration_finished && pending_jobs.is_empty() {
+                                yield Ok(fin_response_packet());
+                                match session
+                                    .shutdown(&mut entries_receiver, &mut jobs_sender, &mut output_receiver)
+                                    .await
+                                {
+                                    Ok(()) => break,
+                                    Err(error) => fail!(error),
+                                }
+                            }
+                        }
+                        Some(Err(error)) => fail!(error),
+                        None => fail!(Status::internal("FileSync output channel closed")),
+                    },
+                }
+            }
+        };
+
+        Ok(Response::new(Box::pin(output)))
+    }
+
+    async fn tar_stream(
+        &self,
+        _request: Request<Streaming<Packet>>,
+    ) -> Result<Response<Self::TarStreamStream>, Status> {
+        Err(Status::unimplemented(
+            "FileSync TarStream is not implemented",
+        ))
+    }
+}
+
+async fn worker_loop(
+    root: Arc<cap_std::fs::Dir>,
+    jobs: Arc<Mutex<tokio::sync::mpsc::Receiver<FileJob>>>,
+    output: tokio::sync::mpsc::Sender<Result<Packet, Status>>,
+    cancellation: CancellationToken,
+    test_panic_worker: bool,
+) {
+    loop {
+        let job = {
+            let mut jobs = jobs.lock().await;
+            jobs.recv().await
+        };
+        let Some(job) = job else { return };
+        if cancellation.is_cancelled() {
+            return;
+        }
+        if test_panic_worker {
+            panic!("injected FileSync worker panic");
+        }
+
+        let file = match open_regular_file(root.clone(), job.relative.clone()).await {
+            Ok(file) => file,
+            Err(error) => {
+                let _ = output.send(Err(error)).await;
+                return;
+            }
+        };
+        let mut file = file;
+        let mut buffer = vec![0_u8; FILE_READ_BUFFER_SIZE];
+        loop {
+            if cancellation.is_cancelled() {
+                return;
+            }
+            let count = match file.read(&mut buffer).await {
+                Ok(count) => count,
+                Err(error) => {
+                    let _ = output
+                        .send(Err(Status::internal(format!(
+                            "failed to read local source file {:?}: {error}",
+                            job.relative
+                        ))))
+                        .await;
+                    return;
+                }
+            };
+            if count == 0 {
+                if output
+                    .send(Ok(file_data_packet(job.id, Vec::new())))
+                    .await
+                    .is_err()
+                {
+                    return;
+                }
+                break;
+            }
+            if output
+                .send(Ok(file_data_packet(job.id, buffer[..count].to_vec())))
+                .await
+                .is_err()
+            {
+                return;
+            }
+        }
+    }
+}
+
+async fn open_regular_file(
+    root: Arc<cap_std::fs::Dir>,
+    relative: PathBuf,
+) -> Result<tokio::fs::File, Status> {
+    let file = tokio::task::spawn_blocking(move || {
+        let file = root
+            .open(&relative)
+            .map_err(|error| filesystem_error("open", &relative, error))?;
+        let metadata = file
+            .metadata()
+            .map_err(|error| filesystem_error("stat", &relative, error))?;
+        if !metadata.file_type().is_file() {
+            return Err(Status::invalid_argument(format!(
+                "FileSync request is no longer a regular file: {relative:?}"
+            )));
+        }
+        Ok(file.into_std())
+    })
+    .await
+    .map_err(|error| Status::internal(format!("FileSync file worker failed: {error}")))??;
+    Ok(tokio::fs::File::from_std(file))
+}
+
+fn scan_selection(metadata: &MetadataMap) -> Result<ScanSelection, Status> {
+    validate_options(metadata)?;
+    let mut paths = Vec::new();
+    for value in metadata.get_all(FOLLOW_PATHS_METADATA).iter() {
+        let value = value
+            .to_str()
+            .map_err(|_| Status::invalid_argument("invalid followpaths metadata"))?;
+        if value == "." {
+            return Ok(ScanSelection::All);
+        }
+        let path = PathBuf::from(value);
+        if value.is_empty()
+            || path.is_absolute()
+            || path
+                .components()
+                .any(|component| !matches!(component, std::path::Component::Normal(_)))
+            || value.contains('*')
+            || value.contains('?')
+            || value.contains('[')
+        {
+            return Err(Status::unimplemented(
+                "FileSync followpaths must be literal relative paths",
+            ));
+        }
+        if path.to_str().is_none() || path.as_os_str().len() > MAX_PATH_LENGTH {
+            return Err(Status::invalid_argument(
+                "invalid FileSync followpaths path",
+            ));
+        }
+        paths.push(path);
+    }
+    if paths.is_empty() {
+        Ok(ScanSelection::All)
+    } else {
+        paths.sort_unstable();
+        paths.dedup();
+        Ok(ScanSelection::Paths(paths))
+    }
+}
+
+fn mount_name(metadata: &MetadataMap) -> Result<String, Status> {
+    let value = metadata
+        .get(DIR_NAME_METADATA)
+        .ok_or_else(|| Status::not_found("local source name is missing"))?;
+    value
+        .to_str()
+        .map(str::to_owned)
+        .map_err(|_| Status::invalid_argument("invalid dir-name metadata"))
+}
+
+fn lookup_mount(
+    mounts: &HashMap<String, Arc<cap_std::fs::Dir>>,
+    name: &str,
+) -> Result<Arc<cap_std::fs::Dir>, Status> {
+    mounts
+        .get(name)
+        .cloned()
+        .ok_or_else(|| Status::not_found(format!("no access allowed to dir {name:?}")))
+}
+
+fn validate_options(metadata: &MetadataMap) -> Result<(), Status> {
+    for key in [INCLUDE_PATTERNS_METADATA, EXCLUDE_PATTERNS_METADATA] {
+        if metadata.contains_key(key) || metadata.contains_key(format!("{key}-encoded")) {
+            return Err(Status::invalid_argument(format!(
+                "FileSync {key} are unsupported"
+            )));
+        }
+    }
+
+    if metadata.contains_key(format!("{FOLLOW_PATHS_METADATA}-encoded")) {
+        return Err(Status::invalid_argument(
+            "encoded FileSync followpaths are unsupported",
+        ));
+    }
+    for value in metadata.get_all(FOLLOW_PATHS_METADATA).iter() {
+        let value = value
+            .to_str()
+            .map_err(|_| Status::invalid_argument("invalid followpaths metadata"))?;
+        if value.contains('*') || value.contains('?') || value.contains('[') {
+            return Err(Status::unimplemented(
+                "wildcard FileSync followpaths are not implemented",
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn scan_entries(
+    root: Arc<cap_std::fs::Dir>,
+    sender: tokio::sync::mpsc::Sender<Result<SourceEntry, Status>>,
+) -> Result<(), Status> {
+    scan_entries_with_selection(
+        root,
+        sender,
+        ScanSelection::All,
+        CancellationToken::new(),
+        false,
+    )
+}
+
+fn scan_entries_with_selection(
+    root: Arc<cap_std::fs::Dir>,
+    sender: tokio::sync::mpsc::Sender<Result<SourceEntry, Status>>,
+    selection: ScanSelection,
+    cancellation: CancellationToken,
+    delay_scan: bool,
+) -> Result<(), Status> {
+    let root = root.try_clone().map_err(|error| {
+        Status::internal(format!("failed to retain local source root: {error}"))
+    })?;
+    let selection = resolve_selection(&root, selection)?;
+    let names = sorted_names(&root)?;
+    let mut frames = vec![ScanFrame {
+        relative: PathBuf::new(),
+        directory: root,
+        names,
+        next_name: 0,
+    }];
+    let mut position = 0_u32;
+
+    while let Some(mut frame) = frames.pop() {
+        if delay_scan {
+            std::thread::sleep(std::time::Duration::from_millis(50));
+        }
+        if cancellation.is_cancelled() {
+            return Ok(());
+        }
+        let Some(name) = frame.names.get(frame.next_name).cloned() else {
+            continue;
+        };
+        frame.next_name += 1;
+
+        let relative = frame.relative.join(&name);
+        let metadata = frame
+            .directory
+            .symlink_metadata(&name)
+            .map_err(|error| filesystem_error("stat", &relative, error))?;
+        if !entry_is_selected(&relative, &metadata, &selection) {
+            if metadata.file_type().is_dir() && entry_is_ancestor(&relative, &selection) {
+                let directory = frame
+                    .directory
+                    .open_dir(&name)
+                    .map_err(|error| filesystem_error("open directory", &relative, error))?;
+                frames.push(frame);
+                frames.push(ScanFrame {
+                    relative,
+                    names: sorted_names(&directory)?,
+                    directory,
+                    next_name: 0,
+                });
+            } else {
+                frames.push(frame);
+            }
+            continue;
+        }
+        let (stat, regular) = source_stat(&frame.directory, &name, &relative, &metadata)?;
+        if position as usize >= MAX_ENTRIES {
+            return Err(Status::resource_exhausted(
+                "local source has too many entries",
+            ));
+        }
+        let current_position = position;
+        position = position
+            .checked_add(1)
+            .ok_or_else(|| Status::resource_exhausted("local source entry ID exhausted"))?;
+
+        if sender
+            .blocking_send(Ok(SourceEntry {
+                stat,
+                position: current_position,
+                regular,
+                relative: relative.clone(),
+            }))
+            .is_err()
+        {
+            return Ok(());
+        }
+
+        let file_type = metadata.file_type();
+        let child = if file_type.is_dir() {
+            if !entry_is_ancestor_or_selected_directory(&relative, &metadata, &selection) {
+                None
+            } else {
+                let directory = frame
+                    .directory
+                    .open_dir(&name)
+                    .map_err(|error| filesystem_error("open directory", &relative, error))?;
+                Some(ScanFrame {
+                    relative,
+                    names: sorted_names(&directory)?,
+                    directory,
+                    next_name: 0,
+                })
+            }
+        } else {
+            None
+        };
+
+        frames.push(frame);
+        if let Some(child) = child {
+            frames.push(child);
+        }
+    }
+
+    Ok(())
+}
+
+fn resolve_selection(
+    root: &cap_std::fs::Dir,
+    selection: ScanSelection,
+) -> Result<ScanSelection, Status> {
+    let ScanSelection::Paths(paths) = selection else {
+        return Ok(ScanSelection::All);
+    };
+    let mut existing = Vec::new();
+    for path in paths {
+        match root.symlink_metadata(&path) {
+            Ok(_) => existing.push(path),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Err(error) => return Err(filesystem_error("stat", &path, error)),
+        }
+    }
+    Ok(ScanSelection::Paths(existing))
+}
+
+fn path_is_prefix(prefix: &Path, path: &Path) -> bool {
+    prefix == path
+        || prefix
+            .components()
+            .zip(path.components())
+            .all(|(a, b)| a == b)
+            && prefix.components().count() <= path.components().count()
+}
+
+fn entry_is_ancestor(path: &Path, selection: &ScanSelection) -> bool {
+    match selection {
+        ScanSelection::All => true,
+        ScanSelection::Paths(paths) => paths.iter().any(|selected| path_is_prefix(path, selected)),
+    }
+}
+
+fn entry_is_selected(
+    path: &Path,
+    _metadata: &cap_std::fs::Metadata,
+    selection: &ScanSelection,
+) -> bool {
+    match selection {
+        ScanSelection::All => true,
+        ScanSelection::Paths(paths) => paths.iter().any(|selected| {
+            path == selected || path_is_prefix(selected, path) || path_is_prefix(path, selected)
+        }),
+    }
+}
+
+fn entry_is_ancestor_or_selected_directory(
+    path: &Path,
+    metadata: &cap_std::fs::Metadata,
+    selection: &ScanSelection,
+) -> bool {
+    metadata.file_type().is_dir() && entry_is_ancestor(path, selection)
+}
+
+fn sorted_names(directory: &cap_std::fs::Dir) -> Result<Vec<OsString>, Status> {
+    let mut names = directory
+        .entries()
+        .map_err(|error| {
+            Status::internal(format!("failed to read local source directory: {error}"))
+        })?
+        .map(|entry| {
+            entry.map(|entry| entry.file_name()).map_err(|error| {
+                Status::internal(format!("failed to read local source entry: {error}"))
+            })
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    names.sort_unstable();
+    Ok(names)
+}
+
+fn source_stat(
+    directory: &cap_std::fs::Dir,
+    name: &OsStr,
+    relative: &Path,
+    metadata: &cap_std::fs::Metadata,
+) -> Result<(Stat, bool), Status> {
+    let path = relative
+        .to_str()
+        .ok_or_else(|| Status::invalid_argument("local source contains a non-UTF-8 path"))?;
+    if path.is_empty()
+        || path.len() > MAX_PATH_LENGTH
+        || !relative
+            .components()
+            .all(|component| matches!(component, std::path::Component::Normal(_)))
+    {
+        return Err(Status::invalid_argument(
+            "local source contains an invalid path",
+        ));
+    }
+
+    let file_type = metadata.file_type();
+    let (mode, size, linkname, regular) = if file_type.is_dir() {
+        (file_mode_dir(metadata), 0, String::new(), false)
+    } else if file_type.is_symlink() {
+        let linkname = directory
+            .read_link_contents(name)
+            .map_err(|error| filesystem_error("read symlink", relative, error))?
+            .into_os_string()
+            .into_string()
+            .map_err(|_| Status::invalid_argument("local source contains a non-UTF-8 symlink"))?;
+        if linkname.is_empty() || linkname.len() > MAX_LINKNAME_LENGTH || linkname.contains('\0') {
+            return Err(Status::invalid_argument(
+                "local source contains an invalid symlink",
+            ));
+        }
+        (
+            super::fsutil::FileMode::Symlink.bits() | 0o777,
+            0,
+            linkname.replace(std::path::MAIN_SEPARATOR, "/"),
+            false,
+        )
+    } else if file_type.is_file() {
+        let size = i64::try_from(metadata.len())
+            .map_err(|_| Status::resource_exhausted("local source file is too large"))?;
+        (file_permissions(metadata), size, String::new(), true)
+    } else {
+        return Err(Status::invalid_argument(format!(
+            "local source contains an unsupported special file: {path:?}"
+        )));
+    };
+
+    Ok((
+        Stat {
+            path: path.replace(std::path::MAIN_SEPARATOR, "/"),
+            mode,
+            uid: file_uid(metadata),
+            gid: file_gid(metadata),
+            size,
+            mod_time: modification_time(metadata),
+            linkname,
+            ..Default::default()
+        },
+        regular,
+    ))
+}
+
+fn filesystem_error(operation: &str, path: &Path, error: std::io::Error) -> Status {
+    Status::internal(format!(
+        "failed to {operation} local source {path:?}: {error}"
+    ))
+}
+
+fn file_mode_dir(metadata: &cap_std::fs::Metadata) -> u32 {
+    super::fsutil::FileMode::Dir.bits() | file_permissions(metadata)
+}
+
+#[cfg(unix)]
+fn file_permissions(metadata: &cap_std::fs::Metadata) -> u32 {
+    metadata.mode() & 0o777
+}
+
+#[cfg(not(unix))]
+fn file_permissions(metadata: &cap_std::fs::Metadata) -> u32 {
+    let _ = metadata;
+    0o755
+}
+
+#[cfg(unix)]
+fn file_uid(metadata: &cap_std::fs::Metadata) -> u32 {
+    metadata.uid()
+}
+
+#[cfg(not(unix))]
+fn file_uid(metadata: &cap_std::fs::Metadata) -> u32 {
+    let _ = metadata;
+    0
+}
+
+#[cfg(unix)]
+fn file_gid(metadata: &cap_std::fs::Metadata) -> u32 {
+    metadata.gid()
+}
+
+#[cfg(not(unix))]
+fn file_gid(metadata: &cap_std::fs::Metadata) -> u32 {
+    let _ = metadata;
+    0
+}
+
+#[cfg(unix)]
+fn modification_time(metadata: &cap_std::fs::Metadata) -> i64 {
+    metadata
+        .mtime()
+        .checked_mul(1_000_000_000)
+        .and_then(|seconds| seconds.checked_add(metadata.mtime_nsec()))
+        .unwrap_or(0)
+}
+
+#[cfg(not(unix))]
+fn modification_time(metadata: &cap_std::fs::Metadata) -> i64 {
+    metadata
+        .modified()
+        .ok()
+        .and_then(|time| time.duration_since(UNIX_EPOCH).ok())
+        .and_then(|duration| i64::try_from(duration.as_nanos()).ok())
+        .unwrap_or(0)
+}
+
+fn stat_entry_packet(stat: Stat) -> Packet {
+    Packet {
+        r#type: PacketType::PacketStat as i32,
+        stat: Some(stat),
+        ..Default::default()
+    }
+}
+
+fn stat_terminator() -> Packet {
+    Packet {
+        r#type: PacketType::PacketStat as i32,
+        ..Default::default()
+    }
+}
+
+fn fin_response_packet() -> Packet {
+    Packet {
+        r#type: PacketType::PacketFin as i32,
+        ..Default::default()
+    }
+}
+
+fn file_data_packet(id: u32, data: Vec<u8>) -> Packet {
+    Packet {
+        r#type: PacketType::PacketData as i32,
+        id,
+        data,
+        ..Default::default()
+    }
+}
+
+fn error_packet(error: &Status) -> Packet {
+    Packet {
+        r#type: PacketType::PacketErr as i32,
+        data: error.message().as_bytes().to_vec(),
+        ..Default::default()
+    }
+}
+
+#[cfg(test)]
+use futures_util::stream;
+#[cfg(test)]
+use std::collections::HashSet;
+#[cfg(test)]
+use tokio_stream::wrappers::{ReceiverStream, TcpListenerStream};
+#[cfg(test)]
+use tonic::transport::Server;
+
+#[cfg(test)]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct ContractEntry {
+    pub(crate) path: &'static str,
+    pub(crate) regular: bool,
+}
+
+#[cfg(test)]
+#[derive(Clone, Debug)]
+pub(crate) struct PacketContract {
+    entries: Vec<ContractEntry>,
+}
+
+#[cfg(test)]
+impl PacketContract {
+    pub(crate) fn new(entries: impl IntoIterator<Item = ContractEntry>) -> Self {
+        Self {
+            entries: entries.into_iter().collect(),
+        }
+    }
+
+    pub(crate) fn stat_packets(&self) -> Vec<Packet> {
+        self.entries
+            .iter()
+            .map(|entry| stat_packet(entry.path))
+            .chain(std::iter::once(stat_packet_without_entry()))
+            .collect()
+    }
+
+    pub(crate) fn validate_stat_packets(&self, packets: &[Packet]) -> Result<(), String> {
+        if packets.len() != self.entries.len() + 1 {
+            return Err(format!(
+                "expected {} STAT packets, got {}",
+                self.entries.len() + 1,
+                packets.len()
+            ));
+        }
+
+        for (index, (packet, expected)) in packets.iter().zip(self.entries.iter()).enumerate() {
+            if packet.r#type != PacketType::PacketStat as i32 {
+                return Err(format!("packet {index} is not PACKET_STAT"));
+            }
+            if packet.id != 0 {
+                return Err(format!("packet {index} has non-zero STAT ID"));
+            }
+            if packet.stat.as_ref().map(|stat| stat.path.as_str()) != Some(expected.path) {
+                return Err(format!("packet {index} has the wrong path"));
+            }
+        }
+
+        let terminator = packets.last().expect("length checked above");
+        if terminator.r#type != PacketType::PacketStat as i32
+            || terminator.id != 0
+            || terminator.stat.is_some()
+        {
+            return Err(String::from("STAT terminator is malformed"));
+        }
+        Ok(())
+    }
+
+    pub(crate) fn regular_ids(&self) -> HashSet<u32> {
+        self.entries
+            .iter()
+            .enumerate()
+            .filter_map(|(index, entry)| entry.regular.then_some(index as u32))
+            .collect()
+    }
+}
+
+#[cfg(test)]
+#[derive(Debug)]
+pub(crate) struct RequestLedger {
+    available: HashSet<u32>,
+}
+
+#[cfg(test)]
+impl RequestLedger {
+    pub(crate) fn new(contract: &PacketContract) -> Self {
+        Self {
+            available: contract.regular_ids(),
+        }
+    }
+
+    pub(crate) fn accept(&mut self, id: u32) -> Result<(), String> {
+        if self.available.remove(&id) {
+            Ok(())
+        } else {
+            Err(format!("invalid or repeated file request {id}"))
+        }
+    }
+}
+
+#[cfg(test)]
+pub(crate) fn stat_packet(path: &'static str) -> Packet {
+    Packet {
+        r#type: PacketType::PacketStat as i32,
+        stat: Some(Stat {
+            path: path.to_owned(),
+            ..Default::default()
+        }),
+        ..Default::default()
+    }
+}
+
+#[cfg(test)]
+pub(crate) fn stat_packet_without_entry() -> Packet {
+    Packet {
+        r#type: PacketType::PacketStat as i32,
+        ..Default::default()
+    }
+}
+
+#[cfg(test)]
+pub(crate) fn request_packet(id: u32) -> Packet {
+    Packet {
+        r#type: PacketType::PacketReq as i32,
+        id,
+        ..Default::default()
+    }
+}
+
+#[cfg(test)]
+pub(crate) fn data_packet(id: u32, data: impl Into<Vec<u8>>) -> Packet {
+    file_data_packet(id, data.into())
+}
+
+#[cfg(test)]
+pub(crate) fn fin_packet() -> Packet {
+    Packet {
+        r#type: PacketType::PacketFin as i32,
+        ..Default::default()
+    }
+}
+
+#[cfg(test)]
+pub(crate) fn err_packet(message: impl Into<Vec<u8>>) -> Packet {
+    Packet {
+        r#type: PacketType::PacketErr as i32,
+        data: message.into(),
+        ..Default::default()
+    }
+}
+
+#[cfg(test)]
+pub(crate) fn collect_file_data(packets: &[Packet], id: u32) -> Result<Vec<u8>, String> {
+    let mut data = Vec::new();
+    let mut terminated = false;
+
+    for packet in packets.iter().filter(|packet| packet.id == id) {
+        if packet.r#type != PacketType::PacketData as i32 {
+            return Err(format!("file {id} contains a non-DATA packet"));
+        }
+        if packet.data.is_empty() {
+            if terminated {
+                return Err(format!("file {id} has repeated EOF"));
+            }
+            terminated = true;
+        } else if terminated {
+            return Err(format!("file {id} has DATA after EOF"));
+        } else {
+            data.extend_from_slice(&packet.data);
+        }
+    }
+
+    if terminated {
+        Ok(data)
+    } else {
+        Err(format!("file {id} has no DATA EOF"))
+    }
+}
+
+#[cfg(test)]
+pub(crate) struct ScriptedPeer {
+    requests: mpsc::Sender<Packet>,
+    responses: Pin<Box<dyn Stream<Item = Result<Packet, Status>> + Send>>,
+}
+
+#[cfg(test)]
+impl ScriptedPeer {
+    pub(crate) fn new(
+        responses: impl Stream<Item = Result<Packet, Status>> + Send + 'static,
+    ) -> (Self, ReceiverStream<Packet>) {
+        let (requests, receiver) = mpsc::channel(OUTPUT_QUEUE_CAPACITY);
+        (
+            Self {
+                requests,
+                responses: Box::pin(responses),
+            },
+            ReceiverStream::new(receiver),
+        )
+    }
+
+    pub(crate) async fn send(&self, packet: Packet) -> Result<(), String> {
+        self.requests
+            .send(packet)
+            .await
+            .map_err(|_| String::from("scripted peer request channel closed"))
+    }
+
+    pub(crate) async fn next(&mut self) -> Option<Result<Packet, Status>> {
+        futures_util::StreamExt::next(&mut self.responses).await
+    }
+
+    pub(crate) fn close(self) {
+        drop(self.requests);
+        drop(self.responses);
+    }
+}
+
+#[cfg(test)]
+async fn start_filesync_server(
+    root: Arc<cap_std::fs::Dir>,
+) -> (
+    std::net::SocketAddr,
+    tokio::sync::oneshot::Sender<()>,
+    tokio::task::JoinHandle<()>,
+) {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("FileSync test listener binds");
+    let address = listener.local_addr().expect("FileSync test address exists");
+    let mounts = HashMap::from([(String::from("context"), root)]);
+    let (shutdown_sender, shutdown_receiver) = tokio::sync::oneshot::channel();
+    let server = Server::builder()
+        .add_service(FileSyncServer::new(FileSyncImpl::new(mounts)))
+        .serve_with_incoming_shutdown(TcpListenerStream::new(listener), async move {
+            let _ = shutdown_receiver.await;
+        });
+    let server_task = tokio::spawn(async move {
+        let _ = server.await;
+    });
+    (address, shutdown_sender, server_task)
+}
+
+#[cfg(test)]
+async fn open_filesync_transfer(
+    root: Arc<cap_std::fs::Dir>,
+) -> (
+    mpsc::Sender<Packet>,
+    Streaming<Packet>,
+    tokio::sync::oneshot::Sender<()>,
+    tokio::task::JoinHandle<()>,
+) {
+    open_filesync_transfer_with_controls(root, false, false).await
+}
+
+#[cfg(test)]
+async fn open_filesync_transfer_with_controls(
+    root: Arc<cap_std::fs::Dir>,
+    panic_worker: bool,
+    delay_scan: bool,
+) -> (
+    mpsc::Sender<Packet>,
+    Streaming<Packet>,
+    tokio::sync::oneshot::Sender<()>,
+    tokio::task::JoinHandle<()>,
+) {
+    let (address, shutdown_sender, server_task) = start_filesync_server(root).await;
+    let mut client =
+        bollard_buildkit_proto::moby::filesync::v1::file_sync_client::FileSyncClient::connect(
+            format!("http://{address}"),
+        )
+        .await
+        .expect("FileSync client connects");
+    let (sender, receiver) = mpsc::channel(OUTPUT_QUEUE_CAPACITY);
+    let mut request = Request::new(ReceiverStream::new(receiver));
+    request.metadata_mut().insert(
+        DIR_NAME_METADATA,
+        tonic::metadata::MetadataValue::try_from("context").expect("metadata value is valid"),
+    );
+    if panic_worker {
+        request.metadata_mut().insert(
+            "x-test-panic-worker",
+            tonic::metadata::MetadataValue::try_from("1").expect("metadata value is valid"),
+        );
+    }
+    if delay_scan {
+        request.metadata_mut().insert(
+            "x-test-delay-scan",
+            tonic::metadata::MetadataValue::try_from("1").expect("metadata value is valid"),
+        );
+    }
+    let responses = client
+        .diff_copy(request)
+        .await
+        .expect("DiffCopy starts")
+        .into_inner();
+    (sender, responses, shutdown_sender, server_task)
+}
+
+#[cfg(test)]
+async fn read_stat_terminator(responses: &mut Streaming<Packet>) -> Vec<Packet> {
+    let mut packets = Vec::new();
+    loop {
+        let packet = responses
+            .message()
+            .await
+            .expect("STAT response succeeds")
+            .expect("STAT response exists");
+        assert_eq!(packet.r#type, PacketType::PacketStat as i32);
+        let done = packet.stat.is_none();
+        packets.push(packet);
+        if done {
+            return packets;
+        }
+    }
+}
+
+#[cfg(test)]
+async fn expect_protocol_error(responses: &mut Streaming<Packet>) -> tonic::Status {
+    loop {
+        let packet = responses
+            .message()
+            .await
+            .expect("FileSync error packet succeeds")
+            .expect("FileSync error packet exists");
+        if packet.r#type == PacketType::PacketErr as i32 {
+            return responses
+                .message()
+                .await
+                .expect_err("FileSync stream returns its protocol error");
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use futures_util::StreamExt;
+    use tempfile::tempdir;
+
+    fn open_mount(path: &Path) -> Arc<cap_std::fs::Dir> {
+        Arc::new(
+            cap_std::fs::Dir::open_ambient_dir(path, cap_std::ambient_authority())
+                .expect("temporary mount opens"),
+        )
+    }
+
+    async fn scan_fixture(root: Arc<cap_std::fs::Dir>) -> Vec<SourceEntry> {
+        let (sender, mut receiver) = mpsc::channel(ENTRY_QUEUE_CAPACITY);
+        let scanner = tokio::task::spawn_blocking(move || scan_entries(root, sender));
+        let mut entries = Vec::new();
+        while let Some(event) = receiver.recv().await {
+            entries.push(event.expect("fixture scan succeeds"));
+        }
+        scanner
+            .await
+            .expect("fixture scanner joins")
+            .expect("fixture scanner succeeds");
+        entries
+    }
+
+    fn sample_contract() -> PacketContract {
+        PacketContract::new([
+            ContractEntry {
+                path: "directory",
+                regular: false,
+            },
+            ContractEntry {
+                path: "directory/input.txt",
+                regular: true,
+            },
+            ContractEntry {
+                path: "link",
+                regular: false,
+            },
+            ContractEntry {
+                path: "empty.txt",
+                regular: true,
+            },
+        ])
+    }
+
+    #[test]
+    fn contract_tracks_positional_regular_file_ids() {
+        let contract = sample_contract();
+        contract
+            .validate_stat_packets(&contract.stat_packets())
+            .expect("fixture STAT packets are valid");
+        assert_eq!(contract.regular_ids(), HashSet::from([1, 3]));
+    }
+
+    #[test]
+    fn contract_requires_zero_stat_packet_ids() {
+        let contract = sample_contract();
+        let mut packets = contract.stat_packets();
+        packets[1].id = 1;
+        assert!(contract.validate_stat_packets(&packets).is_err());
+    }
+
+    #[test]
+    fn request_ledger_rejects_duplicate_unknown_and_non_regular_ids() {
+        let contract = sample_contract();
+        let mut ledger = RequestLedger::new(&contract);
+        assert!(ledger.accept(1).is_ok());
+        assert!(ledger.accept(1).is_err());
+        assert!(ledger.accept(0).is_err());
+        assert!(ledger.accept(99).is_err());
+    }
+
+    #[test]
+    fn data_collection_requires_one_empty_eof_packet() {
+        let packets = [
+            data_packet(1, b"first".to_vec()),
+            data_packet(3, b"other".to_vec()),
+            data_packet(1, b"second".to_vec()),
+            data_packet(1, Vec::new()),
+            data_packet(3, Vec::new()),
+        ];
+        assert_eq!(collect_file_data(&packets, 1).unwrap(), b"firstsecond");
+        assert_eq!(collect_file_data(&packets, 3).unwrap(), b"other");
+    }
+
+    #[test]
+    fn protocol_bounds_are_fixed_before_sender_implementation() {
+        assert_eq!(ENTRY_QUEUE_CAPACITY, 128);
+        assert_eq!(FILE_JOB_QUEUE_CAPACITY, 128);
+        assert_eq!(OUTPUT_QUEUE_CAPACITY, 16);
+        assert_eq!(FILE_WORKER_COUNT, 4);
+        assert_eq!(FILE_READ_BUFFER_SIZE, 32 * 1024);
+    }
+
+    #[tokio::test]
+    async fn scripted_peer_uses_bounded_request_and_response_channels() {
+        let (mut peer, mut requests) =
+            ScriptedPeer::new(stream::iter([Ok(data_packet(1, b"response".to_vec()))]));
+        peer.send(request_packet(1))
+            .await
+            .expect("scripted peer accepts requests");
+        assert_eq!(requests.next().await, Some(request_packet(1)));
+        assert_eq!(
+            peer.next()
+                .await
+                .expect("scripted response exists")
+                .unwrap(),
+            data_packet(1, b"response".to_vec())
+        );
+        peer.close();
+    }
+
+    #[tokio::test]
+    async fn scanner_walks_depth_first_lexically_and_registers_positions() {
+        let root = tempdir().expect("temporary directory is created");
+        std::fs::create_dir(root.path().join("b")).expect("b directory is created");
+        std::fs::create_dir(root.path().join("a")).expect("a directory is created");
+        std::fs::write(root.path().join("b/z.txt"), b"z").expect("z file is created");
+        std::fs::write(root.path().join("a/x.txt"), b"x").expect("x file is created");
+        #[cfg(unix)]
+        std::os::unix::fs::symlink("a/x.txt", root.path().join("link"))
+            .expect("symlink is created");
+
+        let entries = scan_fixture(open_mount(root.path())).await;
+        let paths = entries
+            .iter()
+            .map(|entry| entry.stat.path.as_str())
+            .collect::<Vec<_>>();
+        #[cfg(unix)]
+        assert_eq!(paths, ["a", "a/x.txt", "b", "b/z.txt", "link"]);
+        #[cfg(not(unix))]
+        assert_eq!(paths, ["a", "a/x.txt", "b", "b/z.txt"]);
+        assert!(entries.iter().all(|entry| entry.stat.path != "."));
+        assert_eq!(
+            entries
+                .iter()
+                .filter(|entry| entry.regular)
+                .map(|entry| entry.position)
+                .collect::<Vec<_>>(),
+            [1, 3]
+        );
+        assert!(entries
+            .iter()
+            .all(|entry| entry.stat.path.len() <= MAX_PATH_LENGTH));
+    }
+
+    #[tokio::test]
+    async fn scanner_emits_regular_and_symlink_metadata() {
+        let root = tempdir().expect("temporary directory is created");
+        std::fs::write(root.path().join("empty"), b"").expect("empty file is created");
+        #[cfg(unix)]
+        std::os::unix::fs::symlink("empty", root.path().join("link")).expect("symlink is created");
+
+        let entries = scan_fixture(open_mount(root.path())).await;
+        let empty = entries
+            .iter()
+            .find(|entry| entry.stat.path == "empty")
+            .expect("empty file stat exists");
+        assert!(empty.regular);
+        assert_eq!(empty.stat.size, 0);
+        assert_eq!(
+            empty.stat.mode & super::super::fsutil::FileMode::Type.bits(),
+            0
+        );
+
+        #[cfg(unix)]
+        {
+            let link = entries
+                .iter()
+                .find(|entry| entry.stat.path == "link")
+                .expect("symlink stat exists");
+            assert!(!link.regular);
+            assert_ne!(
+                link.stat.mode & super::super::fsutil::FileMode::Symlink.bits(),
+                0
+            );
+            assert_eq!(link.stat.linkname, "empty");
+            assert_eq!(link.stat.size, 0);
+        }
+    }
+
+    #[tokio::test]
+    async fn scanner_applies_literal_followpaths_with_ancestors() {
+        let root = tempdir().expect("temporary directory is created");
+        std::fs::create_dir(root.path().join("a")).expect("a directory is created");
+        std::fs::create_dir(root.path().join("b")).expect("b directory is created");
+        std::fs::write(root.path().join("a/input"), b"source").expect("input is created");
+        std::fs::write(root.path().join("b/other"), b"other").expect("other is created");
+        let mut metadata = MetadataMap::new();
+        metadata.insert(
+            FOLLOW_PATHS_METADATA,
+            tonic::metadata::MetadataValue::try_from("a/input")
+                .expect("follow path metadata is valid"),
+        );
+        let selection = scan_selection(&metadata).expect("follow path is accepted");
+        let (sender, mut receiver) = mpsc::channel(ENTRY_QUEUE_CAPACITY);
+        let scanner = tokio::task::spawn_blocking({
+            let root = open_mount(root.path());
+            move || {
+                scan_entries_with_selection(
+                    root,
+                    sender,
+                    selection,
+                    CancellationToken::new(),
+                    false,
+                )
+            }
+        });
+        let mut paths = Vec::new();
+        while let Some(event) = receiver.recv().await {
+            paths.push(event.expect("selected scan succeeds").stat.path);
+        }
+        scanner
+            .await
+            .expect("selected scanner joins")
+            .expect("selected scanner succeeds");
+        assert_eq!(paths, ["a", "a/input"]);
+    }
+
+    #[test]
+    fn scanner_rejects_unsupported_options_and_long_paths() {
+        let mut metadata = MetadataMap::new();
+        metadata.insert(
+            DIR_NAME_METADATA,
+            tonic::metadata::MetadataValue::try_from("context").expect("metadata value is valid"),
+        );
+        assert_eq!(mount_name(&metadata).expect("mount name exists"), "context");
+        assert_eq!(
+            mount_name(&MetadataMap::new()).unwrap_err().code(),
+            tonic::Code::NotFound
+        );
+
+        let mut metadata = MetadataMap::new();
+        metadata.insert(
+            INCLUDE_PATTERNS_METADATA,
+            tonic::metadata::MetadataValue::try_from("*.tmp").expect("metadata value is valid"),
+        );
+        assert_eq!(
+            validate_options(&metadata).unwrap_err().code(),
+            tonic::Code::InvalidArgument
+        );
+
+        let mut metadata = MetadataMap::new();
+        metadata.insert(
+            FOLLOW_PATHS_METADATA,
+            tonic::metadata::MetadataValue::try_from("**/*.rs").expect("metadata value is valid"),
+        );
+        assert_eq!(
+            validate_options(&metadata).unwrap_err().code(),
+            tonic::Code::Unimplemented
+        );
+        let mut metadata = MetadataMap::new();
+        metadata.insert(
+            FOLLOW_PATHS_METADATA,
+            tonic::metadata::MetadataValue::try_from(".").expect("metadata value is valid"),
+        );
+        validate_options(&metadata).expect("the whole-tree follow path is supported");
+
+        let root = tempdir().expect("temporary directory is created");
+        let mounts = HashMap::from([(String::from("context"), open_mount(root.path()))]);
+        assert_eq!(
+            lookup_mount(&mounts, "missing").unwrap_err().code(),
+            tonic::Code::NotFound
+        );
+        let file = root.path().join("file");
+        std::fs::write(&file, b"data").expect("file is created");
+        let metadata =
+            cap_std::fs::Dir::open_ambient_dir(root.path(), cap_std::ambient_authority())
+                .expect("mount opens")
+                .symlink_metadata("file")
+                .expect("file metadata exists");
+        let long_path = PathBuf::from("x".repeat(MAX_PATH_LENGTH + 1));
+        assert_eq!(
+            source_stat(
+                &cap_std::fs::Dir::open_ambient_dir(root.path(), cap_std::ambient_authority())
+                    .expect("mount opens"),
+                OsStr::new("file"),
+                &long_path,
+                &metadata,
+            )
+            .unwrap_err()
+            .code(),
+            tonic::Code::InvalidArgument
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn scanner_rejects_special_files() {
+        use std::os::unix::net::UnixListener;
+
+        let root = tempdir().expect("temporary directory is created");
+        let _socket =
+            UnixListener::bind(root.path().join("socket")).expect("unix socket is created");
+        let (sender, mut receiver) = mpsc::channel(ENTRY_QUEUE_CAPACITY);
+        let scanner = tokio::task::spawn_blocking({
+            let root = open_mount(root.path());
+            move || {
+                let result = scan_entries(root, sender.clone());
+                if let Err(error) = &result {
+                    let _ = sender.blocking_send(Err(error.clone()));
+                }
+                result
+            }
+        });
+        let event = receiver.recv().await.expect("scanner reports an error");
+        assert_eq!(event.unwrap_err().code(), tonic::Code::InvalidArgument);
+        assert!(scanner.await.expect("scanner joins").is_err());
+    }
+
+    #[tokio::test]
+    async fn diff_copy_streams_stats_and_transfers_requested_files() {
+        let root = tempdir().expect("temporary directory is created");
+        std::fs::write(root.path().join("input"), b"source").expect("source file is created");
+        let (address, shutdown_sender, server_task) =
+            start_filesync_server(open_mount(root.path())).await;
+        let mut client =
+            bollard_buildkit_proto::moby::filesync::v1::file_sync_client::FileSyncClient::connect(
+                format!("http://{address}"),
+            )
+            .await
+            .expect("FileSync client connects");
+        let (sender, receiver) = mpsc::channel(8);
+        let mut request = Request::new(ReceiverStream::new(receiver));
+        request.metadata_mut().insert(
+            DIR_NAME_METADATA,
+            tonic::metadata::MetadataValue::try_from("context").expect("metadata value is valid"),
+        );
+        let mut responses = client
+            .diff_copy(request)
+            .await
+            .expect("DiffCopy starts")
+            .into_inner();
+        let stat = responses
+            .message()
+            .await
+            .expect("STAT response succeeds")
+            .expect("STAT response exists");
+        assert_eq!(stat.r#type, PacketType::PacketStat as i32);
+        assert_eq!(stat.id, 0);
+        assert_eq!(stat.stat.expect("entry stat exists").path, "input");
+        let terminator = responses
+            .message()
+            .await
+            .expect("STAT terminator succeeds")
+            .expect("STAT terminator exists");
+        assert_eq!(terminator.r#type, PacketType::PacketStat as i32);
+        assert!(terminator.stat.is_none());
+
+        sender
+            .send(request_packet(0))
+            .await
+            .expect("request channel remains open");
+        let data = responses
+            .message()
+            .await
+            .expect("DATA response succeeds")
+            .expect("DATA response exists");
+        assert_eq!(data, data_packet(0, b"source".to_vec()));
+        let eof = responses
+            .message()
+            .await
+            .expect("DATA EOF succeeds")
+            .expect("DATA EOF exists");
+        assert_eq!(eof, data_packet(0, Vec::new()));
+        sender
+            .send(fin_packet())
+            .await
+            .expect("FIN request is accepted");
+        let fin = responses
+            .message()
+            .await
+            .expect("FIN response succeeds")
+            .expect("FIN response exists");
+        assert_eq!(fin.r#type, PacketType::PacketFin as i32);
+        assert!(responses.message().await.expect("stream closes").is_none());
+
+        drop(sender);
+        let _ = shutdown_sender.send(());
+        let _ = server_task.await;
+    }
+
+    #[tokio::test]
+    async fn diff_copy_accepts_pipelined_requests() {
+        let root = tempdir().expect("temporary directory is created");
+        std::fs::write(root.path().join("a"), b"a").expect("a is created");
+        std::fs::write(root.path().join("b"), b"b").expect("b is created");
+        let (sender, mut responses, shutdown, server) =
+            open_filesync_transfer(open_mount(root.path())).await;
+        let stats = read_stat_terminator(&mut responses).await;
+        assert_eq!(stats.len(), 3);
+        sender.send(request_packet(0)).await.expect("request sends");
+        sender.send(request_packet(1)).await.expect("request sends");
+        sender.send(fin_packet()).await.expect("FIN sends");
+        let mut data = Vec::new();
+        let mut eof = HashSet::new();
+        while eof.len() < 2 {
+            let packet = responses
+                .message()
+                .await
+                .expect("DATA succeeds")
+                .expect("DATA exists");
+            assert_eq!(packet.r#type, PacketType::PacketData as i32);
+            if packet.data.is_empty() {
+                eof.insert(packet.id);
+            } else {
+                data.push(packet);
+            }
+        }
+        assert_eq!(data.len(), 2);
+        assert_eq!(
+            responses.message().await.unwrap().unwrap().r#type,
+            PacketType::PacketFin as i32
+        );
+        let _ = shutdown.send(());
+        let _ = server.await;
+    }
+
+    #[tokio::test]
+    async fn diff_copy_reports_peer_protocol_errors() {
+        let root = tempdir().expect("temporary directory is created");
+        std::fs::write(root.path().join("input"), b"source").expect("source is created");
+        let (sender, mut responses, shutdown, server) =
+            open_filesync_transfer(open_mount(root.path())).await;
+        read_stat_terminator(&mut responses).await;
+        sender
+            .send(err_packet("peer failure"))
+            .await
+            .expect("ERR sends");
+        assert_eq!(
+            expect_protocol_error(&mut responses).await.code(),
+            tonic::Code::Aborted
+        );
+        let _ = shutdown.send(());
+        let _ = server.await;
+    }
+
+    #[tokio::test]
+    async fn diff_copy_streams_data_and_fin() {
+        let root = tempdir().expect("temporary directory is created");
+        std::fs::write(root.path().join("input"), b"source").expect("source is created");
+        let (sender, mut responses, shutdown, server) =
+            open_filesync_transfer(open_mount(root.path())).await;
+        read_stat_terminator(&mut responses).await;
+        sender.send(request_packet(0)).await.expect("request sends");
+        assert_eq!(
+            responses.message().await.unwrap().unwrap(),
+            data_packet(0, b"source".to_vec())
+        );
+        assert_eq!(
+            responses.message().await.unwrap().unwrap(),
+            data_packet(0, Vec::new())
+        );
+        sender.send(fin_packet()).await.expect("FIN sends");
+        assert_eq!(
+            responses.message().await.unwrap().unwrap().r#type,
+            PacketType::PacketFin as i32
+        );
+        let _ = shutdown.send(());
+        let _ = server.await;
+    }
+
+    #[tokio::test]
+    async fn diff_copy_terminates_empty_files() {
+        let root = tempdir().expect("temporary directory is created");
+        std::fs::write(root.path().join("empty"), b"").expect("empty file is created");
+        let (sender, mut responses, shutdown, server) =
+            open_filesync_transfer(open_mount(root.path())).await;
+        read_stat_terminator(&mut responses).await;
+        sender.send(request_packet(0)).await.expect("request sends");
+        assert_eq!(
+            responses.message().await.unwrap().unwrap(),
+            data_packet(0, Vec::new())
+        );
+        sender.send(fin_packet()).await.expect("FIN sends");
+        assert_eq!(
+            responses.message().await.unwrap().unwrap().r#type,
+            PacketType::PacketFin as i32
+        );
+        let _ = shutdown.send(());
+        let _ = server.await;
+    }
+
+    #[tokio::test]
+    async fn diff_copy_preserves_each_file_data_order() {
+        let root = tempdir().expect("temporary directory is created");
+        std::fs::write(root.path().join("a"), vec![b'a'; FILE_READ_BUFFER_SIZE * 2])
+            .expect("a is created");
+        std::fs::write(root.path().join("b"), vec![b'b'; FILE_READ_BUFFER_SIZE * 2])
+            .expect("b is created");
+        let (sender, mut responses, shutdown, server) =
+            open_filesync_transfer(open_mount(root.path())).await;
+        read_stat_terminator(&mut responses).await;
+        sender.send(request_packet(0)).await.expect("request sends");
+        sender.send(request_packet(1)).await.expect("request sends");
+        sender.send(fin_packet()).await.expect("FIN sends");
+        let mut packets = Vec::new();
+        let mut eof = HashSet::new();
+        while eof.len() < 2 {
+            let packet = responses.message().await.unwrap().unwrap();
+            if packet.data.is_empty() {
+                eof.insert(packet.id);
+            }
+            packets.push(packet);
+        }
+        assert_eq!(
+            collect_file_data(&packets, 0).unwrap(),
+            vec![b'a'; FILE_READ_BUFFER_SIZE * 2]
+        );
+        assert_eq!(
+            collect_file_data(&packets, 1).unwrap(),
+            vec![b'b'; FILE_READ_BUFFER_SIZE * 2]
+        );
+        assert_eq!(
+            responses.message().await.unwrap().unwrap().r#type,
+            PacketType::PacketFin as i32
+        );
+        let _ = shutdown.send(());
+        let _ = server.await;
+    }
+
+    #[tokio::test]
+    async fn diff_copy_rejects_duplicate_and_unknown_requests() {
+        for duplicate in [true, false] {
+            let root = tempdir().expect("temporary directory is created");
+            std::fs::write(root.path().join("input"), b"source").expect("source is created");
+            let (sender, mut responses, shutdown, server) =
+                open_filesync_transfer(open_mount(root.path())).await;
+            read_stat_terminator(&mut responses).await;
+            sender
+                .send(request_packet(if duplicate { 0 } else { 99 }))
+                .await
+                .expect("request sends");
+            if duplicate {
+                let _ = responses.message().await.unwrap().unwrap();
+                sender
+                    .send(request_packet(0))
+                    .await
+                    .expect("duplicate sends");
+            }
+            assert_eq!(
+                expect_protocol_error(&mut responses).await.code(),
+                tonic::Code::InvalidArgument
+            );
+            let _ = shutdown.send(());
+            let _ = server.await;
+        }
+    }
+
+    #[tokio::test]
+    async fn diff_copy_rejects_unexpected_packets() {
+        let root = tempdir().expect("temporary directory is created");
+        std::fs::write(root.path().join("input"), b"source").expect("source is created");
+        let (sender, mut responses, shutdown, server) =
+            open_filesync_transfer(open_mount(root.path())).await;
+        read_stat_terminator(&mut responses).await;
+        sender
+            .send(data_packet(0, b"unexpected".to_vec()))
+            .await
+            .expect("packet sends");
+        assert_eq!(
+            expect_protocol_error(&mut responses).await.code(),
+            tonic::Code::InvalidArgument
+        );
+        let _ = shutdown.send(());
+        let _ = server.await;
+    }
+
+    #[tokio::test]
+    async fn diff_copy_rejects_early_fin() {
+        let root = tempdir().expect("temporary directory is created");
+        std::fs::write(root.path().join("input"), b"source").expect("source is created");
+        let (sender, mut responses, shutdown, server) =
+            open_filesync_transfer_with_controls(open_mount(root.path()), false, true).await;
+        let first = responses.message().await.unwrap().unwrap();
+        assert_eq!(first.r#type, PacketType::PacketStat as i32);
+        sender.send(fin_packet()).await.expect("FIN sends");
+        assert_eq!(
+            expect_protocol_error(&mut responses).await.code(),
+            tonic::Code::FailedPrecondition
+        );
+        let _ = shutdown.send(());
+        let _ = server.await;
+    }
+
+    #[tokio::test]
+    async fn diff_copy_rejects_input_eof_before_fin() {
+        let root = tempdir().expect("temporary directory is created");
+        std::fs::write(root.path().join("input"), b"source").expect("source is created");
+        let (sender, mut responses, shutdown, server) =
+            open_filesync_transfer(open_mount(root.path())).await;
+        read_stat_terminator(&mut responses).await;
+        drop(sender);
+        assert_eq!(
+            expect_protocol_error(&mut responses).await.code(),
+            tonic::Code::FailedPrecondition
+        );
+        let _ = shutdown.send(());
+        let _ = server.await;
+    }
+
+    #[tokio::test]
+    async fn diff_copy_waits_for_accepted_jobs_before_fin() {
+        let root = tempdir().expect("temporary directory is created");
+        std::fs::write(root.path().join("input"), b"source").expect("source is created");
+        let (sender, mut responses, shutdown, server) =
+            open_filesync_transfer(open_mount(root.path())).await;
+        read_stat_terminator(&mut responses).await;
+        sender.send(request_packet(0)).await.expect("request sends");
+        sender.send(fin_packet()).await.expect("FIN sends");
+        let data = responses.message().await.unwrap().unwrap();
+        assert_eq!(data.r#type, PacketType::PacketData as i32);
+        assert!(!data.data.is_empty());
+        assert_eq!(
+            responses.message().await.unwrap().unwrap(),
+            data_packet(0, Vec::new())
+        );
+        assert_eq!(
+            responses.message().await.unwrap().unwrap().r#type,
+            PacketType::PacketFin as i32
+        );
+        let _ = shutdown.send(());
+        let _ = server.await;
+    }
+
+    #[tokio::test]
+    async fn diff_copy_cancels_owned_tasks_when_response_is_dropped() {
+        let root = tempdir().expect("temporary directory is created");
+        std::fs::write(root.path().join("input"), b"source").expect("source is created");
+        let (sender, mut responses, shutdown, server) =
+            open_filesync_transfer(open_mount(root.path())).await;
+        let _ = responses.message().await;
+        drop(sender);
+        drop(responses);
+        let _ = shutdown.send(());
+        tokio::time::timeout(std::time::Duration::from_secs(1), server)
+            .await
+            .expect("FileSync server shuts down after cancellation")
+            .expect("FileSync server joins");
+    }
+
+    #[tokio::test]
+    async fn diff_copy_reports_worker_errors() {
+        let root = tempdir().expect("temporary directory is created");
+        std::fs::write(root.path().join("input"), b"source").expect("source is created");
+        let (sender, mut responses, shutdown, server) =
+            open_filesync_transfer(open_mount(root.path())).await;
+        read_stat_terminator(&mut responses).await;
+        std::fs::remove_file(root.path().join("input")).expect("source is removed");
+        sender.send(request_packet(0)).await.expect("request sends");
+        assert_eq!(
+            expect_protocol_error(&mut responses).await.code(),
+            tonic::Code::Internal
+        );
+        let _ = shutdown.send(());
+        let _ = server.await;
+    }
+
+    #[tokio::test]
+    async fn diff_copy_reports_worker_panics() {
+        let root = tempdir().expect("temporary directory is created");
+        std::fs::write(root.path().join("input"), b"source").expect("source is created");
+        let (sender, mut responses, shutdown, server) =
+            open_filesync_transfer_with_controls(open_mount(root.path()), true, false).await;
+        read_stat_terminator(&mut responses).await;
+        sender.send(request_packet(0)).await.expect("request sends");
+        assert_eq!(
+            expect_protocol_error(&mut responses).await.code(),
+            tonic::Code::Internal
+        );
+        let _ = shutdown.send(());
+        let _ = server.await;
+    }
+
+    #[tokio::test]
+    async fn diff_copy_applies_output_backpressure() {
+        let root = tempdir().expect("temporary directory is created");
+        std::fs::write(
+            root.path().join("input"),
+            vec![b'x'; FILE_READ_BUFFER_SIZE * 32],
+        )
+        .expect("source is created");
+        let (sender, mut responses, shutdown, server) =
+            open_filesync_transfer(open_mount(root.path())).await;
+        read_stat_terminator(&mut responses).await;
+        sender.send(request_packet(0)).await.expect("request sends");
+        sender.send(fin_packet()).await.expect("FIN sends");
+        let mut packets = Vec::new();
+        loop {
+            let packet = responses.message().await.unwrap().unwrap();
+            let done = packet.r#type == PacketType::PacketData as i32 && packet.data.is_empty();
+            packets.push(packet);
+            if done {
+                break;
+            }
+        }
+        assert_eq!(
+            collect_file_data(&packets, 0).unwrap().len(),
+            FILE_READ_BUFFER_SIZE * 32
+        );
+        assert_eq!(
+            responses.message().await.unwrap().unwrap().r#type,
+            PacketType::PacketFin as i32
+        );
+        let _ = shutdown.send(());
+        let _ = server.await;
+    }
+}

--- a/src/grpc/filesync.rs
+++ b/src/grpc/filesync.rs
@@ -19,11 +19,15 @@ use tokio::io::AsyncReadExt;
 use tokio::sync::{mpsc, Mutex};
 use tokio_util::sync::CancellationToken;
 use tonic::{metadata::MetadataMap, Request, Response, Status, Streaming};
+#[cfg(unix)]
+use xattr::FileExt;
+
+use super::patternmatcher::{match_component, PatternMatcher};
 
 #[cfg(unix)]
 use cap_std::fs::MetadataExt;
 #[cfg(not(unix))]
-use std::time::UNIX_EPOCH;
+use cap_std::time::SystemClock;
 
 const DIR_NAME_METADATA: &str = "dir-name";
 const INCLUDE_PATTERNS_METADATA: &str = "include-patterns";
@@ -233,7 +237,43 @@ impl FileSyncSession {
 #[derive(Clone, Debug)]
 enum ScanSelection {
     All,
-    Paths(Vec<PathBuf>),
+    Filter {
+        include: Option<PatternMatcher>,
+        exclude: Option<PatternMatcher>,
+    },
+}
+
+impl ScanSelection {
+    fn from_patterns(include: &[String], exclude: &[String]) -> Result<Self, Status> {
+        let include = PatternMatcher::new(include).map_err(|error| {
+            Status::invalid_argument(format!("invalid FileSync include pattern: {error}"))
+        })?;
+        let exclude = PatternMatcher::new(exclude).map_err(|error| {
+            Status::invalid_argument(format!("invalid FileSync exclude pattern: {error}"))
+        })?;
+        if include.is_none() && exclude.is_none() {
+            Ok(Self::All)
+        } else {
+            Ok(Self::Filter { include, exclude })
+        }
+    }
+
+    fn is_selected(&self, path: &Path) -> bool {
+        let path = path
+            .to_string_lossy()
+            .replace(std::path::MAIN_SEPARATOR, "/");
+        match self {
+            Self::All => true,
+            Self::Filter { include, exclude } => {
+                include
+                    .as_ref()
+                    .is_none_or(|matcher| matcher.matches_or_parent(&path))
+                    && exclude
+                        .as_ref()
+                        .is_none_or(|matcher| !matcher.matches_or_parent(&path))
+            }
+        }
+    }
 }
 
 struct ScanFrame {
@@ -241,6 +281,13 @@ struct ScanFrame {
     directory: cap_std::fs::Dir,
     names: Vec<OsString>,
     next_name: usize,
+    pending: bool,
+}
+
+struct PendingEntry {
+    stat: Stat,
+    regular: bool,
+    relative: PathBuf,
 }
 
 struct ScanBudget {
@@ -322,9 +369,14 @@ impl FileSync for FileSyncImpl {
         &self,
         request: Request<Streaming<Packet>>,
     ) -> Result<Response<Self::DiffCopyStream>, Status> {
-        let name = mount_name(request.metadata())?;
+        let options = parse_options(request.metadata())?;
+        validate_options(request.metadata())?;
+        let name = options
+            .dir_name
+            .clone()
+            .ok_or_else(|| Status::not_found("local source name is missing"))?;
         let root = lookup_mount(&self.mounts, &name)?;
-        let selection = scan_selection(request.metadata())?;
+        let selection = scan_selection(&root, &options)?;
         #[cfg(test)]
         let faults = FaultInjection::from_metadata(request.metadata());
         #[cfg(not(test))]
@@ -623,54 +675,243 @@ async fn open_regular_file(
     Ok(tokio::fs::File::from_std(file))
 }
 
-fn scan_selection(metadata: &MetadataMap) -> Result<ScanSelection, Status> {
-    validate_options(metadata)?;
-    let mut paths = Vec::new();
-    for value in metadata.get_all(FOLLOW_PATHS_METADATA).iter() {
-        let value = value
-            .to_str()
-            .map_err(|_| Status::invalid_argument("invalid followpaths metadata"))?;
-        if value == "." {
-            return Ok(ScanSelection::All);
-        }
-        let path = PathBuf::from(value);
-        if value.is_empty()
-            || path.is_absolute()
-            || path
-                .components()
-                .any(|component| !matches!(component, std::path::Component::Normal(_)))
-            || value.contains('*')
-            || value.contains('?')
-            || value.contains('[')
-        {
-            return Err(Status::unimplemented(
-                "FileSync followpaths must be literal relative paths",
-            ));
-        }
-        if path.to_str().is_none() || path.as_os_str().len() > MAX_PATH_LENGTH {
-            return Err(Status::invalid_argument(
-                "invalid FileSync followpaths path",
-            ));
-        }
-        paths.push(path);
+#[derive(Clone, Debug, Default)]
+struct FileSyncOptions {
+    dir_name: Option<String>,
+    include_patterns: Vec<String>,
+    exclude_patterns: Vec<String>,
+    follow_paths: Vec<String>,
+}
+
+fn parse_options(metadata: &MetadataMap) -> Result<FileSyncOptions, Status> {
+    Ok(FileSyncOptions {
+        dir_name: metadata_values(metadata, DIR_NAME_METADATA)?
+            .into_iter()
+            .next(),
+        include_patterns: metadata_values(metadata, INCLUDE_PATTERNS_METADATA)?,
+        exclude_patterns: metadata_values(metadata, EXCLUDE_PATTERNS_METADATA)?,
+        follow_paths: metadata_values(metadata, FOLLOW_PATHS_METADATA)?,
+    })
+}
+
+fn metadata_values(metadata: &MetadataMap, key: &str) -> Result<Vec<String>, Status> {
+    let encoded = metadata
+        .get(format!("{key}-encoded"))
+        .and_then(|value| value.to_str().ok())
+        .is_some_and(|value| matches!(value, "1" | "true" | "TRUE" | "True" | "t" | "T"));
+    metadata
+        .get_all(key)
+        .iter()
+        .map(|value| {
+            let value = value
+                .to_str()
+                .map_err(|_| Status::invalid_argument(format!("invalid {key} metadata")))?;
+            if encoded {
+                let encoded_value = format!("value={value}");
+                Ok(url::form_urlencoded::parse(encoded_value.as_bytes())
+                    .next()
+                    .map(|(_, value)| value.into_owned())
+                    .unwrap_or_default())
+            } else {
+                Ok(value.to_owned())
+            }
+        })
+        .collect()
+}
+
+fn scan_selection(
+    root: &cap_std::fs::Dir,
+    options: &FileSyncOptions,
+) -> Result<ScanSelection, Status> {
+    let mut include_patterns = options.include_patterns.clone();
+    let follow_patterns = resolve_follow_paths(root, &options.follow_paths)?;
+    if follow_patterns.iter().any(|path| path == ".") {
+        return ScanSelection::from_patterns(&include_patterns, &options.exclude_patterns);
     }
-    if paths.is_empty() {
-        Ok(ScanSelection::All)
+    include_patterns.extend(follow_patterns);
+    ScanSelection::from_patterns(&include_patterns, &options.exclude_patterns)
+}
+
+fn resolve_follow_paths(root: &cap_std::fs::Dir, paths: &[String]) -> Result<Vec<String>, Status> {
+    let mut resolved = Vec::new();
+    for path in paths {
+        if path == "." {
+            return Ok(vec![String::from(".")]);
+        }
+        resolved.push(path.clone());
+        let components = path.split('/').map(str::to_owned).collect::<Vec<_>>();
+        resolve_follow_components(
+            root,
+            Path::new(""),
+            &components,
+            &mut Vec::new(),
+            &mut resolved,
+        )?;
+    }
+    resolved.sort_unstable();
+    resolved.dedup();
+    Ok(resolved)
+}
+
+fn resolve_follow_components(
+    root: &cap_std::fs::Dir,
+    current: &Path,
+    components: &[String],
+    visited: &mut Vec<String>,
+    resolved: &mut Vec<String>,
+) -> Result<(), Status> {
+    let Some(component) = components.first() else {
+        if !current.as_os_str().is_empty() {
+            resolved.push(path_string(current)?);
+        }
+        return Ok(());
+    };
+
+    if contains_wildcard(component) {
+        let directory = if current.as_os_str().is_empty() {
+            root.try_clone()
+        } else {
+            root.open_dir(current)
+        };
+        let directory = match directory {
+            Ok(directory) => directory,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+            Err(error) => {
+                return Err(filesystem_error(
+                    "open followpaths directory",
+                    current,
+                    error,
+                ))
+            }
+        };
+        let mut names = directory
+            .entries()
+            .map_err(|error| filesystem_error("read followpaths directory", current, error))?
+            .map(|entry| {
+                entry
+                    .map(|entry| entry.file_name())
+                    .map_err(|error| filesystem_error("read followpaths entry", current, error))
+            })
+            .collect::<Result<Vec<_>, Status>>()?;
+        names.sort_unstable();
+        for name in names {
+            let Some(name) = name.to_str() else { continue };
+            if match_component(component, name) {
+                let next = current.join(name);
+                resolve_follow_components(root, &next, &components[1..], visited, resolved)?;
+            }
+        }
+        return Ok(());
+    }
+
+    let next = current.join(component);
+    let metadata = match root.symlink_metadata(&next) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(error) => return Err(filesystem_error("stat followpaths entry", &next, error)),
+    };
+    let next_string = path_string(&next)?;
+    if metadata.file_type().is_symlink() {
+        if visited.contains(&next_string) {
+            return Ok(());
+        }
+        visited.push(next_string.clone());
+        resolved.push(next_string);
+        let parent = next.parent().unwrap_or_else(|| Path::new(""));
+        let link = root
+            .read_link_contents(current.join(component).as_path())
+            .map_err(|error| filesystem_error("read followpaths symlink", &next, error))?;
+        let Some(target) = normalize_follow_target(parent, &link) else {
+            return Ok(());
+        };
+        if target.as_os_str().is_empty() {
+            resolved.push(String::from("."));
+            return Ok(());
+        }
+        let mut target_components = target
+            .components()
+            .filter_map(|component| match component {
+                std::path::Component::Normal(value) => value.to_str().map(str::to_owned),
+                _ => None,
+            })
+            .collect::<Vec<_>>();
+        target_components.extend_from_slice(&components[1..]);
+        return resolve_follow_components(
+            root,
+            Path::new(""),
+            &target_components,
+            visited,
+            resolved,
+        );
+    }
+    if components.len() == 1 {
+        resolved.push(next_string);
+    } else if !metadata.file_type().is_dir() {
+        return Ok(());
     } else {
-        paths.sort_unstable();
-        paths.dedup();
-        Ok(ScanSelection::Paths(paths))
+        resolve_follow_components(root, &next, &components[1..], visited, resolved)?;
     }
+    Ok(())
+}
+
+fn normalize_follow_target(parent: &Path, link: &Path) -> Option<PathBuf> {
+    let mut result = if link.is_absolute() {
+        PathBuf::new()
+    } else {
+        parent.to_path_buf()
+    };
+    for component in link.components() {
+        match component {
+            std::path::Component::RootDir | std::path::Component::CurDir => {}
+            std::path::Component::ParentDir => {
+                if !result.pop() {
+                    return None;
+                }
+            }
+            std::path::Component::Normal(value) => result.push(value),
+            std::path::Component::Prefix(_) => return None,
+        }
+    }
+    Some(result)
+}
+
+fn contains_wildcard(value: &str) -> bool {
+    let mut escaped = false;
+    for character in value.chars() {
+        if cfg!(not(windows)) && escaped {
+            escaped = false;
+            continue;
+        }
+        if cfg!(not(windows)) && character == '\\' {
+            escaped = true;
+            continue;
+        }
+        if matches!(character, '*' | '?' | '[') {
+            return true;
+        }
+    }
+    false
+}
+
+fn path_string(path: &Path) -> Result<String, Status> {
+    let value = path
+        .to_str()
+        .ok_or_else(|| {
+            Status::invalid_argument("local source contains a non-UTF-8 followpaths path")
+        })?
+        .replace(std::path::MAIN_SEPARATOR, "/");
+    if value.len() > MAX_PATH_LENGTH {
+        return Err(Status::invalid_argument(
+            "invalid FileSync followpaths path",
+        ));
+    }
+    Ok(value)
 }
 
 fn mount_name(metadata: &MetadataMap) -> Result<String, Status> {
-    let value = metadata
-        .get(DIR_NAME_METADATA)
-        .ok_or_else(|| Status::not_found("local source name is missing"))?;
-    value
-        .to_str()
-        .map(str::to_owned)
-        .map_err(|_| Status::invalid_argument("invalid dir-name metadata"))
+    parse_options(metadata)?
+        .dir_name
+        .ok_or_else(|| Status::not_found("local source name is missing"))
 }
 
 fn lookup_mount(
@@ -684,29 +925,36 @@ fn lookup_mount(
 }
 
 fn validate_options(metadata: &MetadataMap) -> Result<(), Status> {
-    for key in [INCLUDE_PATTERNS_METADATA, EXCLUDE_PATTERNS_METADATA] {
-        if metadata.contains_key(key) || metadata.contains_key(format!("{key}-encoded")) {
-            return Err(Status::invalid_argument(format!(
-                "FileSync {key} are unsupported"
-            )));
+    let options = parse_options(metadata)?;
+    for value in options.follow_paths {
+        if value == "." {
+            continue;
         }
-    }
-
-    if metadata.contains_key(format!("{FOLLOW_PATHS_METADATA}-encoded")) {
-        return Err(Status::invalid_argument(
-            "encoded FileSync followpaths are unsupported",
-        ));
-    }
-    for value in metadata.get_all(FOLLOW_PATHS_METADATA).iter() {
-        let value = value
-            .to_str()
-            .map_err(|_| Status::invalid_argument("invalid followpaths metadata"))?;
-        if value.contains('*') || value.contains('?') || value.contains('[') {
-            return Err(Status::unimplemented(
-                "wildcard FileSync followpaths are not implemented",
+        let path = PathBuf::from(&value);
+        if value.is_empty()
+            || path.is_absolute()
+            || path.components().any(|component| {
+                matches!(
+                    component,
+                    std::path::Component::ParentDir | std::path::Component::RootDir
+                )
+            })
+            || path.as_os_str().len() > MAX_PATH_LENGTH
+        {
+            return Err(Status::invalid_argument(
+                "invalid FileSync followpaths path",
             ));
         }
+        PatternMatcher::new(std::slice::from_ref(&value)).map_err(|error| {
+            Status::invalid_argument(format!("invalid FileSync followpath pattern: {error}"))
+        })?;
     }
+    PatternMatcher::new(&options.include_patterns).map_err(|error| {
+        Status::invalid_argument(format!("invalid FileSync include pattern: {error}"))
+    })?;
+    PatternMatcher::new(&options.exclude_patterns).map_err(|error| {
+        Status::invalid_argument(format!("invalid FileSync exclude pattern: {error}"))
+    })?;
     Ok(())
 }
 
@@ -733,7 +981,6 @@ fn scan_entries_with_selection(
     let root = root.try_clone().map_err(|error| {
         Status::internal(format!("failed to retain local source root: {error}"))
     })?;
-    let selection = resolve_selection(&root, selection)?;
     let mut budget = ScanBudget { inspected: 0 };
     let names = sorted_names(&root, &mut budget)?;
     let mut frames = vec![ScanFrame {
@@ -741,8 +988,11 @@ fn scan_entries_with_selection(
         directory: root,
         names,
         next_name: 0,
+        pending: false,
     }];
     let mut position = 0_u32;
+    let mut pending = Vec::<PendingEntry>::new();
+    let mut seen_hardlinks = HashMap::<(u64, u64), String>::new();
 
     while let Some(mut frame) = frames.pop() {
         if faults.delay_scan {
@@ -752,6 +1002,9 @@ fn scan_entries_with_selection(
             return Ok(());
         }
         let Some(name) = frame.names.get(frame.next_name).cloned() else {
+            if frame.pending {
+                pending.pop();
+            }
             continue;
         };
         frame.next_name += 1;
@@ -761,63 +1014,68 @@ fn scan_entries_with_selection(
             .directory
             .symlink_metadata(&name)
             .map_err(|error| filesystem_error("stat", &relative, error))?;
-        if !entry_is_selected(&relative, &metadata, &selection) {
-            if metadata.file_type().is_dir() && entry_is_ancestor(&relative, &selection) {
+        if !selection.is_selected(&relative) {
+            if metadata.file_type().is_dir() {
+                let (stat, regular) = source_stat(
+                    &frame.directory,
+                    &name,
+                    &relative,
+                    &metadata,
+                    &mut seen_hardlinks,
+                )?;
                 let directory = frame
                     .directory
                     .open_dir(&name)
                     .map_err(|error| filesystem_error("open directory", &relative, error))?;
+                pending.push(PendingEntry {
+                    stat,
+                    regular,
+                    relative: relative.clone(),
+                });
                 frames.push(frame);
                 frames.push(ScanFrame {
                     relative,
                     names: sorted_names(&directory, &mut budget)?,
                     directory,
                     next_name: 0,
+                    pending: true,
                 });
             } else {
                 frames.push(frame);
             }
             continue;
         }
-        let (stat, regular) = source_stat(&frame.directory, &name, &relative, &metadata)?;
-        if position as usize >= MAX_ENTRIES {
-            return Err(Status::resource_exhausted(
-                "local source has too many entries",
-            ));
+        let (stat, regular) = source_stat(
+            &frame.directory,
+            &name,
+            &relative,
+            &metadata,
+            &mut seen_hardlinks,
+        )?;
+        for pending_entry in pending.drain(..) {
+            emit_source_entry(
+                &sender,
+                &mut position,
+                pending_entry.stat,
+                pending_entry.regular,
+                pending_entry.relative,
+            )?;
         }
-        let current_position = position;
-        position = position
-            .checked_add(1)
-            .ok_or_else(|| Status::resource_exhausted("local source entry ID exhausted"))?;
-
-        if sender
-            .blocking_send(Ok(SourceEntry {
-                stat,
-                position: current_position,
-                regular,
-                relative: relative.clone(),
-            }))
-            .is_err()
-        {
-            return Ok(());
-        }
+        emit_source_entry(&sender, &mut position, stat, regular, relative.clone())?;
 
         let file_type = metadata.file_type();
         let child = if file_type.is_dir() {
-            if !entry_is_ancestor_or_selected_directory(&relative, &metadata, &selection) {
-                None
-            } else {
-                let directory = frame
-                    .directory
-                    .open_dir(&name)
-                    .map_err(|error| filesystem_error("open directory", &relative, error))?;
-                Some(ScanFrame {
-                    relative,
-                    names: sorted_names(&directory, &mut budget)?,
-                    directory,
-                    next_name: 0,
-                })
-            }
+            let directory = frame
+                .directory
+                .open_dir(&name)
+                .map_err(|error| filesystem_error("open directory", &relative, error))?;
+            Some(ScanFrame {
+                relative,
+                names: sorted_names(&directory, &mut budget)?,
+                directory,
+                next_name: 0,
+                pending: false,
+            })
         } else {
             None
         };
@@ -831,65 +1089,34 @@ fn scan_entries_with_selection(
     Ok(())
 }
 
-fn resolve_selection(
-    root: &cap_std::fs::Dir,
-    selection: ScanSelection,
-) -> Result<ScanSelection, Status> {
-    let ScanSelection::Paths(paths) = selection else {
-        return Ok(ScanSelection::All);
-    };
-    let mut existing = Vec::new();
-    for path in paths {
-        match root.symlink_metadata(&path) {
-            Ok(_) => existing.push(path),
-            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
-            Err(error) => return Err(filesystem_error("stat", &path, error)),
-        }
+fn emit_source_entry(
+    sender: &tokio::sync::mpsc::Sender<Result<SourceEntry, Status>>,
+    position: &mut u32,
+    stat: Stat,
+    regular: bool,
+    relative: PathBuf,
+) -> Result<(), Status> {
+    if *position as usize >= MAX_ENTRIES {
+        return Err(Status::resource_exhausted(
+            "local source has too many entries",
+        ));
     }
-    Ok(ScanSelection::Paths(existing))
-}
-
-fn path_is_prefix(prefix: &Path, path: &Path) -> bool {
-    prefix == path
-        || prefix
-            .components()
-            .zip(path.components())
-            .all(|(a, b)| a == b)
-            && prefix.components().count() <= path.components().count()
-}
-
-fn entry_is_ancestor(path: &Path, selection: &ScanSelection) -> bool {
-    match selection {
-        ScanSelection::All => true,
-        ScanSelection::Paths(paths) => paths.iter().any(|selected| path_is_prefix(path, selected)),
+    let current_position = *position;
+    *position = position
+        .checked_add(1)
+        .ok_or_else(|| Status::resource_exhausted("local source entry ID exhausted"))?;
+    if sender
+        .blocking_send(Ok(SourceEntry {
+            stat,
+            position: current_position,
+            regular,
+            relative,
+        }))
+        .is_err()
+    {
+        return Ok(());
     }
-}
-
-fn entry_is_selected(
-    path: &Path,
-    _metadata: &cap_std::fs::Metadata,
-    selection: &ScanSelection,
-) -> bool {
-    match selection {
-        ScanSelection::All => true,
-        ScanSelection::Paths(paths) => paths.iter().any(|selected| {
-            path == selected || path_is_prefix(selected, path) || path_is_prefix(path, selected)
-        }),
-    }
-}
-
-fn entry_is_ancestor_or_selected_directory(
-    path: &Path,
-    metadata: &cap_std::fs::Metadata,
-    selection: &ScanSelection,
-) -> bool {
-    metadata.file_type().is_dir()
-        && match selection {
-            ScanSelection::All => true,
-            ScanSelection::Paths(paths) => paths
-                .iter()
-                .any(|selected| path_is_prefix(path, selected) || path_is_prefix(selected, path)),
-        }
+    Ok(())
 }
 
 fn sorted_names(
@@ -921,6 +1148,7 @@ fn source_stat(
     name: &OsStr,
     relative: &Path,
     metadata: &cap_std::fs::Metadata,
+    _seen_hardlinks: &mut HashMap<(u64, u64), String>,
 ) -> Result<(Stat, bool), Status> {
     let path = relative
         .to_str()
@@ -967,6 +1195,32 @@ fn source_stat(
         )));
     };
 
+    #[cfg(unix)]
+    let (linkname, size) = {
+        let mut linkname = linkname;
+        let mut size = size;
+        if regular && metadata.nlink() > 1 {
+            let identity = (metadata.dev(), metadata.ino());
+            if let Some(first) = _seen_hardlinks.get(&identity) {
+                linkname = first.clone();
+                size = 0;
+            } else {
+                _seen_hardlinks.insert(identity, path.to_owned());
+            }
+        }
+        (linkname, size)
+    };
+
+    #[cfg(unix)]
+    let xattrs = if file_type.is_dir() || regular {
+        entry_xattrs(directory, name, file_type.is_dir())?
+    } else {
+        HashMap::new()
+    };
+
+    #[cfg(not(unix))]
+    let xattrs = HashMap::new();
+
     Ok((
         Stat {
             path: path.replace(std::path::MAIN_SEPARATOR, "/"),
@@ -976,10 +1230,45 @@ fn source_stat(
             size,
             mod_time: modification_time(metadata),
             linkname,
+            xattrs,
             ..Default::default()
         },
         regular,
     ))
+}
+
+#[cfg(unix)]
+fn entry_xattrs(
+    directory: &cap_std::fs::Dir,
+    name: &OsStr,
+    _is_directory: bool,
+) -> Result<HashMap<String, Vec<u8>>, Status> {
+    let mut options = cap_std::fs::OpenOptions::new();
+    options.read(true).follow(FollowSymlinks::No);
+    let file = directory
+        .open_with(name, &options)
+        .map_err(|error| filesystem_error("open xattr entry", Path::new(name), error))?
+        .into_std();
+    let names = match file.list_xattr() {
+        Ok(names) => names,
+        Err(error) if error.kind() == std::io::ErrorKind::Unsupported => return Ok(HashMap::new()),
+        Err(error) => return Err(filesystem_error("list xattrs", Path::new(name), error)),
+    };
+    let mut xattrs = HashMap::new();
+    for name in names {
+        if name.to_string_lossy().starts_with("com.apple.") {
+            continue;
+        }
+        if let Some(value) = file
+            .get_xattr(&name)
+            .map_err(|error| filesystem_error("read xattr", Path::new(&name), error))?
+        {
+            if let Some(name) = name.to_str() {
+                xattrs.insert(name.to_owned(), value);
+            }
+        }
+    }
+    Ok(xattrs)
 }
 
 fn filesystem_error(operation: &str, path: &Path, error: std::io::Error) -> Status {
@@ -1039,7 +1328,7 @@ fn modification_time(metadata: &cap_std::fs::Metadata) -> i64 {
     metadata
         .modified()
         .ok()
-        .and_then(|time| time.duration_since(UNIX_EPOCH).ok())
+        .and_then(|time| time.duration_since(SystemClock::UNIX_EPOCH).ok())
         .and_then(|duration| i64::try_from(duration.as_nanos()).ok())
         .unwrap_or(0)
 }
@@ -1653,7 +1942,11 @@ mod tests {
             FOLLOW_PATHS_METADATA,
             tonic::metadata::MetadataValue::try_from("a").expect("follow path metadata is valid"),
         );
-        let selection = scan_selection(&metadata).expect("follow path is accepted");
+        let selection = scan_selection(
+            &open_mount(root.path()),
+            &parse_options(&metadata).expect("follow path options parse"),
+        )
+        .expect("follow path is accepted");
         let (sender, mut receiver) = mpsc::channel(ENTRY_QUEUE_CAPACITY);
         let scanner = tokio::task::spawn_blocking({
             let root = open_mount(root.path());
@@ -1678,6 +1971,152 @@ mod tests {
         assert_eq!(paths, ["a", "a/subdir", "a/subdir/input"]);
     }
 
+    #[tokio::test]
+    async fn scanner_applies_ordered_filters_and_doublestar() {
+        let root = tempdir().expect("temporary directory is created");
+        std::fs::create_dir_all(root.path().join("a/b")).expect("nested directory is created");
+        std::fs::create_dir(root.path().join("other")).expect("other directory is created");
+        std::fs::write(root.path().join("a/b/input.txt"), b"input").expect("input is created");
+        std::fs::write(root.path().join("a/b/skip.txt"), b"skip").expect("skip is created");
+        std::fs::write(root.path().join("other/output.txt"), b"output").expect("output is created");
+        let selection = ScanSelection::from_patterns(
+            &[String::from("**/*.txt")],
+            &[String::from("**/skip.txt")],
+        )
+        .expect("patterns compile");
+        let (sender, mut receiver) = mpsc::channel(ENTRY_QUEUE_CAPACITY);
+        let scanner = tokio::task::spawn_blocking({
+            let root = open_mount(root.path());
+            move || {
+                scan_entries_with_selection(
+                    root,
+                    sender,
+                    selection,
+                    CancellationToken::new(),
+                    FaultInjection::default(),
+                )
+            }
+        });
+        let mut paths = Vec::new();
+        while let Some(event) = receiver.recv().await {
+            paths.push(event.expect("filtered scan succeeds").stat.path);
+        }
+        scanner
+            .await
+            .expect("filtered scanner joins")
+            .expect("filtered scanner succeeds");
+        assert_eq!(
+            paths,
+            ["a", "a/b", "a/b/input.txt", "other", "other/output.txt"]
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn scanner_resolves_wildcard_and_transitive_followpaths() {
+        let root = tempdir().expect("temporary directory is created");
+        std::fs::create_dir(root.path().join("dir")).expect("directory is created");
+        std::fs::create_dir(root.path().join("target")).expect("target directory is created");
+        std::fs::write(root.path().join("target/input"), b"source")
+            .expect("target file is created");
+        std::os::unix::fs::symlink("../target", root.path().join("dir/link1"))
+            .expect("first symlink is created");
+        std::os::unix::fs::symlink("dir/link1", root.path().join("link2"))
+            .expect("second symlink is created");
+        let options = FileSyncOptions {
+            follow_paths: vec![String::from("dir/link*"), String::from("link2")],
+            ..Default::default()
+        };
+        let selection =
+            scan_selection(&open_mount(root.path()), &options).expect("followpaths resolve");
+        let (sender, mut receiver) = mpsc::channel(ENTRY_QUEUE_CAPACITY);
+        let scanner = tokio::task::spawn_blocking({
+            let root = open_mount(root.path());
+            move || {
+                scan_entries_with_selection(
+                    root,
+                    sender,
+                    selection,
+                    CancellationToken::new(),
+                    FaultInjection::default(),
+                )
+            }
+        });
+        let mut paths = Vec::new();
+        while let Some(event) = receiver.recv().await {
+            paths.push(event.expect("followpaths scan succeeds").stat.path);
+        }
+        scanner
+            .await
+            .expect("followpaths scanner joins")
+            .expect("followpaths scanner succeeds");
+        assert_eq!(
+            paths,
+            ["dir", "dir/link1", "link2", "target", "target/input"]
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn scanner_preserves_hardlink_topology() {
+        let root = tempdir().expect("temporary directory is created");
+        std::fs::write(root.path().join("a"), b"shared").expect("source is created");
+        std::fs::hard_link(root.path().join("a"), root.path().join("b"))
+            .expect("hardlink is created");
+        let entries = scan_fixture(open_mount(root.path())).await;
+        let first = entries
+            .iter()
+            .find(|entry| entry.stat.path == "a")
+            .expect("first hardlink stat exists");
+        let second = entries
+            .iter()
+            .find(|entry| entry.stat.path == "b")
+            .expect("second hardlink stat exists");
+        assert!(first.stat.linkname.is_empty());
+        assert_eq!(first.stat.size, 6);
+        assert_eq!(second.stat.linkname, "a");
+        assert_eq!(second.stat.size, 0);
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn scanner_reads_supported_xattrs() {
+        let root = tempdir().expect("temporary directory is created");
+        let file = root.path().join("input");
+        std::fs::write(&file, b"source").expect("source is created");
+        if let Err(error) = xattr::set(&file, "user.bollard", b"metadata") {
+            if error.kind() == std::io::ErrorKind::Unsupported {
+                return;
+            }
+            panic!("xattr setup failed: {error}");
+        }
+        let entries = scan_fixture(open_mount(root.path())).await;
+        let input = entries
+            .iter()
+            .find(|entry| entry.stat.path == "input")
+            .expect("xattr file stat exists");
+        assert_eq!(
+            input.stat.xattrs.get("user.bollard"),
+            Some(&b"metadata".to_vec())
+        );
+    }
+
+    #[test]
+    fn metadata_decodes_encoded_values() {
+        let mut metadata = MetadataMap::new();
+        metadata.insert(
+            DIR_NAME_METADATA,
+            tonic::metadata::MetadataValue::try_from("caf%C3%A9")
+                .expect("encoded metadata is valid"),
+        );
+        metadata.insert(
+            "dir-name-encoded",
+            tonic::metadata::MetadataValue::try_from("1").expect("encoded marker is valid"),
+        );
+        let options = parse_options(&metadata).expect("metadata decodes");
+        assert_eq!(options.dir_name.as_deref(), Some("café"));
+    }
+
     #[test]
     fn scanner_bounds_directory_entry_collection() {
         let root = tempdir().expect("temporary directory is created");
@@ -1696,7 +2135,7 @@ mod tests {
     }
 
     #[test]
-    fn scanner_rejects_unsupported_options_and_long_paths() {
+    fn scanner_rejects_invalid_options_and_long_paths() {
         let mut metadata = MetadataMap::new();
         metadata.insert(
             DIR_NAME_METADATA,
@@ -1713,20 +2152,14 @@ mod tests {
             INCLUDE_PATTERNS_METADATA,
             tonic::metadata::MetadataValue::try_from("*.tmp").expect("metadata value is valid"),
         );
-        assert_eq!(
-            validate_options(&metadata).unwrap_err().code(),
-            tonic::Code::InvalidArgument
-        );
+        validate_options(&metadata).expect("include patterns are supported");
 
         let mut metadata = MetadataMap::new();
         metadata.insert(
             FOLLOW_PATHS_METADATA,
             tonic::metadata::MetadataValue::try_from("**/*.rs").expect("metadata value is valid"),
         );
-        assert_eq!(
-            validate_options(&metadata).unwrap_err().code(),
-            tonic::Code::Unimplemented
-        );
+        validate_options(&metadata).expect("wildcard followpaths are supported");
         let mut metadata = MetadataMap::new();
         metadata.insert(
             FOLLOW_PATHS_METADATA,
@@ -1764,6 +2197,7 @@ mod tests {
                 OsStr::new("file"),
                 &long_path,
                 &metadata,
+                &mut HashMap::new(),
             )
             .unwrap_err()
             .code(),
@@ -1778,11 +2212,19 @@ mod tests {
                     .expect("follow path metadata is valid"),
             );
             assert_eq!(
-                scan_selection(&metadata).unwrap_err().code(),
-                tonic::Code::Unimplemented,
-                "path {value:?} must fail closed"
+                validate_options(&metadata).unwrap_err().code(),
+                tonic::Code::InvalidArgument
             );
         }
+    }
+
+    #[test]
+    fn followpath_wildcard_detection_honors_escaped_metacharacters() {
+        assert!(contains_wildcard("link*"));
+        assert!(contains_wildcard("link[0-9]"));
+        assert!(!contains_wildcard("literal"));
+        #[cfg(not(windows))]
+        assert!(!contains_wildcard(r"literal\*"));
     }
 
     #[cfg(unix)]

--- a/src/grpc/filesync.rs
+++ b/src/grpc/filesync.rs
@@ -1402,6 +1402,11 @@ fn source_stat(
         (linkname, size)
     };
 
+    // Symlink xattrs require path-based no-follow calls. The mount retains only
+    // a capability directory, so deriving an ambient path would weaken that
+    // boundary; cap-std's no-follow file handle cannot read symlink xattrs.
+    // Keep this divergence from fsutil explicit until a capability-relative
+    // llistxattr/lgetxattr implementation is available.
     #[cfg(unix)]
     let xattrs = if file_type.is_dir() || regular {
         entry_xattrs(directory, name, file_type.is_dir())?

--- a/src/grpc/filesync.rs
+++ b/src/grpc/filesync.rs
@@ -1389,12 +1389,10 @@ fn source_stat(
     #[cfg(unix)]
     let (linkname, size) = {
         let mut linkname = linkname;
-        let mut size = size;
         if regular && metadata.nlink() > 1 {
             let identity = (metadata.dev(), metadata.ino());
             if let Some(first) = _seen_hardlinks.get(&identity) {
                 linkname = first.clone();
-                size = 0;
             } else {
                 _seen_hardlinks.insert(identity, path.to_owned());
             }
@@ -2084,7 +2082,7 @@ mod tests {
         assert!(first.stat.linkname.is_empty());
         assert_eq!(first.stat.size, 6);
         assert_eq!(second.stat.linkname, "a");
-        assert_eq!(second.stat.size, 0);
+        assert_eq!(second.stat.size, 6);
     }
 
     #[cfg(unix)]

--- a/src/grpc/filesync.rs
+++ b/src/grpc/filesync.rs
@@ -5,12 +5,14 @@ use std::{
     path::{Path, PathBuf},
     pin::Pin,
     sync::Arc,
+    time::Duration,
 };
 
 use bollard_buildkit_proto::{
     fsutil::types::{packet::PacketType, Packet, Stat},
     moby::filesync::v1::file_sync_server::FileSync,
 };
+use cap_fs_ext::{FollowSymlinks, OpenOptionsFollowExt};
 use futures_core::Stream;
 use futures_util::{FutureExt, StreamExt};
 use tokio::io::AsyncReadExt;
@@ -35,6 +37,7 @@ const FILE_JOB_QUEUE_CAPACITY: usize = 128;
 const OUTPUT_QUEUE_CAPACITY: usize = 16;
 const FILE_WORKER_COUNT: usize = 4;
 const FILE_READ_BUFFER_SIZE: usize = 32 * 1024;
+const FILESYNC_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(5);
 
 type EntryReceiver = tokio::sync::mpsc::Receiver<Result<SourceEntry, Status>>;
 type JobSender = tokio::sync::mpsc::Sender<FileJob>;
@@ -69,6 +72,27 @@ struct FileTarget {
     relative: PathBuf,
 }
 
+/// Test-only fault-injection switches for exercising panic and race paths
+/// through the real FileSync wire protocol. Always all-off in production:
+/// `diff_copy` only parses them from request metadata under `cfg(test)`.
+#[derive(Clone, Copy, Debug, Default)]
+struct FaultInjection {
+    panic_worker: bool,
+    delay_scan: bool,
+    panic_scanner: bool,
+}
+
+impl FaultInjection {
+    #[cfg(test)]
+    fn from_metadata(metadata: &tonic::metadata::MetadataMap) -> Self {
+        Self {
+            panic_worker: metadata.contains_key("x-test-panic-worker"),
+            delay_scan: metadata.contains_key("x-test-delay-scan"),
+            panic_scanner: metadata.contains_key("x-test-panic-scanner"),
+        }
+    }
+}
+
 struct FileSyncSession {
     cancellation: CancellationToken,
     scanner: Option<tokio::task::JoinHandle<()>>,
@@ -89,8 +113,7 @@ impl FileSyncSession {
     fn start(
         root: Arc<cap_std::fs::Dir>,
         selection: ScanSelection,
-        test_panic_worker: bool,
-        test_delay_scan: bool,
+        faults: FaultInjection,
     ) -> FileSyncStart {
         let cancellation = CancellationToken::new();
         let scanner_root = root.clone();
@@ -99,12 +122,15 @@ impl FileSyncSession {
         let (output_sender, output_receiver) = mpsc::channel(OUTPUT_QUEUE_CAPACITY);
         let scanner_cancellation = cancellation.clone();
         let scanner = tokio::task::spawn_blocking(move || {
+            if faults.panic_scanner {
+                panic!("injected FileSync scanner panic");
+            }
             let result = scan_entries_with_selection(
                 scanner_root,
                 entries_sender.clone(),
                 selection,
                 scanner_cancellation,
-                test_delay_scan,
+                faults,
             );
             if let Err(error) = result {
                 let _ = entries_sender.blocking_send(Err(error));
@@ -125,7 +151,7 @@ impl FileSyncSession {
                         worker_jobs,
                         worker_output.clone(),
                         worker_cancellation,
-                        test_panic_worker,
+                        faults,
                     )
                     .await;
                 })
@@ -163,22 +189,44 @@ impl FileSyncSession {
         output.close();
         jobs.take();
 
-        if let Some(scanner) = self.scanner.take() {
-            scanner.await.map_err(|error| {
-                Status::internal(format!("FileSync scanner task failed: {error}"))
-            })?;
-        }
-        self.workers.abort_all();
-        while let Some(result) = self.workers.join_next().await {
-            if let Err(error) = result {
-                if !error.is_cancelled() {
-                    return Err(Status::internal(format!(
-                        "FileSync worker task failed: {error}"
-                    )));
+        let result = tokio::time::timeout(FILESYNC_SHUTDOWN_TIMEOUT, async {
+            let scanner_result = if let Some(scanner) = self.scanner.as_mut() {
+                scanner.await.map_err(|error| {
+                    Status::internal(format!("FileSync scanner task failed: {error}"))
+                })
+            } else {
+                Ok(())
+            };
+            self.scanner.take();
+
+            self.workers.abort_all();
+            let mut worker_error = None;
+            while let Some(result) = self.workers.join_next().await {
+                if let Err(error) = result {
+                    if !error.is_cancelled() && worker_error.is_none() {
+                        worker_error = Some(Status::internal(format!(
+                            "FileSync worker task failed: {error}"
+                        )));
+                    }
                 }
             }
+            scanner_result?;
+            worker_error.map_or(Ok(()), Err)
+        })
+        .await;
+
+        match result {
+            Ok(result) => result,
+            Err(_) => {
+                if let Some(scanner) = self.scanner.as_ref() {
+                    scanner.abort();
+                }
+                self.workers.abort_all();
+                Err(Status::deadline_exceeded(
+                    "FileSync session cleanup exceeded its timeout",
+                ))
+            }
         }
-        Ok(())
     }
 }
 
@@ -193,6 +241,22 @@ struct ScanFrame {
     directory: cap_std::fs::Dir,
     names: Vec<OsString>,
     next_name: usize,
+}
+
+struct ScanBudget {
+    inspected: usize,
+}
+
+impl ScanBudget {
+    fn inspect(&mut self) -> Result<(), Status> {
+        if self.inspected >= MAX_ENTRIES {
+            return Err(Status::resource_exhausted(
+                "local source has too many entries",
+            ));
+        }
+        self.inspected += 1;
+        Ok(())
+    }
 }
 
 enum SessionEvent {
@@ -262,15 +326,11 @@ impl FileSync for FileSyncImpl {
         let root = lookup_mount(&self.mounts, &name)?;
         let selection = scan_selection(request.metadata())?;
         #[cfg(test)]
-        let test_panic_worker = request.metadata().contains_key("x-test-panic-worker");
+        let faults = FaultInjection::from_metadata(request.metadata());
         #[cfg(not(test))]
-        let test_panic_worker = false;
-        #[cfg(test)]
-        let test_delay_scan = request.metadata().contains_key("x-test-delay-scan");
-        #[cfg(not(test))]
-        let test_delay_scan = false;
+        let faults = FaultInjection::default();
         let (mut session, mut entries_receiver, jobs_sender, mut output_receiver) =
-            FileSyncSession::start(root, selection, test_panic_worker, test_delay_scan);
+            FileSyncSession::start(root, selection, faults);
         let mut jobs_sender = Some(jobs_sender);
         let mut input = Box::pin(request.into_inner());
 
@@ -407,6 +467,11 @@ impl FileSync for FileSyncImpl {
                                         "FileSync received PACKET_FIN before STAT termination",
                                     ));
                                 }
+                                if fin_requested {
+                                    fail!(Status::failed_precondition(
+                                        "FileSync received repeated PACKET_FIN",
+                                    ));
+                                }
                                 fin_requested = true;
                                 if pending_jobs.is_empty() {
                                     yield Ok(fin_response_packet());
@@ -472,7 +537,7 @@ async fn worker_loop(
     jobs: Arc<Mutex<tokio::sync::mpsc::Receiver<FileJob>>>,
     output: tokio::sync::mpsc::Sender<Result<Packet, Status>>,
     cancellation: CancellationToken,
-    test_panic_worker: bool,
+    faults: FaultInjection,
 ) {
     loop {
         let job = {
@@ -483,7 +548,7 @@ async fn worker_loop(
         if cancellation.is_cancelled() {
             return;
         }
-        if test_panic_worker {
+        if faults.panic_worker {
             panic!("injected FileSync worker panic");
         }
 
@@ -538,8 +603,10 @@ async fn open_regular_file(
     relative: PathBuf,
 ) -> Result<tokio::fs::File, Status> {
     let file = tokio::task::spawn_blocking(move || {
+        let mut options = cap_std::fs::OpenOptions::new();
+        options.read(true).follow(FollowSymlinks::No);
         let file = root
-            .open(&relative)
+            .open_with(&relative, &options)
             .map_err(|error| filesystem_error("open", &relative, error))?;
         let metadata = file
             .metadata()
@@ -652,7 +719,7 @@ fn scan_entries(
         sender,
         ScanSelection::All,
         CancellationToken::new(),
-        false,
+        FaultInjection::default(),
     )
 }
 
@@ -661,13 +728,14 @@ fn scan_entries_with_selection(
     sender: tokio::sync::mpsc::Sender<Result<SourceEntry, Status>>,
     selection: ScanSelection,
     cancellation: CancellationToken,
-    delay_scan: bool,
+    faults: FaultInjection,
 ) -> Result<(), Status> {
     let root = root.try_clone().map_err(|error| {
         Status::internal(format!("failed to retain local source root: {error}"))
     })?;
     let selection = resolve_selection(&root, selection)?;
-    let names = sorted_names(&root)?;
+    let mut budget = ScanBudget { inspected: 0 };
+    let names = sorted_names(&root, &mut budget)?;
     let mut frames = vec![ScanFrame {
         relative: PathBuf::new(),
         directory: root,
@@ -677,7 +745,7 @@ fn scan_entries_with_selection(
     let mut position = 0_u32;
 
     while let Some(mut frame) = frames.pop() {
-        if delay_scan {
+        if faults.delay_scan {
             std::thread::sleep(std::time::Duration::from_millis(50));
         }
         if cancellation.is_cancelled() {
@@ -702,7 +770,7 @@ fn scan_entries_with_selection(
                 frames.push(frame);
                 frames.push(ScanFrame {
                     relative,
-                    names: sorted_names(&directory)?,
+                    names: sorted_names(&directory, &mut budget)?,
                     directory,
                     next_name: 0,
                 });
@@ -745,7 +813,7 @@ fn scan_entries_with_selection(
                     .map_err(|error| filesystem_error("open directory", &relative, error))?;
                 Some(ScanFrame {
                     relative,
-                    names: sorted_names(&directory)?,
+                    names: sorted_names(&directory, &mut budget)?,
                     directory,
                     next_name: 0,
                 })
@@ -815,21 +883,35 @@ fn entry_is_ancestor_or_selected_directory(
     metadata: &cap_std::fs::Metadata,
     selection: &ScanSelection,
 ) -> bool {
-    metadata.file_type().is_dir() && entry_is_ancestor(path, selection)
+    metadata.file_type().is_dir()
+        && match selection {
+            ScanSelection::All => true,
+            ScanSelection::Paths(paths) => paths
+                .iter()
+                .any(|selected| path_is_prefix(path, selected) || path_is_prefix(selected, path)),
+        }
 }
 
-fn sorted_names(directory: &cap_std::fs::Dir) -> Result<Vec<OsString>, Status> {
+fn sorted_names(
+    directory: &cap_std::fs::Dir,
+    budget: &mut ScanBudget,
+) -> Result<Vec<OsString>, Status> {
     let mut names = directory
         .entries()
         .map_err(|error| {
             Status::internal(format!("failed to read local source directory: {error}"))
         })?
         .map(|entry| {
-            entry.map(|entry| entry.file_name()).map_err(|error| {
-                Status::internal(format!("failed to read local source entry: {error}"))
-            })
+            entry
+                .map(|entry| {
+                    budget.inspect()?;
+                    Ok(entry.file_name())
+                })
+                .map_err(|error| {
+                    Status::internal(format!("failed to read local source entry: {error}"))
+                })?
         })
-        .collect::<Result<Vec<_>, _>>()?;
+        .collect::<Result<Vec<_>, Status>>()?;
     names.sort_unstable();
     Ok(names)
 }
@@ -1227,11 +1309,21 @@ async fn start_filesync_server(
     tokio::sync::oneshot::Sender<()>,
     tokio::task::JoinHandle<()>,
 ) {
+    start_filesync_server_with_mounts(HashMap::from([(String::from("context"), root)])).await
+}
+
+#[cfg(test)]
+async fn start_filesync_server_with_mounts(
+    mounts: HashMap<String, Arc<cap_std::fs::Dir>>,
+) -> (
+    std::net::SocketAddr,
+    tokio::sync::oneshot::Sender<()>,
+    tokio::task::JoinHandle<()>,
+) {
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
         .await
         .expect("FileSync test listener binds");
     let address = listener.local_addr().expect("FileSync test address exists");
-    let mounts = HashMap::from([(String::from("context"), root)]);
     let (shutdown_sender, shutdown_receiver) = tokio::sync::oneshot::channel();
     let server = Server::builder()
         .add_service(FileSyncServer::new(FileSyncImpl::new(mounts)))
@@ -1253,21 +1345,40 @@ async fn open_filesync_transfer(
     tokio::sync::oneshot::Sender<()>,
     tokio::task::JoinHandle<()>,
 ) {
-    open_filesync_transfer_with_controls(root, false, false).await
+    open_filesync_transfer_with_metadata(root, "context", FaultInjection::default()).await
 }
 
 #[cfg(test)]
-async fn open_filesync_transfer_with_controls(
+async fn open_filesync_transfer_with_metadata(
     root: Arc<cap_std::fs::Dir>,
-    panic_worker: bool,
-    delay_scan: bool,
+    dir_name: &str,
+    faults: FaultInjection,
 ) -> (
     mpsc::Sender<Packet>,
     Streaming<Packet>,
     tokio::sync::oneshot::Sender<()>,
     tokio::task::JoinHandle<()>,
 ) {
-    let (address, shutdown_sender, server_task) = start_filesync_server(root).await;
+    open_filesync_transfer_from_mounts(
+        HashMap::from([(String::from("context"), root)]),
+        dir_name,
+        faults,
+    )
+    .await
+}
+
+#[cfg(test)]
+async fn open_filesync_transfer_from_mounts(
+    mounts: HashMap<String, Arc<cap_std::fs::Dir>>,
+    dir_name: &str,
+    faults: FaultInjection,
+) -> (
+    mpsc::Sender<Packet>,
+    Streaming<Packet>,
+    tokio::sync::oneshot::Sender<()>,
+    tokio::task::JoinHandle<()>,
+) {
+    let (address, shutdown_sender, server_task) = start_filesync_server_with_mounts(mounts).await;
     let mut client =
         bollard_buildkit_proto::moby::filesync::v1::file_sync_client::FileSyncClient::connect(
             format!("http://{address}"),
@@ -1278,17 +1389,23 @@ async fn open_filesync_transfer_with_controls(
     let mut request = Request::new(ReceiverStream::new(receiver));
     request.metadata_mut().insert(
         DIR_NAME_METADATA,
-        tonic::metadata::MetadataValue::try_from("context").expect("metadata value is valid"),
+        tonic::metadata::MetadataValue::try_from(dir_name).expect("metadata value is valid"),
     );
-    if panic_worker {
+    if faults.panic_worker {
         request.metadata_mut().insert(
             "x-test-panic-worker",
             tonic::metadata::MetadataValue::try_from("1").expect("metadata value is valid"),
         );
     }
-    if delay_scan {
+    if faults.delay_scan {
         request.metadata_mut().insert(
             "x-test-delay-scan",
+            tonic::metadata::MetadataValue::try_from("1").expect("metadata value is valid"),
+        );
+    }
+    if faults.panic_scanner {
+        request.metadata_mut().insert(
+            "x-test-panic-scanner",
             tonic::metadata::MetadataValue::try_from("1").expect("metadata value is valid"),
         );
     }
@@ -1487,17 +1604,21 @@ mod tests {
     #[tokio::test]
     async fn scanner_emits_regular_and_symlink_metadata() {
         let root = tempdir().expect("temporary directory is created");
-        std::fs::write(root.path().join("empty"), b"").expect("empty file is created");
+        std::fs::write(root.path().join("target"), b"non-empty target")
+            .expect("target file is created");
         #[cfg(unix)]
-        std::os::unix::fs::symlink("empty", root.path().join("link")).expect("symlink is created");
+        std::os::unix::fs::symlink("target", root.path().join("link")).expect("symlink is created");
 
         let entries = scan_fixture(open_mount(root.path())).await;
         let empty = entries
             .iter()
-            .find(|entry| entry.stat.path == "empty")
-            .expect("empty file stat exists");
+            .find(|entry| entry.stat.path == "target")
+            .expect("target file stat exists");
         assert!(empty.regular);
-        assert_eq!(empty.stat.size, 0);
+        assert_eq!(
+            empty.stat.size,
+            i64::try_from(b"non-empty target".len()).expect("target length fits")
+        );
         assert_eq!(
             empty.stat.mode & super::super::fsutil::FileMode::Type.bits(),
             0
@@ -1514,7 +1635,7 @@ mod tests {
                 link.stat.mode & super::super::fsutil::FileMode::Symlink.bits(),
                 0
             );
-            assert_eq!(link.stat.linkname, "empty");
+            assert_eq!(link.stat.linkname, "target");
             assert_eq!(link.stat.size, 0);
         }
     }
@@ -1524,13 +1645,13 @@ mod tests {
         let root = tempdir().expect("temporary directory is created");
         std::fs::create_dir(root.path().join("a")).expect("a directory is created");
         std::fs::create_dir(root.path().join("b")).expect("b directory is created");
-        std::fs::write(root.path().join("a/input"), b"source").expect("input is created");
+        std::fs::create_dir(root.path().join("a/subdir")).expect("subdir is created");
+        std::fs::write(root.path().join("a/subdir/input"), b"source").expect("input is created");
         std::fs::write(root.path().join("b/other"), b"other").expect("other is created");
         let mut metadata = MetadataMap::new();
         metadata.insert(
             FOLLOW_PATHS_METADATA,
-            tonic::metadata::MetadataValue::try_from("a/input")
-                .expect("follow path metadata is valid"),
+            tonic::metadata::MetadataValue::try_from("a").expect("follow path metadata is valid"),
         );
         let selection = scan_selection(&metadata).expect("follow path is accepted");
         let (sender, mut receiver) = mpsc::channel(ENTRY_QUEUE_CAPACITY);
@@ -1542,7 +1663,7 @@ mod tests {
                     sender,
                     selection,
                     CancellationToken::new(),
-                    false,
+                    FaultInjection::default(),
                 )
             }
         });
@@ -1554,7 +1675,24 @@ mod tests {
             .await
             .expect("selected scanner joins")
             .expect("selected scanner succeeds");
-        assert_eq!(paths, ["a", "a/input"]);
+        assert_eq!(paths, ["a", "a/subdir", "a/subdir/input"]);
+    }
+
+    #[test]
+    fn scanner_bounds_directory_entry_collection() {
+        let root = tempdir().expect("temporary directory is created");
+        std::fs::write(root.path().join("a"), b"a").expect("a is created");
+        std::fs::write(root.path().join("b"), b"b").expect("b is created");
+        let directory = open_mount(root.path());
+        let mut budget = ScanBudget {
+            inspected: MAX_ENTRIES - 1,
+        };
+        assert_eq!(
+            sorted_names(&directory, &mut budget)
+                .expect_err("directory budget is enforced")
+                .code(),
+            tonic::Code::ResourceExhausted
+        );
     }
 
     #[test]
@@ -1598,8 +1736,17 @@ mod tests {
 
         let root = tempdir().expect("temporary directory is created");
         let mounts = HashMap::from([(String::from("context"), open_mount(root.path()))]);
+        assert!(lookup_mount(&mounts, "context").is_ok());
         assert_eq!(
             lookup_mount(&mounts, "missing").unwrap_err().code(),
+            tonic::Code::NotFound
+        );
+        assert_eq!(
+            lookup_mount(&mounts, "con").unwrap_err().code(),
+            tonic::Code::NotFound
+        );
+        assert_eq!(
+            lookup_mount(&mounts, "Context").unwrap_err().code(),
             tonic::Code::NotFound
         );
         let file = root.path().join("file");
@@ -1622,6 +1769,20 @@ mod tests {
             .code(),
             tonic::Code::InvalidArgument
         );
+
+        for value in ["../escape", "/absolute", "foo/../bar"] {
+            let mut metadata = MetadataMap::new();
+            metadata.insert(
+                FOLLOW_PATHS_METADATA,
+                tonic::metadata::MetadataValue::try_from(value)
+                    .expect("follow path metadata is valid"),
+            );
+            assert_eq!(
+                scan_selection(&metadata).unwrap_err().code(),
+                tonic::Code::Unimplemented,
+                "path {value:?} must fail closed"
+            );
+        }
     }
 
     #[cfg(unix)]
@@ -1910,8 +2071,15 @@ mod tests {
     async fn diff_copy_rejects_early_fin() {
         let root = tempdir().expect("temporary directory is created");
         std::fs::write(root.path().join("input"), b"source").expect("source is created");
-        let (sender, mut responses, shutdown, server) =
-            open_filesync_transfer_with_controls(open_mount(root.path()), false, true).await;
+        let (sender, mut responses, shutdown, server) = open_filesync_transfer_with_metadata(
+            open_mount(root.path()),
+            "context",
+            FaultInjection {
+                delay_scan: true,
+                ..Default::default()
+            },
+        )
+        .await;
         let first = responses.message().await.unwrap().unwrap();
         assert_eq!(first.r#type, PacketType::PacketStat as i32);
         sender.send(fin_packet()).await.expect("FIN sends");
@@ -2000,13 +2168,317 @@ mod tests {
     async fn diff_copy_reports_worker_panics() {
         let root = tempdir().expect("temporary directory is created");
         std::fs::write(root.path().join("input"), b"source").expect("source is created");
-        let (sender, mut responses, shutdown, server) =
-            open_filesync_transfer_with_controls(open_mount(root.path()), true, false).await;
+        let (sender, mut responses, shutdown, server) = open_filesync_transfer_with_metadata(
+            open_mount(root.path()),
+            "context",
+            FaultInjection {
+                panic_worker: true,
+                ..Default::default()
+            },
+        )
+        .await;
         read_stat_terminator(&mut responses).await;
         sender.send(request_packet(0)).await.expect("request sends");
         assert_eq!(
             expect_protocol_error(&mut responses).await.code(),
             tonic::Code::Internal
+        );
+        let _ = shutdown.send(());
+        let _ = server.await;
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn diff_copy_reports_scanner_errors() {
+        use std::os::unix::net::UnixListener;
+
+        let root = tempdir().expect("temporary directory is created");
+        let _socket =
+            UnixListener::bind(root.path().join("socket")).expect("unix socket is created");
+        let (_sender, mut responses, shutdown, server) =
+            open_filesync_transfer(open_mount(root.path())).await;
+        assert_eq!(
+            expect_protocol_error(&mut responses).await.code(),
+            tonic::Code::InvalidArgument
+        );
+        let _ = shutdown.send(());
+        let _ = server.await;
+    }
+
+    #[tokio::test]
+    async fn diff_copy_reports_scanner_panics() {
+        let root = tempdir().expect("temporary directory is created");
+        let (_sender, mut responses, shutdown, server) = open_filesync_transfer_with_metadata(
+            open_mount(root.path()),
+            "context",
+            FaultInjection {
+                panic_scanner: true,
+                ..Default::default()
+            },
+        )
+        .await;
+        assert_eq!(
+            expect_protocol_error(&mut responses).await.code(),
+            tonic::Code::Internal
+        );
+        let _ = shutdown.send(());
+        let _ = server.await;
+    }
+
+    #[tokio::test]
+    async fn diff_copy_rejects_unknown_mount_names() {
+        let root = tempdir().expect("temporary directory is created");
+        let (address, shutdown, server) = start_filesync_server(open_mount(root.path())).await;
+        let mut client =
+            bollard_buildkit_proto::moby::filesync::v1::file_sync_client::FileSyncClient::connect(
+                format!("http://{address}"),
+            )
+            .await
+            .expect("FileSync client connects");
+        let mut request = Request::new(stream::empty::<Packet>());
+        request.metadata_mut().insert(
+            DIR_NAME_METADATA,
+            tonic::metadata::MetadataValue::try_from("missing").expect("metadata value is valid"),
+        );
+        let error = client
+            .diff_copy(request)
+            .await
+            .expect_err("unknown mount names are rejected");
+        assert_eq!(error.code(), tonic::Code::NotFound);
+        let _ = shutdown.send(());
+        let _ = server.await;
+    }
+
+    #[tokio::test]
+    async fn diff_copy_rejects_non_regular_requests() {
+        let root = tempdir().expect("temporary directory is created");
+        std::fs::create_dir(root.path().join("directory")).expect("directory is created");
+        std::fs::write(root.path().join("directory/input"), b"source").expect("source is created");
+        let (sender, mut responses, shutdown, server) =
+            open_filesync_transfer(open_mount(root.path())).await;
+        let stats = read_stat_terminator(&mut responses).await;
+        assert_eq!(stats[0].stat.as_ref().unwrap().path, "directory");
+        sender.send(request_packet(0)).await.expect("request sends");
+        assert_eq!(
+            expect_protocol_error(&mut responses).await.code(),
+            tonic::Code::InvalidArgument
+        );
+        let _ = shutdown.send(());
+        let _ = server.await;
+    }
+
+    #[tokio::test]
+    async fn diff_copy_rejects_unknown_and_unexpected_packet_types() {
+        for packet in [
+            Packet {
+                r#type: 999,
+                ..Default::default()
+            },
+            stat_packet("unexpected"),
+        ] {
+            let root = tempdir().expect("temporary directory is created");
+            std::fs::write(root.path().join("input"), b"source").expect("source is created");
+            let (sender, mut responses, shutdown, server) =
+                open_filesync_transfer(open_mount(root.path())).await;
+            read_stat_terminator(&mut responses).await;
+            sender.send(packet).await.expect("packet sends");
+            assert_eq!(
+                expect_protocol_error(&mut responses).await.code(),
+                tonic::Code::InvalidArgument
+            );
+            let _ = shutdown.send(());
+            let _ = server.await;
+        }
+    }
+
+    #[tokio::test]
+    async fn diff_copy_rejects_repeated_fin_and_peer_errors_during_transfer() {
+        for peer_error in [false, true] {
+            let root = tempdir().expect("temporary directory is created");
+            std::fs::write(
+                root.path().join("input"),
+                vec![b'x'; FILE_READ_BUFFER_SIZE * 8],
+            )
+            .expect("source is created");
+            let (sender, mut responses, shutdown, server) =
+                open_filesync_transfer(open_mount(root.path())).await;
+            read_stat_terminator(&mut responses).await;
+            sender.send(request_packet(0)).await.expect("request sends");
+            sender
+                .send(if peer_error {
+                    err_packet("peer failure")
+                } else {
+                    fin_packet()
+                })
+                .await
+                .expect("control packet sends");
+            sender
+                .send(fin_packet())
+                .await
+                .expect("second control packet sends");
+            assert_eq!(
+                expect_protocol_error(&mut responses).await.code(),
+                if peer_error {
+                    tonic::Code::Aborted
+                } else {
+                    tonic::Code::FailedPrecondition
+                }
+            );
+            let _ = shutdown.send(());
+            let _ = server.await;
+        }
+    }
+
+    #[tokio::test]
+    async fn diff_copy_accepts_requests_while_stat_is_in_flight() {
+        let root = tempdir().expect("temporary directory is created");
+        std::fs::write(root.path().join("a"), b"a").expect("a is created");
+        std::fs::write(root.path().join("b"), b"b").expect("b is created");
+        let (sender, mut responses, shutdown, server) = open_filesync_transfer_with_metadata(
+            open_mount(root.path()),
+            "context",
+            FaultInjection {
+                delay_scan: true,
+                ..Default::default()
+            },
+        )
+        .await;
+        let first = responses
+            .message()
+            .await
+            .expect("first STAT succeeds")
+            .expect("first STAT exists");
+        assert_eq!(first.stat.as_ref().unwrap().path, "a");
+        sender.send(request_packet(0)).await.expect("request sends");
+
+        let mut saw_data = false;
+        let mut saw_eof = false;
+        loop {
+            let packet = responses
+                .message()
+                .await
+                .expect("FileSync response succeeds")
+                .expect("FileSync response exists");
+            match PacketType::try_from(packet.r#type).expect("response type is known") {
+                PacketType::PacketStat if packet.stat.is_none() => break,
+                PacketType::PacketData => {
+                    saw_data = true;
+                    if packet.data.is_empty() {
+                        saw_eof = true;
+                    }
+                }
+                _ => {}
+            }
+        }
+        assert!(saw_data);
+        assert!(saw_eof);
+        sender.send(fin_packet()).await.expect("FIN sends");
+        assert_eq!(
+            responses.message().await.unwrap().unwrap().r#type,
+            PacketType::PacketFin as i32
+        );
+        let _ = shutdown.send(());
+        let _ = server.await;
+    }
+
+    #[tokio::test]
+    async fn diff_copy_handles_large_stat_streams_with_bounded_queues() {
+        let root = tempdir().expect("temporary directory is created");
+        for index in 0..(ENTRY_QUEUE_CAPACITY * 2) {
+            std::fs::write(root.path().join(format!("entry-{index:03}")), b"entry")
+                .expect("entry is created");
+        }
+        let (sender, mut responses, shutdown, server) =
+            open_filesync_transfer(open_mount(root.path())).await;
+        let stats = read_stat_terminator(&mut responses).await;
+        assert_eq!(stats.len(), ENTRY_QUEUE_CAPACITY * 2 + 1);
+        sender.send(fin_packet()).await.expect("FIN sends");
+        assert_eq!(
+            responses.message().await.unwrap().unwrap().r#type,
+            PacketType::PacketFin as i32
+        );
+        let _ = shutdown.send(());
+        let _ = server.await;
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn diff_copy_rejects_replaced_regular_files() {
+        let root = tempdir().expect("temporary directory is created");
+        let outside = root.path().with_extension("outside");
+        std::fs::write(&outside, b"outside").expect("outside target is created");
+
+        for replacement in ["outside-symlink", "inside-symlink", "directory"] {
+            std::fs::write(root.path().join("input"), b"source").expect("source is created");
+            let (sender, mut responses, shutdown, server) =
+                open_filesync_transfer(open_mount(root.path())).await;
+            read_stat_terminator(&mut responses).await;
+            std::fs::remove_file(root.path().join("input")).expect("source is removed");
+            match replacement {
+                "outside-symlink" => {
+                    std::os::unix::fs::symlink(&outside, root.path().join("input"))
+                        .expect("outside symlink is created")
+                }
+                "inside-symlink" => {
+                    std::os::unix::fs::symlink("replacement-target", root.path().join("input"))
+                        .expect("inside symlink is created")
+                }
+                "directory" => std::fs::create_dir(root.path().join("input"))
+                    .expect("replacement directory is created"),
+                _ => unreachable!(),
+            }
+            if replacement == "inside-symlink" {
+                std::fs::write(root.path().join("replacement-target"), b"different")
+                    .expect("replacement target is created");
+            }
+
+            sender.send(request_packet(0)).await.expect("request sends");
+            let error = expect_protocol_error(&mut responses).await;
+            assert!(
+                matches!(
+                    error.code(),
+                    tonic::Code::Internal | tonic::Code::InvalidArgument
+                ),
+                "replacement {replacement:?} returned {:?}",
+                error.code()
+            );
+            let _ = shutdown.send(());
+            let _ = server.await;
+            let input = root.path().join("input");
+            if input.is_dir() {
+                std::fs::remove_dir(input).expect("replacement directory is removed");
+            } else {
+                std::fs::remove_file(input).expect("replacement link is removed");
+            }
+            let target = root.path().join("replacement-target");
+            if target.exists() {
+                std::fs::remove_file(target).expect("replacement target is removed");
+            }
+        }
+        std::fs::remove_file(outside).expect("outside target is removed");
+    }
+
+    #[tokio::test]
+    async fn diff_copy_reads_current_file_contents_after_stat() {
+        let root = tempdir().expect("temporary directory is created");
+        std::fs::write(root.path().join("input"), b"before").expect("source is created");
+        let (sender, mut responses, shutdown, server) =
+            open_filesync_transfer(open_mount(root.path())).await;
+        read_stat_terminator(&mut responses).await;
+        std::fs::write(root.path().join("input"), b"after").expect("source is modified");
+        sender.send(request_packet(0)).await.expect("request sends");
+        assert_eq!(
+            responses.message().await.unwrap().unwrap(),
+            data_packet(0, b"after".to_vec())
+        );
+        assert_eq!(
+            responses.message().await.unwrap().unwrap(),
+            data_packet(0, Vec::new())
+        );
+        sender.send(fin_packet()).await.expect("FIN sends");
+        assert_eq!(
+            responses.message().await.unwrap().unwrap().r#type,
+            PacketType::PacketFin as i32
         );
         let _ = shutdown.send(());
         let _ = server.await;
@@ -2029,6 +2501,9 @@ mod tests {
         loop {
             let packet = responses.message().await.unwrap().unwrap();
             let done = packet.r#type == PacketType::PacketData as i32 && packet.data.is_empty();
+            if packet.r#type == PacketType::PacketData as i32 {
+                assert!(packet.data.len() <= FILE_READ_BUFFER_SIZE);
+            }
             packets.push(packet);
             if done {
                 break;
@@ -2044,5 +2519,53 @@ mod tests {
         );
         let _ = shutdown.send(());
         let _ = server.await;
+    }
+
+    #[tokio::test]
+    async fn diff_copy_cancellation_stops_a_delayed_scanner() {
+        let root = tempdir().expect("temporary directory is created");
+        for index in 0..16 {
+            std::fs::write(root.path().join(format!("entry-{index}")), b"entry")
+                .expect("entry is created");
+        }
+        let (sender, mut responses, shutdown, server) = open_filesync_transfer_with_metadata(
+            open_mount(root.path()),
+            "context",
+            FaultInjection {
+                delay_scan: true,
+                ..Default::default()
+            },
+        )
+        .await;
+        let _ = responses.message().await;
+        drop(sender);
+        drop(responses);
+        let _ = shutdown.send(());
+        tokio::time::timeout(std::time::Duration::from_secs(1), server)
+            .await
+            .expect("delayed scanner service shuts down")
+            .expect("delayed scanner service joins");
+    }
+
+    #[tokio::test]
+    async fn diff_copy_cancellation_stops_a_worker_under_output_backpressure() {
+        let root = tempdir().expect("temporary directory is created");
+        std::fs::write(
+            root.path().join("input"),
+            vec![b'x'; FILE_READ_BUFFER_SIZE * OUTPUT_QUEUE_CAPACITY * 2],
+        )
+        .expect("source is created");
+        let (sender, responses, shutdown, server) =
+            open_filesync_transfer(open_mount(root.path())).await;
+        let mut responses = responses;
+        read_stat_terminator(&mut responses).await;
+        sender.send(request_packet(0)).await.expect("request sends");
+        drop(sender);
+        drop(responses);
+        let _ = shutdown.send(());
+        tokio::time::timeout(std::time::Duration::from_secs(1), server)
+            .await
+            .expect("backpressured service shuts down")
+            .expect("backpressured service joins");
     }
 }

--- a/src/grpc/filesync.rs
+++ b/src/grpc/filesync.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::HashMap,
+    collections::{HashMap, HashSet},
     ffi::{OsStr, OsString},
     panic::AssertUnwindSafe,
     path::{Path, PathBuf},
@@ -22,7 +22,7 @@ use tonic::{metadata::MetadataMap, Request, Response, Status, Streaming};
 #[cfg(unix)]
 use xattr::FileExt;
 
-use super::patternmatcher::{match_component, PatternMatcher};
+use super::patternmatcher::{compile_component, PatternMatcher};
 
 #[cfg(unix)]
 use cap_std::fs::MetadataExt;
@@ -36,6 +36,11 @@ const FOLLOW_PATHS_METADATA: &str = "followpaths";
 const MAX_ENTRIES: usize = 100_000;
 const MAX_PATH_LENGTH: usize = 4096;
 const MAX_LINKNAME_LENGTH: usize = 4096;
+const MAX_FILESYNC_PATTERNS: usize = 4096;
+const MAX_FOLLOW_PATHS: usize = 1024;
+const MAX_FOLLOW_RESOLVED_PATHS: usize = MAX_ENTRIES;
+const MAX_FOLLOW_INSPECTED_ENTRIES: usize = MAX_ENTRIES;
+const MAX_FOLLOW_DEPTH: usize = 256;
 const ENTRY_QUEUE_CAPACITY: usize = 128;
 const FILE_JOB_QUEUE_CAPACITY: usize = 128;
 const OUTPUT_QUEUE_CAPACITY: usize = 16;
@@ -306,6 +311,33 @@ impl ScanBudget {
     }
 }
 
+struct FollowPathBudget {
+    inspected: usize,
+    resolved: usize,
+}
+
+impl FollowPathBudget {
+    fn inspect(&mut self) -> Result<(), Status> {
+        if self.inspected >= MAX_FOLLOW_INSPECTED_ENTRIES {
+            return Err(Status::resource_exhausted(
+                "FileSync followpaths inspected too many entries",
+            ));
+        }
+        self.inspected += 1;
+        Ok(())
+    }
+
+    fn resolve(&mut self, path: &Path) -> Result<String, Status> {
+        if self.resolved >= MAX_FOLLOW_RESOLVED_PATHS {
+            return Err(Status::resource_exhausted(
+                "FileSync followpaths resolved too many paths",
+            ));
+        }
+        self.resolved += 1;
+        path_string(path)
+    }
+}
+
 enum SessionEvent {
     Entry(Option<Result<SourceEntry, Status>>),
     Packet(Option<Result<Packet, Status>>),
@@ -376,7 +408,14 @@ impl FileSync for FileSyncImpl {
             .clone()
             .ok_or_else(|| Status::not_found("local source name is missing"))?;
         let root = lookup_mount(&self.mounts, &name)?;
-        let selection = scan_selection(&root, &options)?;
+        let selection = tokio::task::spawn_blocking({
+            let root = root.clone();
+            move || scan_selection(&root, &options)
+        })
+        .await
+        .map_err(|error| {
+            Status::internal(format!("FileSync selection worker failed: {error}"))
+        })??;
         #[cfg(test)]
         let faults = FaultInjection::from_metadata(request.metadata());
         #[cfg(not(test))]
@@ -723,6 +762,13 @@ fn scan_selection(
     root: &cap_std::fs::Dir,
     options: &FileSyncOptions,
 ) -> Result<ScanSelection, Status> {
+    if options.include_patterns.len() > MAX_FILESYNC_PATTERNS
+        || options.exclude_patterns.len() > MAX_FILESYNC_PATTERNS
+    {
+        return Err(Status::resource_exhausted(
+            "FileSync request contains too many filter patterns",
+        ));
+    }
     let mut include_patterns = options.include_patterns.clone();
     let follow_patterns = resolve_follow_paths(root, &options.follow_paths)?;
     if follow_patterns.iter().any(|path| path == ".") {
@@ -733,19 +779,37 @@ fn scan_selection(
 }
 
 fn resolve_follow_paths(root: &cap_std::fs::Dir, paths: &[String]) -> Result<Vec<String>, Status> {
+    if paths.len() > MAX_FOLLOW_PATHS {
+        return Err(Status::resource_exhausted(
+            "FileSync request contains too many followpaths",
+        ));
+    }
     let mut resolved = Vec::new();
+    let mut budget = FollowPathBudget {
+        inspected: 0,
+        resolved: 0,
+    };
+    let mut visited = HashSet::new();
     for path in paths {
         if path == "." {
             return Ok(vec![String::from(".")]);
         }
+        budget.resolve(Path::new(path))?;
         resolved.push(path.clone());
         let components = path.split('/').map(str::to_owned).collect::<Vec<_>>();
+        if components.len() > MAX_FOLLOW_DEPTH {
+            return Err(Status::resource_exhausted(
+                "FileSync followpaths path is too deep",
+            ));
+        }
         resolve_follow_components(
             root,
             Path::new(""),
             &components,
-            &mut Vec::new(),
+            &mut visited,
             &mut resolved,
+            &mut budget,
+            0,
         )?;
     }
     resolved.sort_unstable();
@@ -757,17 +821,29 @@ fn resolve_follow_components(
     root: &cap_std::fs::Dir,
     current: &Path,
     components: &[String],
-    visited: &mut Vec<String>,
+    visited: &mut HashSet<String>,
     resolved: &mut Vec<String>,
+    budget: &mut FollowPathBudget,
+    depth: usize,
 ) -> Result<(), Status> {
+    if depth > MAX_FOLLOW_DEPTH {
+        return Err(Status::resource_exhausted(
+            "FileSync followpaths resolution is too deep",
+        ));
+    }
     let Some(component) = components.first() else {
         if !current.as_os_str().is_empty() {
-            resolved.push(path_string(current)?);
+            resolved.push(budget.resolve(current)?);
         }
         return Ok(());
     };
 
     if contains_wildcard(component) {
+        let component_pattern = compile_component(component).ok_or_else(|| {
+            Status::invalid_argument(format!(
+                "invalid FileSync followpath pattern: {component:?}"
+            ))
+        })?;
         let directory = if current.as_os_str().is_empty() {
             root.try_clone()
         } else {
@@ -784,27 +860,59 @@ fn resolve_follow_components(
                 ))
             }
         };
-        let mut names = directory
+        let mut names = Vec::new();
+        for entry in directory
             .entries()
             .map_err(|error| filesystem_error("read followpaths directory", current, error))?
-            .map(|entry| {
-                entry
-                    .map(|entry| entry.file_name())
-                    .map_err(|error| filesystem_error("read followpaths entry", current, error))
-            })
-            .collect::<Result<Vec<_>, Status>>()?;
+        {
+            budget.inspect()?;
+            let entry = entry
+                .map_err(|error| filesystem_error("read followpaths entry", current, error))?;
+            names.push(entry.file_name());
+        }
         names.sort_unstable();
         for name in names {
             let Some(name) = name.to_str() else { continue };
-            if match_component(component, name) {
-                let next = current.join(name);
-                resolve_follow_components(root, &next, &components[1..], visited, resolved)?;
+            if component_pattern.matches(name) {
+                resolve_follow_entry(
+                    root,
+                    current,
+                    name,
+                    &components[1..],
+                    visited,
+                    resolved,
+                    budget,
+                    depth + 1,
+                )?;
             }
         }
         return Ok(());
     }
 
-    let next = current.join(component);
+    budget.inspect()?;
+    resolve_follow_entry(
+        root,
+        current,
+        component,
+        &components[1..],
+        visited,
+        resolved,
+        budget,
+        depth + 1,
+    )
+}
+
+fn resolve_follow_entry(
+    root: &cap_std::fs::Dir,
+    current: &Path,
+    name: &str,
+    remaining: &[String],
+    visited: &mut HashSet<String>,
+    resolved: &mut Vec<String>,
+    budget: &mut FollowPathBudget,
+    depth: usize,
+) -> Result<(), Status> {
+    let next = current.join(name);
     let metadata = match root.symlink_metadata(&next) {
         Ok(metadata) => metadata,
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
@@ -812,14 +920,13 @@ fn resolve_follow_components(
     };
     let next_string = path_string(&next)?;
     if metadata.file_type().is_symlink() {
-        if visited.contains(&next_string) {
+        if !visited.insert(next_string.clone()) {
             return Ok(());
         }
-        visited.push(next_string.clone());
-        resolved.push(next_string);
+        resolved.push(budget.resolve(&next)?);
         let parent = next.parent().unwrap_or_else(|| Path::new(""));
         let link = root
-            .read_link_contents(current.join(component).as_path())
+            .read_link_contents(&next)
             .map_err(|error| filesystem_error("read followpaths symlink", &next, error))?;
         let Some(target) = normalize_follow_target(parent, &link) else {
             return Ok(());
@@ -835,21 +942,23 @@ fn resolve_follow_components(
                 _ => None,
             })
             .collect::<Vec<_>>();
-        target_components.extend_from_slice(&components[1..]);
+        target_components.extend_from_slice(remaining);
         return resolve_follow_components(
             root,
             Path::new(""),
             &target_components,
             visited,
             resolved,
+            budget,
+            depth + 1,
         );
     }
-    if components.len() == 1 {
-        resolved.push(next_string);
+    if remaining.is_empty() {
+        resolved.push(budget.resolve(&next)?);
     } else if !metadata.file_type().is_dir() {
         return Ok(());
     } else {
-        resolve_follow_components(root, &next, &components[1..], visited, resolved)?;
+        resolve_follow_components(root, &next, remaining, visited, resolved, budget, depth)?;
     }
     Ok(())
 }
@@ -1374,8 +1483,6 @@ fn error_packet(error: &Status) -> Packet {
 
 #[cfg(test)]
 use futures_util::stream;
-#[cfg(test)]
-use std::collections::HashSet;
 #[cfg(test)]
 use tokio_stream::wrappers::{ReceiverStream, TcpListenerStream};
 #[cfg(test)]
@@ -2029,6 +2136,14 @@ mod tests {
         };
         let selection =
             scan_selection(&open_mount(root.path()), &options).expect("followpaths resolve");
+        let wildcard_only = FileSyncOptions {
+            follow_paths: vec![String::from("dir/link*")],
+            ..Default::default()
+        };
+        let wildcard_selection = scan_selection(&open_mount(root.path()), &wildcard_only)
+            .expect("wildcard followpath resolves");
+        assert!(wildcard_selection.is_selected(Path::new("dir/link1")));
+        assert!(wildcard_selection.is_selected(Path::new("target/input")));
         let (sender, mut receiver) = mpsc::channel(ENTRY_QUEUE_CAPACITY);
         let scanner = tokio::task::spawn_blocking({
             let root = open_mount(root.path());
@@ -2216,6 +2331,30 @@ mod tests {
                 tonic::Code::InvalidArgument
             );
         }
+    }
+
+    #[test]
+    fn followpath_resolution_has_bounded_input_and_depth() {
+        let root = tempdir().expect("temporary directory is created");
+        let mount = open_mount(root.path());
+        let too_many = vec![String::from("missing"); MAX_FOLLOW_PATHS + 1];
+        assert_eq!(
+            resolve_follow_paths(&mount, &too_many)
+                .expect_err("too many followpaths are rejected")
+                .code(),
+            tonic::Code::ResourceExhausted
+        );
+
+        let too_deep = (0..=MAX_FOLLOW_DEPTH)
+            .map(|_| "missing")
+            .collect::<Vec<_>>()
+            .join("/");
+        assert_eq!(
+            resolve_follow_paths(&mount, &[too_deep])
+                .expect_err("deep followpaths are rejected")
+                .code(),
+            tonic::Code::ResourceExhausted
+        );
     }
 
     #[test]

--- a/src/grpc/filesync.rs
+++ b/src/grpc/filesync.rs
@@ -805,6 +805,11 @@ fn scan_selection(
     }
     let mut include_patterns = options.include_patterns.clone();
     let follow_patterns = resolve_follow_paths(root, &options.follow_paths)?;
+    if include_patterns.len().saturating_add(follow_patterns.len()) > MAX_FILESYNC_PATTERNS {
+        return Err(Status::resource_exhausted(
+            "FileSync request resolves to too many filter patterns",
+        ));
+    }
     if follow_patterns.iter().any(|path| path == ".") {
         return ScanSelection::from_patterns(&include_patterns, &options.exclude_patterns);
     }
@@ -2473,6 +2478,22 @@ mod tests {
         assert_eq!(
             resolve_follow_paths(&mount, &[too_deep])
                 .expect_err("deep followpaths are rejected")
+                .code(),
+            tonic::Code::ResourceExhausted
+        );
+    }
+
+    #[test]
+    fn scan_selection_bounds_resolved_filter_patterns() {
+        let root = tempdir().expect("temporary directory is created");
+        let options = FileSyncOptions {
+            include_patterns: vec![String::from("included"); MAX_FILESYNC_PATTERNS],
+            follow_paths: vec![String::from("followed")],
+            ..Default::default()
+        };
+        assert_eq!(
+            scan_selection(&open_mount(root.path()), &options)
+                .expect_err("effective pattern limit is enforced")
                 .code(),
             tonic::Code::ResourceExhausted
         );

--- a/src/grpc/filesync.rs
+++ b/src/grpc/filesync.rs
@@ -139,7 +139,7 @@ impl FileSyncSession {
         root: Arc<cap_std::fs::Dir>,
         selection: ScanSelection,
         faults: FaultInjection,
-    ) -> FileSyncStart {
+    ) -> Result<FileSyncStart, Status> {
         let cancellation = CancellationToken::new();
         let scanner_root = root.clone();
         let (entries_sender, entries_receiver) = mpsc::channel(ENTRY_QUEUE_CAPACITY);
@@ -168,8 +168,7 @@ impl FileSyncSession {
                 let result = result.map_err(|_| Status::internal("FileSync scanner panicked"));
                 let _ = completion_sender.send(result);
             })
-            .map_err(|error| Status::internal(format!("FileSync scanner task failed: {error}")))
-            .expect("FileSync scanner thread starts");
+            .map_err(|error| Status::internal(format!("FileSync scanner task failed: {error}")))?;
 
         let jobs_receiver = Arc::new(Mutex::new(jobs_receiver));
         let mut workers = tokio::task::JoinSet::new();
@@ -200,7 +199,7 @@ impl FileSyncSession {
         }
         drop(output_sender);
 
-        (
+        Ok((
             Self {
                 cancellation,
                 scanner: Some(ScannerHandle {
@@ -212,7 +211,7 @@ impl FileSyncSession {
             entries_receiver,
             jobs_sender,
             output_receiver,
-        )
+        ))
     }
 
     async fn shutdown(
@@ -453,7 +452,7 @@ impl FileSync for FileSyncImpl {
         #[cfg(not(test))]
         let faults = FaultInjection::default();
         let (mut session, mut entries_receiver, jobs_sender, mut output_receiver) =
-            FileSyncSession::start(root, selection, faults);
+            FileSyncSession::start(root, selection, faults)?;
         let mut jobs_sender = Some(jobs_sender);
         let mut input = Box::pin(request.into_inner());
 

--- a/src/grpc/fsutil.rs
+++ b/src/grpc/fsutil.rs
@@ -1,5 +1,22 @@
 use bitflags::bitflags;
 
+pub(crate) fn is_transferable_xattr(name: &str) -> bool {
+    name.starts_with("user.")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_transferable_xattr;
+
+    #[test]
+    fn only_user_xattrs_are_transferable() {
+        assert!(is_transferable_xattr("user.bollard"));
+        assert!(!is_transferable_xattr("security.capability"));
+        assert!(!is_transferable_xattr("trusted.overlay.opaque"));
+        assert!(!is_transferable_xattr("system.posix_acl_access"));
+    }
+}
+
 bitflags! { // source: https://pkg.go.dev/io/fs#FileMode
     pub struct FileMode: u32 {
         const Dir        = 1 << (32 -  1); // d: is a directory

--- a/src/grpc/mod.rs
+++ b/src/grpc/mod.rs
@@ -182,7 +182,7 @@ impl GrpcServer {
             }
             GrpcServer::FileSync(_file_sync_server) => {
                 vec![format!(
-                    "/{}/DiffCopy",
+                    "/{}/diffcopy",
                     FileSyncServer::<filesync::FileSyncImpl>::NAME
                 )]
             }
@@ -2451,7 +2451,7 @@ mod tests {
 
     #[cfg(unix)]
     #[tokio::test]
-    async fn test_file_receive_state_restores_xattrs() {
+    async fn test_file_receive_state_restores_and_filters_xattrs() {
         let dir = tempfile::tempdir().unwrap();
         let mut state = FileReceiveState::new(dir.path().to_path_buf())
             .await
@@ -2475,7 +2475,7 @@ mod tests {
                     0o644,
                     5,
                     "",
-                    &[("user.file", b"value")],
+                    &[("user.file", b"value"), ("security.capability", b"blocked")],
                 ))))
                 .await
                 .unwrap()
@@ -2485,6 +2485,18 @@ mod tests {
         );
         state.handle_packet(packet_data(1, b"hello")).await.unwrap();
         state.handle_packet(packet_data(1, &[])).await.unwrap();
+        assert_eq!(
+            xattr::get(dir.path().join("nested"), "user.directory").unwrap(),
+            Some(b"value".to_vec())
+        );
+        assert_eq!(
+            xattr::get(dir.path().join("nested/file"), "user.file").unwrap(),
+            Some(b"value".to_vec())
+        );
+        assert_eq!(
+            xattr::get(dir.path().join("nested/file"), "security.capability").unwrap(),
+            None
+        );
         state.handle_packet(packet_stat(None)).await.unwrap();
         state.finalize().await.unwrap();
 
@@ -2496,82 +2508,8 @@ mod tests {
             xattr::get(dir.path().join("nested/file"), "user.file").unwrap(),
             Some(b"value".to_vec())
         );
-    }
-
-    #[cfg(unix)]
-    #[tokio::test]
-    async fn test_file_receive_state_applies_xattrs_before_finalize() {
-        let dir = tempfile::tempdir().unwrap();
-        let mut state = FileReceiveState::new(dir.path().to_path_buf())
-            .await
-            .unwrap();
-        let directory_mode = fsutil::FileMode::Dir.bits() | 0o755;
-
-        state
-            .handle_packet(packet_stat(Some(stat_with_xattrs(
-                "nested",
-                directory_mode,
-                0,
-                "",
-                &[("user.directory", b"value")],
-            ))))
-            .await
-            .unwrap();
         assert_eq!(
-            xattr::get(dir.path().join("nested"), "user.directory").unwrap(),
-            Some(b"value".to_vec())
-        );
-
-        let request = state
-            .handle_packet(packet_stat(Some(stat_with_xattrs(
-                "nested/file",
-                0o644,
-                5,
-                "",
-                &[("user.file", b"value")],
-            ))))
-            .await
-            .unwrap()
-            .unwrap();
-        state
-            .handle_packet(packet_data(request.id, b"hello"))
-            .await
-            .unwrap();
-        assert_eq!(
-            xattr::get(dir.path().join("nested/file"), "user.file").unwrap(),
-            Some(b"value".to_vec())
-        );
-    }
-
-    #[cfg(unix)]
-    #[tokio::test]
-    async fn test_file_receive_state_filters_privileged_xattrs() {
-        let dir = tempfile::tempdir().unwrap();
-        let mut state = FileReceiveState::new(dir.path().to_path_buf())
-            .await
-            .unwrap();
-        let request = state
-            .handle_packet(packet_stat(Some(stat_with_xattrs(
-                "file",
-                0o644,
-                0,
-                "",
-                &[("user.file", b"value"), ("security.capability", b"blocked")],
-            ))))
-            .await
-            .unwrap()
-            .unwrap();
-        state
-            .handle_packet(packet_data(request.id, &[]))
-            .await
-            .unwrap();
-
-        assert_eq!(
-            xattr::get(dir.path().join("file"), "user.file").unwrap(),
-            Some(b"value".to_vec())
-        );
-        assert_eq!(
-            xattr::get(dir.path().join("file"), "security.capability").unwrap(),
+            xattr::get(dir.path().join("nested/file"), "security.capability").unwrap(),
             None
         );
     }

--- a/src/grpc/mod.rs
+++ b/src/grpc/mod.rs
@@ -846,14 +846,12 @@ async fn prepare_staging_directory(destination: &Path) -> Result<PathBuf, Status
 
 struct StagingGuard {
     staging: Option<PathBuf>,
-    runtime: tokio::runtime::Handle,
 }
 
 impl StagingGuard {
     async fn new(destination: &Path) -> Result<Self, Status> {
         Ok(Self {
             staging: Some(prepare_staging_directory(destination).await?),
-            runtime: tokio::runtime::Handle::current(),
         })
     }
 
@@ -886,12 +884,16 @@ impl Drop for StagingGuard {
             return;
         };
 
-        let runtime = self.runtime.clone();
-        runtime.spawn(async move {
-            if let Err(error) = remove_path(&staging).await {
-                warn!("failed to clean up cancelled FileSend staging directory: {error}");
-            }
-        });
+        let thread = std::thread::Builder::new()
+            .name(String::from("bollard-filesend-cleanup"))
+            .spawn(move || {
+                if let Err(error) = remove_path_blocking(&staging) {
+                    warn!("failed to clean up cancelled FileSend staging directory: {error}");
+                }
+            });
+        if let Err(error) = thread {
+            warn!("failed to spawn FileSend cleanup thread: {error}");
+        }
     }
 }
 
@@ -1924,6 +1926,30 @@ mod tests {
             .map(|entry| entry.unwrap().file_name().to_string_lossy().into_owned())
             .filter(|name| name.contains(".bollard-staging-") || name.contains(".bollard-backup-"))
             .collect()
+    }
+
+    #[test]
+    fn staging_guard_cleans_after_runtime_shutdown() {
+        let root = tempfile::tempdir().unwrap();
+        let destination = root.path().join("output");
+        let guard = {
+            let runtime = tokio::runtime::Runtime::new().unwrap();
+            runtime
+                .block_on(super::StagingGuard::new(&destination))
+                .expect("staging directory is created")
+        };
+
+        assert!(!transfer_sibling_names(root.path()).is_empty());
+        drop(guard);
+
+        let deadline = std::time::Instant::now() + Duration::from_secs(1);
+        while std::time::Instant::now() < deadline {
+            if transfer_sibling_names(root.path()).is_empty() {
+                return;
+            }
+            std::thread::sleep(Duration::from_millis(10));
+        }
+        panic!("staging cleanup did not finish after runtime shutdown");
     }
 
     async fn wait_for_staging_siblings(root: &Path, expected: bool) {

--- a/src/grpc/mod.rs
+++ b/src/grpc/mod.rs
@@ -10,6 +10,7 @@ pub mod driver;
 pub mod error;
 /// End-user buildkit export functions
 pub mod export;
+mod filesync;
 mod fsutil;
 /// Internal interfaces to convert types for GRPC communication
 pub(crate) mod io;
@@ -50,6 +51,7 @@ use bollard_buildkit_proto::moby::filesync::packet::file_send_server::{
 };
 use bollard_buildkit_proto::moby::filesync::v1::auth_server::AuthServer;
 use bollard_buildkit_proto::moby::filesync::v1::file_send_server::FileSendServer;
+use bollard_buildkit_proto::moby::filesync::v1::file_sync_server::FileSyncServer;
 use bollard_buildkit_proto::moby::sshforward::v1::ssh_server::{Ssh, SshServer};
 use bollard_buildkit_proto::moby::sshforward::v1::{CheckAgentRequest, CheckAgentResponse};
 use bytes::Bytes;
@@ -122,6 +124,7 @@ pub(crate) enum GrpcServer {
     Upload(UploadServer<UploadProvider>),
     FileSend(FileSendServer<FileSendImpl>),
     FileSendPacket(FileSendPacketServer<FileSendPacketImpl>),
+    FileSync(FileSyncServer<filesync::FileSyncImpl>),
     Secrets(SecretsServer<SecretProvider>),
     Ssh(SshServer<SshProvider>),
 }
@@ -138,6 +141,7 @@ impl GrpcServer {
             GrpcServer::FileSendPacket(file_send_packet_server) => {
                 builder.add_service(file_send_packet_server)
             }
+            GrpcServer::FileSync(file_sync_server) => builder.add_service(file_sync_server),
             GrpcServer::Secrets(secret_server) => builder.add_service(secret_server),
             GrpcServer::Ssh(ssh_server) => builder.add_service(ssh_server),
         }
@@ -165,6 +169,12 @@ impl GrpcServer {
                 vec![format!(
                     "/{}/diffcopy",
                     FileSendPacketServer::<FileSendPacketImpl>::NAME
+                )]
+            }
+            GrpcServer::FileSync(_file_sync_server) => {
+                vec![format!(
+                    "/{}/DiffCopy",
+                    FileSyncServer::<filesync::FileSyncImpl>::NAME
                 )]
             }
             GrpcServer::Secrets(_secret_server) => {

--- a/src/grpc/mod.rs
+++ b/src/grpc/mod.rs
@@ -33,6 +33,8 @@ use crate::moby::filesync::v1::{
 };
 use crate::moby::upload::v1::upload_server::{Upload, UploadServer};
 use crate::moby::upload::v1::BytesMessage as UploadBytesMessage;
+#[cfg(unix)]
+use cap_fs_ext::{FollowSymlinks, OpenOptionsFollowExt};
 use std::collections::{HashMap, HashSet};
 use std::env;
 use std::ffi::OsString;
@@ -41,6 +43,8 @@ use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
 use std::pin::Pin;
 use std::task::{Context, Poll};
+#[cfg(unix)]
+use xattr::FileExt;
 
 use bollard_buildkit_proto::fsutil::types::packet::PacketType;
 use bollard_buildkit_proto::fsutil::types::{Packet, Stat};
@@ -386,11 +390,47 @@ const MAX_PENDING_FILES: usize = 4096;
 const MAX_FILE_SIZE: u64 = 4 * 1024 * 1024 * 1024;
 const MAX_TOTAL_SIZE: u64 = 16 * 1024 * 1024 * 1024;
 
+#[cfg(unix)]
+fn apply_xattrs(
+    parent: &cap_std::fs::Dir,
+    name: &std::ffi::OsStr,
+    xattrs: &HashMap<String, Vec<u8>>,
+) -> std::io::Result<()> {
+    if xattrs.is_empty() {
+        return Ok(());
+    }
+
+    let mut options = cap_std::fs::OpenOptions::new();
+    options.read(true).follow(FollowSymlinks::No);
+    let file = parent.open_with(name, &options)?.into_std();
+    for (name, value) in xattrs {
+        if !fsutil::is_transferable_xattr(name) {
+            continue;
+        }
+        file.set_xattr(name, value)?;
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
+fn apply_xattrs_to_file(
+    file: &std::fs::File,
+    xattrs: &HashMap<String, Vec<u8>>,
+) -> std::io::Result<()> {
+    for (name, value) in xattrs {
+        if !fsutil::is_transferable_xattr(name) {
+            continue;
+        }
+        file.set_xattr(name, value)?;
+    }
+    Ok(())
+}
+
 struct FileReceiveState {
     root: cap_std::fs::Dir,
     stats: HashMap<u32, PendingFile>,
     declared_paths: HashSet<PathBuf>,
-    directories: HashMap<PathBuf, (u32, cap_std::fs::Dir, OsString)>,
+    directories: HashMap<PathBuf, PendingDirectory>,
     received_all_stats: bool,
     received_fin: bool,
     next_stat_id: u32,
@@ -400,9 +440,16 @@ struct FileReceiveState {
 }
 
 struct PendingFile {
-    stat: Stat,
+    size: i64,
+    mode: u32,
     file: File,
     received_bytes: u64,
+}
+
+struct PendingDirectory {
+    mode: u32,
+    parent: cap_std::fs::Dir,
+    name: OsString,
 }
 
 impl FileReceiveState {
@@ -633,7 +680,11 @@ impl FileReceiveState {
         for (directory, parent, name) in created {
             self.directories
                 .entry(directory)
-                .or_insert((0o700, parent, name));
+                .or_insert(PendingDirectory {
+                    mode: 0o700,
+                    parent,
+                    name,
+                });
         }
 
         let name = path.file_name().ok_or_else(|| {
@@ -694,9 +745,19 @@ impl FileReceiveState {
                 Status::already_exists(format!("cannot create export directory: {error}"))
             })?;
             drop(directory);
+            #[cfg(unix)]
+            apply_xattrs(&permission_parent, &permission_name, &stat.xattrs).map_err(|error| {
+                Status::internal(format!(
+                    "failed to set directory extended attributes: {error}"
+                ))
+            })?;
             self.directories.insert(
                 path,
-                (stat.mode & 0o777, permission_parent, permission_name),
+                PendingDirectory {
+                    mode: stat.mode & 0o777,
+                    parent: permission_parent,
+                    name: permission_name,
+                },
             );
             self.file_count += 1;
             return Ok(false);
@@ -724,13 +785,24 @@ impl FileReceiveState {
                     "hardlink target is not a regular file",
                 ));
             }
+            #[cfg(unix)]
+            let xattr_parent = parent.try_clone().map_err(|error| {
+                Status::internal(format!("failed to retain export directory: {error}"))
+            })?;
             let name = name.to_owned();
-            tokio::task::spawn_blocking(move || root.hard_link(&target, &parent, &name))
+            let hardlink_name = name.clone();
+            tokio::task::spawn_blocking(move || root.hard_link(&target, &parent, &hardlink_name))
                 .await
                 .map_err(|error| Status::internal(format!("filesystem worker failed: {error}")))?
                 .map_err(|error| {
                     Status::invalid_argument(format!("failed to create hardlink: {error}"))
                 })?;
+            #[cfg(unix)]
+            apply_xattrs(&xattr_parent, &name, &stat.xattrs).map_err(|error| {
+                Status::internal(format!(
+                    "failed to set hardlink extended attributes: {error}"
+                ))
+            })?;
             self.file_count += 1;
             return Ok(false);
         }
@@ -752,6 +824,7 @@ impl FileReceiveState {
             Status::internal(format!("failed to retain export directory: {error}"))
         })?;
         let name = name.to_owned();
+        let xattrs = stat.xattrs.clone();
         let file = tokio::task::spawn_blocking(move || {
             let mut options = cap_std::fs::OpenOptions::new();
             options.write(true).create_new(true);
@@ -760,9 +833,10 @@ impl FileReceiveState {
                 use cap_std::fs::OpenOptionsExt;
                 options.mode(0o600);
             }
-            parent
-                .open_with(&name, &options)
-                .map(|file| file.into_std())
+            let file = parent.open_with(&name, &options)?.into_std();
+            #[cfg(unix)]
+            apply_xattrs_to_file(&file, &xattrs)?;
+            Ok::<_, std::io::Error>(file)
         })
         .await
         .map_err(|error| Status::internal(format!("filesystem worker failed: {error}")))?
@@ -772,7 +846,8 @@ impl FileReceiveState {
         self.stats.insert(
             request_id,
             PendingFile {
-                stat: stat.clone(),
+                size: stat.size,
+                mode: stat.mode,
                 file: File::from_std(file),
                 received_bytes: 0,
             },
@@ -791,7 +866,7 @@ impl FileReceiveState {
             .received_bytes
             .checked_add(data_len)
             .ok_or_else(|| Status::resource_exhausted("file byte count overflow"))?;
-        let expected_bytes = u64::try_from(pending.stat.size)
+        let expected_bytes = u64::try_from(pending.size)
             .map_err(|_| Status::invalid_argument("file stat has a negative size"))?;
         if received_bytes > expected_bytes {
             return Err(Status::resource_exhausted(
@@ -812,7 +887,7 @@ impl FileReceiveState {
             .stats
             .remove(&id)
             .ok_or_else(|| Status::invalid_argument("end-of-file packet for unknown file"))?;
-        let expected_bytes = u64::try_from(pending.stat.size)
+        let expected_bytes = u64::try_from(pending.size)
             .map_err(|_| Status::invalid_argument("file stat has a negative size"))?;
         if pending.received_bytes != expected_bytes {
             return Err(Status::invalid_argument(format!(
@@ -827,13 +902,13 @@ impl FileReceiveState {
             .await
             .map_err(|error| Status::internal(format!("failed to flush file data: {error}")))?;
         #[cfg(unix)]
-        pending
-            .file
-            .set_permissions(std::fs::Permissions::from_mode(pending.stat.mode & 0o777))
-            .await
-            .map_err(|error| {
-                Status::internal(format!("failed to set file permissions: {error}"))
-            })?;
+        {
+            let file = pending.file.into_std().await;
+            file.set_permissions(std::fs::Permissions::from_mode(pending.mode & 0o777))
+                .map_err(|error| {
+                    Status::internal(format!("failed to set file permissions: {error}"))
+                })?;
+        }
         Ok(())
     }
 
@@ -846,14 +921,16 @@ impl FileReceiveState {
         self.stats.clear();
         let directories: Vec<_> = self.directories.into_values().collect();
         tokio::task::spawn_blocking(move || {
-            for (mode, parent, name) in directories {
+            for directory in directories {
                 #[cfg(unix)]
-                parent.set_permissions(
-                    name,
-                    cap_std::fs::Permissions::from_std(std::fs::Permissions::from_mode(mode)),
+                directory.parent.set_permissions(
+                    &directory.name,
+                    cap_std::fs::Permissions::from_std(std::fs::Permissions::from_mode(
+                        directory.mode,
+                    )),
                 )?;
                 #[cfg(not(unix))]
-                let _ = (parent, name, mode);
+                let _ = directory;
             }
             Ok::<(), std::io::Error>(())
         })
@@ -918,11 +995,9 @@ impl StagingGuard {
     async fn publish(mut self, destination: &Path) -> Result<(), Status> {
         let staging = self
             .staging
-            .as_ref()
-            .expect("staging guard owns a path before publication");
-        publish_staging_directory(staging, destination).await?;
-        self.staging = None;
-        Ok(())
+            .take()
+            .ok_or_else(|| Status::failed_precondition("staging directory is not available"))?;
+        publish_staging_directory(&staging, destination).await
     }
 }
 
@@ -1050,14 +1125,28 @@ fn publish_staging_directory_blocking(staging: &Path, destination: &Path) -> Res
     result
 }
 
+struct StagingPublication {
+    path: PathBuf,
+}
+
+impl Drop for StagingPublication {
+    fn drop(&mut self) {
+        if let Err(error) = remove_path_blocking(&self.path) {
+            warn!("failed to clean up unpublished export: {error}");
+        }
+    }
+}
+
 async fn publish_staging_directory(staging: &Path, destination: &Path) -> Result<(), Status> {
-    let staging = staging.to_owned();
+    let staging = StagingPublication {
+        path: staging.to_owned(),
+    };
     let destination = destination.to_owned();
-    tokio::task::spawn_blocking(move || publish_staging_directory_blocking(&staging, &destination))
-        .await
-        .map_err(|error| {
-            Status::internal(format!("filesystem publication worker failed: {error}"))
-        })?
+    tokio::task::spawn_blocking(move || {
+        publish_staging_directory_blocking(&staging.path, &destination)
+    })
+    .await
+    .map_err(|error| Status::internal(format!("filesystem publication worker failed: {error}")))?
 }
 
 #[tonic::async_trait]
@@ -1953,6 +2042,22 @@ mod tests {
         }
     }
 
+    #[cfg(unix)]
+    fn stat_with_xattrs(
+        path: &str,
+        mode: u32,
+        size: i64,
+        linkname: &str,
+        xattrs: &[(&str, &[u8])],
+    ) -> Stat {
+        let mut stat = stat(path, mode, size, linkname);
+        stat.xattrs = xattrs
+            .iter()
+            .map(|(name, value)| ((*name).to_owned(), (*value).to_vec()))
+            .collect();
+        stat
+    }
+
     async fn start_file_send_server(
         destination: std::path::PathBuf,
     ) -> (
@@ -2318,6 +2423,133 @@ mod tests {
         let second = std::fs::metadata(dir.path().join("second")).unwrap();
         assert_eq!(first.ino(), second.ino());
         assert_eq!(std::fs::read(dir.path().join("second")).unwrap(), b"hello");
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_file_receive_state_restores_xattrs() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut state = FileReceiveState::new(dir.path().to_path_buf())
+            .await
+            .unwrap();
+        let directory_mode = fsutil::FileMode::Dir.bits() | 0o755;
+
+        state
+            .handle_packet(packet_stat(Some(stat_with_xattrs(
+                "nested",
+                directory_mode,
+                0,
+                "",
+                &[("user.directory", b"value")],
+            ))))
+            .await
+            .unwrap();
+        assert_eq!(
+            state
+                .handle_packet(packet_stat(Some(stat_with_xattrs(
+                    "nested/file",
+                    0o644,
+                    5,
+                    "",
+                    &[("user.file", b"value")],
+                ))))
+                .await
+                .unwrap()
+                .unwrap()
+                .id,
+            1
+        );
+        state.handle_packet(packet_data(1, b"hello")).await.unwrap();
+        state.handle_packet(packet_data(1, &[])).await.unwrap();
+        state.handle_packet(packet_stat(None)).await.unwrap();
+        state.finalize().await.unwrap();
+
+        assert_eq!(
+            xattr::get(dir.path().join("nested"), "user.directory").unwrap(),
+            Some(b"value".to_vec())
+        );
+        assert_eq!(
+            xattr::get(dir.path().join("nested/file"), "user.file").unwrap(),
+            Some(b"value".to_vec())
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_file_receive_state_applies_xattrs_before_finalize() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut state = FileReceiveState::new(dir.path().to_path_buf())
+            .await
+            .unwrap();
+        let directory_mode = fsutil::FileMode::Dir.bits() | 0o755;
+
+        state
+            .handle_packet(packet_stat(Some(stat_with_xattrs(
+                "nested",
+                directory_mode,
+                0,
+                "",
+                &[("user.directory", b"value")],
+            ))))
+            .await
+            .unwrap();
+        assert_eq!(
+            xattr::get(dir.path().join("nested"), "user.directory").unwrap(),
+            Some(b"value".to_vec())
+        );
+
+        let request = state
+            .handle_packet(packet_stat(Some(stat_with_xattrs(
+                "nested/file",
+                0o644,
+                5,
+                "",
+                &[("user.file", b"value")],
+            ))))
+            .await
+            .unwrap()
+            .unwrap();
+        state
+            .handle_packet(packet_data(request.id, b"hello"))
+            .await
+            .unwrap();
+        assert_eq!(
+            xattr::get(dir.path().join("nested/file"), "user.file").unwrap(),
+            Some(b"value".to_vec())
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_file_receive_state_filters_privileged_xattrs() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut state = FileReceiveState::new(dir.path().to_path_buf())
+            .await
+            .unwrap();
+        let request = state
+            .handle_packet(packet_stat(Some(stat_with_xattrs(
+                "file",
+                0o644,
+                0,
+                "",
+                &[("user.file", b"value"), ("security.capability", b"blocked")],
+            ))))
+            .await
+            .unwrap()
+            .unwrap();
+        state
+            .handle_packet(packet_data(request.id, &[]))
+            .await
+            .unwrap();
+
+        assert_eq!(
+            xattr::get(dir.path().join("file"), "user.file").unwrap(),
+            Some(b"value".to_vec())
+        );
+        assert_eq!(
+            xattr::get(dir.path().join("file"), "security.capability").unwrap(),
+            None
+        );
     }
 
     #[tokio::test]

--- a/src/grpc/mod.rs
+++ b/src/grpc/mod.rs
@@ -906,20 +906,23 @@ impl StagingGuard {
             .expect("staging guard owns a path before publication")
     }
 
-    async fn cleanup(mut self) -> Result<(), Status> {
-        let staging = self
-            .staging
-            .take()
-            .expect("staging guard owns a path before cleanup");
-        remove_path(&staging).await
+    async fn cleanup(&mut self) -> Result<(), Status> {
+        let Some(staging) = self.staging.clone() else {
+            return Ok(());
+        };
+        remove_path(&staging).await?;
+        self.staging = None;
+        Ok(())
     }
 
     async fn publish(mut self, destination: &Path) -> Result<(), Status> {
         let staging = self
             .staging
-            .take()
+            .as_ref()
             .expect("staging guard owns a path before publication");
-        publish_staging_directory(&staging, destination).await
+        publish_staging_directory(staging, destination).await?;
+        self.staging = None;
+        Ok(())
     }
 }
 
@@ -946,7 +949,7 @@ async fn prepare_file_receive_state(
     destination: &Path,
     limits: FileTransferLimits,
 ) -> Result<(StagingGuard, FileReceiveState), Status> {
-    let staging_guard = StagingGuard::new(destination).await?;
+    let mut staging_guard = StagingGuard::new(destination).await?;
     let staging = staging_guard.path().to_owned();
     match FileReceiveState::with_limits(staging, limits).await {
         Ok(state) => Ok((staging_guard, state)),
@@ -960,9 +963,11 @@ async fn prepare_file_receive_state(
 }
 
 async fn cleanup_staging_guard(guard: &mut Option<StagingGuard>, context: &str) {
-    if let Some(guard) = guard.take() {
+    if let Some(guard) = guard.as_mut() {
         if let Err(error) = guard.cleanup().await {
             warn!("failed to clean up {context}: {error}");
+        } else {
+            *guard = None;
         }
     }
 }
@@ -1903,7 +1908,7 @@ mod tests {
     use super::{
         fs, fsutil, prepare_staging_directory, publish_staging_directory, FileReceiveState,
         FileSendPacketImpl, FileSendPacketServer, FileTransferLimits, SshAgentSource, SshProvider,
-        MAX_FILE_SIZE,
+        StagingGuard, MAX_FILE_SIZE,
     };
 
     fn packet_stat(stat: Option<Stat>) -> Packet {
@@ -1998,6 +2003,17 @@ mod tests {
             std::thread::sleep(Duration::from_millis(10));
         }
         panic!("staging cleanup did not finish after runtime shutdown");
+    }
+
+    #[tokio::test]
+    async fn staging_guard_retains_path_after_cleanup_failure() {
+        let staging = PathBuf::from("invalid\0staging");
+        let mut guard = StagingGuard {
+            staging: Some(staging.clone()),
+        };
+
+        assert!(guard.cleanup().await.is_err());
+        assert_eq!(guard.staging.as_ref(), Some(&staging));
     }
 
     async fn wait_for_staging_siblings(root: &Path, expected: bool) {

--- a/src/grpc/mod.rs
+++ b/src/grpc/mod.rs
@@ -14,6 +14,7 @@ mod filesync;
 mod fsutil;
 /// Internal interfaces to convert types for GRPC communication
 pub(crate) mod io;
+mod patternmatcher;
 /// End-user buildkit registry functions
 pub mod registry;
 mod ssh;
@@ -64,9 +65,13 @@ use hyper_util::rt::TokioExecutor;
 use log::{debug, error, info, trace, warn};
 use rustls::ALL_VERSIONS;
 use serde_derive::Deserialize;
+#[cfg(not(windows))]
 use ssh::SshAgentPacketDecoder;
+#[cfg(not(windows))]
 use tokio::sync::mpsc;
+#[cfg(not(windows))]
 use tokio_util::codec::FramedRead;
+#[cfg(not(windows))]
 use tokio_util::io::{ReaderStream, StreamReader};
 use tonic::server::NamedService;
 use tonic::{Code, Request, Response, Status, Streaming};
@@ -357,9 +362,10 @@ impl FileSendPacketImpl {
         if mode.contains(fsutil::FileMode::Symlink) {
             Self::validate_linkname(&stat.linkname)?;
         } else if !mode.intersects(fsutil::FileMode::Type) && !stat.linkname.is_empty() {
-            return Err(Status::invalid_argument(
-                "regular file has an unexpected symlink target",
-            ));
+            let target = FileSendPacketImpl::validate_path(&stat.linkname)?;
+            if target == path {
+                return Err(Status::invalid_argument("hardlink cannot target itself"));
+            }
         }
 
         Ok((path, mode))
@@ -549,12 +555,14 @@ impl FileReceiveState {
                     Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
                         let permission_parent = current.try_clone()?;
                         let permission_name = name.to_owned();
-                        let mut builder = cap_std::fs::DirBuilder::new();
+                        let builder = cap_std::fs::DirBuilder::new();
                         #[cfg(unix)]
-                        {
+                        let builder = {
+                            let mut builder = builder;
                             use cap_std::fs::DirBuilderExt;
                             builder.mode(0o700);
-                        }
+                            builder
+                        };
                         current.create_dir_with(name, &builder).map_err(|error| {
                             std::io::Error::new(
                                 error.kind(),
@@ -634,23 +642,25 @@ impl FileReceiveState {
 
         if mode.contains(fsutil::FileMode::Symlink) {
             #[cfg(unix)]
-            tokio::task::spawn_blocking({
-                let linkname = stat.linkname.clone();
-                let parent = parent.try_clone().map_err(|error| {
-                    Status::internal(format!("failed to retain export directory: {error}"))
-                })?;
-                let name = name.to_owned();
-                move || parent.symlink_contents(linkname, name)
-            })
-            .await
-            .map_err(|error| Status::internal(format!("filesystem worker failed: {error}")))?
-            .map_err(|error| Status::internal(format!("failed to create symlink: {error}")))?;
+            {
+                tokio::task::spawn_blocking({
+                    let linkname = stat.linkname.clone();
+                    let parent = parent.try_clone().map_err(|error| {
+                        Status::internal(format!("failed to retain export directory: {error}"))
+                    })?;
+                    let name = name.to_owned();
+                    move || parent.symlink_contents(linkname, name)
+                })
+                .await
+                .map_err(|error| Status::internal(format!("filesystem worker failed: {error}")))?
+                .map_err(|error| Status::internal(format!("failed to create symlink: {error}")))?;
+                self.file_count += 1;
+                return Ok(false);
+            }
             #[cfg(not(unix))]
             return Err(Status::unimplemented(
                 "symlink export is only supported on Unix",
             ));
-            self.file_count += 1;
-            return Ok(false);
         }
 
         if mode.contains(fsutil::FileMode::Dir) {
@@ -665,12 +675,14 @@ impl FileReceiveState {
             let directory = tokio::task::spawn_blocking(move || match parent.open_dir(&name) {
                 Ok(directory) => Ok(directory),
                 Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
-                    let mut builder = cap_std::fs::DirBuilder::new();
+                    let builder = cap_std::fs::DirBuilder::new();
                     #[cfg(unix)]
-                    {
+                    let builder = {
+                        let mut builder = builder;
                         use cap_std::fs::DirBuilderExt;
                         builder.mode(0o700);
-                    }
+                        builder
+                    };
                     parent.create_dir_with(&name, &builder)?;
                     parent.open_dir(&name)
                 }
@@ -686,6 +698,39 @@ impl FileReceiveState {
                 path,
                 (stat.mode & 0o777, permission_parent, permission_name),
             );
+            self.file_count += 1;
+            return Ok(false);
+        }
+
+        if !mode.intersects(fsutil::FileMode::Type) && !stat.linkname.is_empty() {
+            let target = FileSendPacketImpl::validate_path(&stat.linkname)?;
+            if !self.declared_paths.contains(&target) {
+                return Err(Status::invalid_argument(format!(
+                    "hardlink target has not been declared: {:?}",
+                    stat.linkname
+                )));
+            }
+            let root = self.root.try_clone().map_err(|error| {
+                Status::internal(format!("failed to retain export directory: {error}"))
+            })?;
+            let parent = parent.try_clone().map_err(|error| {
+                Status::internal(format!("failed to retain export directory: {error}"))
+            })?;
+            let target_metadata = root.symlink_metadata(&target).map_err(|error| {
+                Status::invalid_argument(format!("invalid hardlink target: {error}"))
+            })?;
+            if !target_metadata.file_type().is_file() {
+                return Err(Status::invalid_argument(
+                    "hardlink target is not a regular file",
+                ));
+            }
+            let name = name.to_owned();
+            tokio::task::spawn_blocking(move || root.hard_link(&target, &parent, &name))
+                .await
+                .map_err(|error| Status::internal(format!("filesystem worker failed: {error}")))?
+                .map_err(|error| {
+                    Status::invalid_argument(format!("failed to create hardlink: {error}"))
+                })?;
             self.file_count += 1;
             return Ok(false);
         }
@@ -1740,7 +1785,7 @@ impl Ssh for SshProvider {
     #[cfg(windows)]
     async fn forward_agent(
         &self,
-        request: Request<Streaming<bollard_buildkit_proto::moby::sshforward::v1::BytesMessage>>,
+        _request: Request<Streaming<bollard_buildkit_proto::moby::sshforward::v1::BytesMessage>>,
     ) -> Result<Response<Self::ForwardAgentStream>, Status> {
         unimplemented!();
     }
@@ -2222,6 +2267,38 @@ mod tests {
             .unwrap_err();
 
         assert_eq!(error.code(), tonic::Code::AlreadyExists);
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_file_receive_state_preserves_hardlinks() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut state = FileReceiveState::new(dir.path().to_path_buf())
+            .await
+            .unwrap();
+
+        assert_eq!(
+            state
+                .handle_packet(packet_stat(Some(stat("first", 0o644, 5, ""))))
+                .await
+                .unwrap()
+                .unwrap()
+                .id,
+            0
+        );
+        state.handle_packet(packet_data(0, b"hello")).await.unwrap();
+        state.handle_packet(packet_data(0, &[])).await.unwrap();
+        state
+            .handle_packet(packet_stat(Some(stat("second", 0o644, 0, "first"))))
+            .await
+            .unwrap();
+        state.handle_packet(packet_stat(None)).await.unwrap();
+        state.finalize().await.unwrap();
+
+        let first = std::fs::metadata(dir.path().join("first")).unwrap();
+        let second = std::fs::metadata(dir.path().join("second")).unwrap();
+        assert_eq!(first.ino(), second.ino());
+        assert_eq!(std::fs::read(dir.path().join("second")).unwrap(), b"hello");
     }
 
     #[tokio::test]

--- a/src/grpc/mod.rs
+++ b/src/grpc/mod.rs
@@ -746,11 +746,23 @@ impl FileReceiveState {
             })?;
             drop(directory);
             #[cfg(unix)]
-            apply_xattrs(&permission_parent, &permission_name, &stat.xattrs).map_err(|error| {
-                Status::internal(format!(
-                    "failed to set directory extended attributes: {error}"
-                ))
-            })?;
+            {
+                let xattr_parent = permission_parent.try_clone().map_err(|error| {
+                    Status::internal(format!("failed to retain export directory: {error}"))
+                })?;
+                let xattr_name = permission_name.clone();
+                let xattrs = stat.xattrs.clone();
+                tokio::task::spawn_blocking(move || {
+                    apply_xattrs(&xattr_parent, &xattr_name, &xattrs)
+                })
+                .await
+                .map_err(|error| Status::internal(format!("filesystem worker failed: {error}")))?
+                .map_err(|error| {
+                    Status::internal(format!(
+                        "failed to set directory extended attributes: {error}"
+                    ))
+                })?;
+            }
             self.directories.insert(
                 path,
                 PendingDirectory {
@@ -798,11 +810,19 @@ impl FileReceiveState {
                     Status::invalid_argument(format!("failed to create hardlink: {error}"))
                 })?;
             #[cfg(unix)]
-            apply_xattrs(&xattr_parent, &name, &stat.xattrs).map_err(|error| {
-                Status::internal(format!(
-                    "failed to set hardlink extended attributes: {error}"
-                ))
-            })?;
+            {
+                let xattrs = stat.xattrs.clone();
+                tokio::task::spawn_blocking(move || apply_xattrs(&xattr_parent, &name, &xattrs))
+                    .await
+                    .map_err(|error| {
+                        Status::internal(format!("filesystem worker failed: {error}"))
+                    })?
+                    .map_err(|error| {
+                        Status::internal(format!(
+                            "failed to set hardlink extended attributes: {error}"
+                        ))
+                    })?;
+            }
             self.file_count += 1;
             return Ok(false);
         }

--- a/src/grpc/mod.rs
+++ b/src/grpc/mod.rs
@@ -1121,16 +1121,19 @@ impl FileSendPacket for FileSendPacketImpl {
                             }
                             Ok(None) => {}
                             Err(error) => {
+                                drop(state.take());
                                 cleanup_staging_guard(&mut staging_guard, "failed export").await;
                                 Err::<(), Status>(error)?;
                             }
                         }
                     }
                     Some(Err(error)) => {
+                        drop(state.take());
                         cleanup_staging_guard(&mut staging_guard, "failed export").await;
                         Err::<(), Status>(Status::internal(format!("packet stream error: {error}")))?;
                     }
                     None => {
+                        drop(state.take());
                         cleanup_staging_guard(&mut staging_guard, "incomplete export").await;
                         Err::<(), Status>(Status::failed_precondition(
                             "file packet stream ended before PACKET_FIN",
@@ -1998,12 +2001,12 @@ mod tests {
     }
 
     async fn wait_for_staging_siblings(root: &Path, expected: bool) {
-        tokio::time::timeout(Duration::from_secs(1), async {
+        tokio::time::timeout(Duration::from_secs(5), async {
             loop {
                 if !transfer_sibling_names(root).is_empty() == expected {
                     break;
                 }
-                tokio::task::yield_now().await;
+                tokio::time::sleep(Duration::from_millis(10)).await;
             }
         })
         .await
@@ -2131,7 +2134,7 @@ mod tests {
             fs::read_link(destination.join("link")).await.unwrap(),
             Path::new("message")
         );
-        assert!(transfer_sibling_names(root.path()).is_empty());
+        wait_for_staging_siblings(root.path(), false).await;
         #[cfg(unix)]
         {
             assert_eq!(
@@ -2178,7 +2181,7 @@ mod tests {
         }
 
         assert!(sent_fin);
-        assert!(transfer_sibling_names(root.path()).is_empty());
+        wait_for_staging_siblings(root.path(), false).await;
         server_task.abort();
         let _ = server_task.await;
     }
@@ -2215,7 +2218,7 @@ mod tests {
             fs::read(destination.join("sentinel")).await.unwrap(),
             b"old"
         );
-        assert!(transfer_sibling_names(root.path()).is_empty());
+        wait_for_staging_siblings(root.path(), false).await;
     }
 
     #[tokio::test]

--- a/src/grpc/mod.rs
+++ b/src/grpc/mod.rs
@@ -1038,12 +1038,16 @@ async fn prepare_file_receive_state(
 }
 
 async fn cleanup_staging_guard(guard: &mut Option<StagingGuard>, context: &str) {
-    if let Some(guard) = guard.as_mut() {
-        if let Err(error) = guard.cleanup().await {
-            warn!("failed to clean up {context}: {error}");
-        } else {
-            *guard = None;
-        }
+    let result = if let Some(staging_guard) = guard.as_mut() {
+        staging_guard.cleanup().await
+    } else {
+        return;
+    };
+
+    if let Err(error) = result {
+        warn!("failed to clean up {context}: {error}");
+    } else {
+        *guard = None;
     }
 }
 

--- a/src/grpc/patternmatcher.rs
+++ b/src/grpc/patternmatcher.rs
@@ -1,0 +1,224 @@
+use regex::Regex;
+
+#[derive(Clone, Debug)]
+pub(crate) struct PatternMatcher {
+    patterns: Vec<Pattern>,
+}
+
+#[derive(Clone, Debug)]
+struct Pattern {
+    exclusion: bool,
+    raw: String,
+    regex: Regex,
+}
+
+impl PatternMatcher {
+    pub(crate) fn new(patterns: &[String]) -> Result<Option<Self>, String> {
+        let mut compiled = Vec::new();
+        for value in patterns {
+            let mut value = value.trim().to_owned();
+            if value.is_empty() {
+                continue;
+            }
+            let exclusion = value.starts_with('!');
+            if exclusion {
+                value.remove(0);
+                if value.is_empty() {
+                    return Err("illegal exclusion pattern: \"!\"".to_owned());
+                }
+            }
+            value = clean_pattern(&value)?;
+            if value.is_empty() {
+                return Err("empty pattern after exclusion marker".to_owned());
+            }
+            compiled.push(Pattern {
+                exclusion,
+                regex: compile_pattern(&value)?,
+                raw: value,
+            });
+        }
+        Ok((!compiled.is_empty()).then_some(Self { patterns: compiled }))
+    }
+
+    pub(crate) fn matches_or_parent(&self, path: &str) -> bool {
+        let mut matched = false;
+        for pattern in &self.patterns {
+            if pattern.exclusion != matched {
+                continue;
+            }
+            let mut current = path;
+            let mut match_found = false;
+            loop {
+                if pattern.regex.is_match(current) {
+                    match_found = true;
+                    break;
+                }
+                if current.is_empty() {
+                    break;
+                }
+                current = current.rsplit_once('/').map_or("", |(parent, _)| parent);
+            }
+            if match_found {
+                matched = !pattern.exclusion;
+            }
+        }
+        matched
+    }
+
+    pub(crate) fn patterns(&self) -> impl Iterator<Item = (&str, bool)> {
+        self.patterns
+            .iter()
+            .map(|pattern| (pattern.raw.as_str(), pattern.exclusion))
+    }
+}
+
+pub(crate) fn match_component(pattern: &str, value: &str) -> bool {
+    let pattern = if cfg!(not(windows)) {
+        let mut normalized = String::new();
+        let mut characters = pattern.chars();
+        while let Some(character) = characters.next() {
+            if character == '\\' {
+                if let Some(escaped) = characters.next() {
+                    normalized.push_str(&glob::Pattern::escape(&escaped.to_string()));
+                } else {
+                    normalized.push_str(&glob::Pattern::escape("\\"));
+                }
+            } else {
+                normalized.push(character);
+            }
+        }
+        normalized
+    } else {
+        pattern.to_owned()
+    };
+    glob::Pattern::new(&pattern).is_ok_and(|pattern| pattern.matches(value))
+}
+
+fn clean_pattern(value: &str) -> Result<String, String> {
+    let mut result = Vec::new();
+    let normalized = if cfg!(windows) {
+        value.replace('\\', "/")
+    } else {
+        value.to_owned()
+    };
+    for component in normalized.split('/') {
+        match component {
+            "" | "." => {}
+            ".." => {
+                result.pop();
+            }
+            component => result.push(component),
+        }
+    }
+    Ok(result.join("/"))
+}
+
+fn compile_pattern(pattern: &str) -> Result<Regex, String> {
+    let mut expression = String::from("^");
+    let chars: Vec<char> = pattern.chars().collect();
+    let mut index = 0;
+    while index < chars.len() {
+        match chars[index] {
+            '*' if chars.get(index + 1) == Some(&'*') => {
+                index += 2;
+                if chars.get(index) == Some(&'/') {
+                    index += 1;
+                    expression.push_str("(?:.*/)?");
+                } else {
+                    expression.push_str(".*");
+                }
+            }
+            '*' => {
+                expression.push_str("[^/]*");
+                index += 1;
+            }
+            '?' => {
+                expression.push_str("[^/]");
+                index += 1;
+            }
+            '[' => {
+                let start = index;
+                index += 1;
+                if chars.get(index) == Some(&'!') || chars.get(index) == Some(&'^') {
+                    index += 1;
+                }
+                if chars.get(index) == Some(&']') {
+                    index += 1;
+                }
+                while chars.get(index).is_some_and(|ch| *ch != ']') {
+                    index += 1;
+                }
+                if chars.get(index) != Some(&']') {
+                    return Err(format!("invalid pattern {:?}", pattern));
+                }
+                let mut class: String = chars[start..=index].iter().collect();
+                if class.contains('/') {
+                    return Err(format!("invalid pattern {:?}", pattern));
+                }
+                if class.starts_with("[!") {
+                    class.replace_range(1..2, "^");
+                }
+                expression.push_str(&class);
+                index += 1;
+            }
+            '\\' if chars.get(index + 1).is_some() => {
+                expression.push_str(&regex::escape(&chars[index + 1].to_string()));
+                index += 2;
+            }
+            character => {
+                expression.push_str(&regex::escape(&character.to_string()));
+                index += 1;
+            }
+        }
+    }
+    expression.push('$');
+    Regex::new(&expression).map_err(|error| format!("invalid pattern {:?}: {error}", pattern))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{match_component, PatternMatcher};
+
+    fn matcher(patterns: &[&str]) -> PatternMatcher {
+        PatternMatcher::new(
+            &patterns
+                .iter()
+                .map(|value| (*value).to_owned())
+                .collect::<Vec<_>>(),
+        )
+        .expect("patterns compile")
+        .expect("matcher exists")
+    }
+
+    #[test]
+    fn supports_ancestors_and_doublestar() {
+        let matcher = matcher(&["**/bar/foo"]);
+        assert!(matcher.matches_or_parent("a/bar/foo"));
+        assert!(!matcher.matches_or_parent("a/bar"));
+        assert!(!matcher.matches_or_parent("a/baz"));
+    }
+
+    #[test]
+    fn preserves_ordered_exceptions() {
+        let matcher = matcher(&["foo*", "!foo/bar"]);
+        assert!(matcher.matches_or_parent("foo"));
+        assert!(!matcher.matches_or_parent("foo/bar"));
+        assert!(matcher.matches_or_parent("foo/other"));
+    }
+
+    #[test]
+    fn rejects_bare_exclusion() {
+        assert!(PatternMatcher::new(&["!".to_owned()]).is_err());
+    }
+
+    #[test]
+    fn component_matching_uses_glob_pattern() {
+        assert!(match_component("l*", "link"));
+        assert!(match_component("l[ia]nk", "link"));
+        assert!(!match_component("l[ia]nk", "look"));
+        assert!(!match_component("[", "link"));
+
+        #[cfg(not(windows))]
+        assert!(match_component(r"\*", "*"));
+    }
+}

--- a/src/grpc/patternmatcher.rs
+++ b/src/grpc/patternmatcher.rs
@@ -207,6 +207,7 @@ mod tests {
         let matcher = matcher(&["foo*", "!foo/bar"]);
         assert!(matcher.matches_or_parent("foo"));
         assert!(!matcher.matches_or_parent("foo/bar"));
+        assert!(!matcher.matches_or_parent("foo/bar/x"));
         assert!(matcher.matches_or_parent("foo/other"));
     }
 

--- a/src/grpc/patternmatcher.rs
+++ b/src/grpc/patternmatcher.rs
@@ -73,6 +73,10 @@ impl PatternMatcher {
 }
 
 pub(crate) fn match_component(pattern: &str, value: &str) -> bool {
+    compile_component(pattern).is_some_and(|pattern| pattern.matches(value))
+}
+
+pub(crate) fn compile_component(pattern: &str) -> Option<glob::Pattern> {
     let pattern = if cfg!(not(windows)) {
         let mut normalized = String::new();
         let mut characters = pattern.chars();
@@ -91,7 +95,7 @@ pub(crate) fn match_component(pattern: &str, value: &str) -> bool {
     } else {
         pattern.to_owned()
     };
-    glob::Pattern::new(&pattern).is_ok_and(|pattern| pattern.matches(value))
+    glob::Pattern::new(&pattern).ok()
 }
 
 fn clean_pattern(value: &str) -> Result<String, String> {

--- a/tests/llb_solve_test.rs
+++ b/tests/llb_solve_test.rs
@@ -253,9 +253,32 @@ fn create_application_fixture() -> Result<tempfile::TempDir, Error> {
             source.path().join("mode.txt"),
             std::fs::Permissions::from_mode(0o600),
         )?;
+        xattr::set(
+            source.path().join("nested"),
+            "user.bollard.directory",
+            b"directory metadata",
+        )?;
+        xattr::set(
+            source.path().join("nested/input.txt"),
+            "user.bollard.file",
+            b"file metadata",
+        )?;
         symlink("nested/input.txt", source.path().join("link"))?;
     }
     Ok(source)
+}
+
+#[cfg(unix)]
+fn xattrs_for_path(path: &Path) -> Result<BTreeMap<String, Vec<u8>>, Error> {
+    let mut values = BTreeMap::new();
+    for name in xattr::list(path)? {
+        if let Some(name_str) = name.to_str() {
+            if let Some(value) = xattr::get(path, &name)? {
+                values.insert(name_str.to_owned(), value);
+            }
+        }
+    }
+    Ok(values)
 }
 
 fn relative_entries(root: &Path) -> Result<BTreeSet<PathBuf>, Error> {
@@ -312,6 +335,15 @@ fn assert_tree_equal(expected: &Path, actual: &Path) -> Result<(), Error> {
                 std::fs::read(&expected_path)?,
                 std::fs::read(&actual_path)?,
                 "{relative:?}"
+            );
+        }
+
+        #[cfg(unix)]
+        if !expected_type.is_symlink() {
+            assert_eq!(
+                xattrs_for_path(&expected_path)?,
+                xattrs_for_path(&actual_path)?,
+                "{relative:?} xattrs"
             );
         }
 

--- a/tests/llb_solve_test.rs
+++ b/tests/llb_solve_test.rs
@@ -1,15 +1,20 @@
 #![cfg(feature = "buildkit")]
 
+use bollard::container::LogOutput;
 use bollard::errors::Error;
+use bollard::exec::{CreateExecOptions, StartExecOptions, StartExecResults};
 use bollard::grpc::driver::docker_container::DockerContainerBuilder;
 use bollard::grpc::driver::{
     DefinitionExporter, DefinitionSolveOptionsBuilder, DefinitionSolveRequest, SolveDefinition,
 };
 use bollard::Docker;
 use bollard_buildkit_proto::pb;
+use futures_util::TryStreamExt;
 use prost::Message;
 use sha2::{Digest, Sha256};
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::{Path, PathBuf};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use tokio::runtime::Runtime;
 
 #[macro_use]
@@ -44,19 +49,40 @@ fn minimal_mkfile_definition() -> pb::Definition {
     pb::Definition::decode(bytes.as_slice()).expect("minimal definition is valid protobuf")
 }
 
-fn local_source_fixture_definition() -> pb::Definition {
-    let source_operation = pb::Op {
-        op: Some(pb::op::Op::Source(pb::SourceOp {
-            identifier: String::from("local://context"),
-            attrs: Default::default(),
-        })),
+fn operation_digest(operation: &pb::Op) -> String {
+    format!("sha256:{:x}", Sha256::digest(operation.encode_to_vec()))
+}
+
+fn source_operation(identifier: impl Into<String>) -> (Vec<u8>, String) {
+    let identifier = identifier.into();
+    let attrs = if identifier.starts_with("docker-image://") {
+        BTreeMap::from([(String::from("image.resolvemode"), String::from("default"))])
+    } else {
+        BTreeMap::new()
+    };
+    let operation = pb::Op {
+        op: Some(pb::op::Op::Source(pb::SourceOp { identifier, attrs })),
         ..Default::default()
     };
-    let source_bytes = source_operation.encode_to_vec();
-    let source_digest = format!("sha256:{:x}", Sha256::digest(&source_bytes));
+    let bytes = operation.encode_to_vec();
+    let digest = format!("sha256:{:x}", Sha256::digest(&bytes));
+    (bytes, digest)
+}
+
+fn local_source_copy_definition(name: &str, destination: &str) -> pb::Definition {
+    local_source_copy_definition_with_patterns(name, destination, &[], &[])
+}
+
+fn local_source_copy_definition_with_patterns(
+    name: &str,
+    destination: &str,
+    include_patterns: &[&str],
+    exclude_patterns: &[&str],
+) -> pb::Definition {
+    let (source_bytes, source_digest) = source_operation(format!("local://{name}"));
     let copy = pb::FileActionCopy {
         src: String::from("/"),
-        dest: String::from("/"),
+        dest: String::from(destination),
         owner: None,
         mode: -1,
         follow_symlink: false,
@@ -66,8 +92,14 @@ fn local_source_fixture_definition() -> pb::Definition {
         allow_wildcard: false,
         allow_empty_wildcard: false,
         timestamp: -1,
-        include_patterns: Vec::new(),
-        exclude_patterns: Vec::new(),
+        include_patterns: include_patterns
+            .iter()
+            .map(|value| (*value).to_owned())
+            .collect(),
+        exclude_patterns: exclude_patterns
+            .iter()
+            .map(|value| (*value).to_owned())
+            .collect(),
         always_replace_existing_dest_paths: false,
         mode_str: String::new(),
         required_paths: Vec::new(),
@@ -103,12 +135,276 @@ fn local_source_fixture_definition() -> pb::Definition {
     }
 }
 
+fn local_source_exec_definition(image_identifier: &str, name: &str) -> pb::Definition {
+    let (local_bytes, local_digest) = source_operation(format!("local://{name}"));
+    let (image_bytes, image_digest) = source_operation(image_identifier);
+    let exec_operation = pb::Op {
+        inputs: vec![
+            pb::Input {
+                digest: image_digest,
+                index: 0,
+            },
+            pb::Input {
+                digest: local_digest,
+                index: 0,
+            },
+        ],
+        op: Some(pb::op::Op::Exec(pb::ExecOp {
+            meta: Some(pb::Meta {
+                args: vec![
+                    String::from("/bin/sh"),
+                    String::from("-c"),
+                    String::from(
+                        "cat /app/nested/input.txt > /result.txt; date +%s > /cache-proof",
+                    ),
+                ],
+                cwd: String::from("/"),
+                ..Default::default()
+            }),
+            mounts: vec![
+                pb::Mount {
+                    input: 0,
+                    dest: String::from("/"),
+                    output: 0,
+                    mount_type: pb::MountType::Bind as i32,
+                    ..Default::default()
+                },
+                pb::Mount {
+                    input: 1,
+                    dest: String::from("/app"),
+                    output: -1,
+                    readonly: true,
+                    mount_type: pb::MountType::Bind as i32,
+                    ..Default::default()
+                },
+            ],
+            ..Default::default()
+        })),
+        ..Default::default()
+    };
+    let wrapper_operation = pb::Op {
+        inputs: vec![pb::Input {
+            digest: operation_digest(&exec_operation),
+            index: 0,
+        }],
+        ..Default::default()
+    };
+
+    pb::Definition {
+        def: vec![
+            local_bytes,
+            image_bytes,
+            exec_operation.encode_to_vec(),
+            wrapper_operation.encode_to_vec(),
+        ],
+        metadata: Default::default(),
+        source: None,
+    }
+}
+
+fn alpine_image_reference() -> (String, Option<String>) {
+    if std::env::var_os("DISABLE_REGISTRY").is_some() {
+        return (String::from("docker.io/library/alpine:latest"), None);
+    }
+
+    let host = std::env::var("REGISTRY_HTTP_ADDR")
+        .unwrap_or_else(|_| String::from("localhost:5000"))
+        .trim_end_matches('/')
+        .to_string();
+    (format!("{host}/alpine:latest"), Some(host))
+}
+
+fn local_source_options(
+    source_name: &str,
+    source_path: &Path,
+    image_registry: Option<&str>,
+) -> Result<bollard::grpc::driver::DefinitionSolveOptions, Error> {
+    let mut builder = DefinitionSolveOptionsBuilder::new()
+        .local_mount(source_name, source_path)
+        .map_err(|error| Error::IOError {
+            err: std::io::Error::other(format!("local mount setup failed: {error}")),
+        })?;
+    if let Some(host) = image_registry {
+        builder = builder.credential(host, integration_test_registry_credentials());
+    }
+    Ok(builder.build())
+}
+
+fn create_application_fixture() -> Result<tempfile::TempDir, Error> {
+    let source = tempfile::tempdir()?;
+    std::fs::create_dir(source.path().join("nested"))?;
+    std::fs::write(source.path().join("nested/input.txt"), b"local source")?;
+    std::fs::write(source.path().join("empty.txt"), [])?;
+    std::fs::write(source.path().join("mode.txt"), b"mode")?;
+    std::fs::write(source.path().join("café.txt"), b"unicode")?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::{symlink, PermissionsExt};
+
+        std::fs::set_permissions(
+            source.path().join("nested"),
+            std::fs::Permissions::from_mode(0o750),
+        )?;
+        std::fs::set_permissions(
+            source.path().join("nested/input.txt"),
+            std::fs::Permissions::from_mode(0o640),
+        )?;
+        std::fs::set_permissions(
+            source.path().join("mode.txt"),
+            std::fs::Permissions::from_mode(0o600),
+        )?;
+        symlink("nested/input.txt", source.path().join("link"))?;
+    }
+    Ok(source)
+}
+
+fn relative_entries(root: &Path) -> Result<BTreeSet<PathBuf>, Error> {
+    fn visit(root: &Path, path: &Path, entries: &mut BTreeSet<PathBuf>) -> Result<(), Error> {
+        for item in std::fs::read_dir(path)? {
+            let item = item?;
+            let path = item.path();
+            let relative = path.strip_prefix(root).map_err(|error| Error::IOError {
+                err: std::io::Error::other(format!("failed to relativize fixture path: {error}")),
+            })?;
+            entries.insert(relative.to_path_buf());
+            if item.file_type()?.is_dir() {
+                visit(root, &path, entries)?;
+            }
+        }
+        Ok(())
+    }
+
+    let mut entries = BTreeSet::new();
+    visit(root, root, &mut entries)?;
+    Ok(entries)
+}
+
+fn assert_tree_equal(expected: &Path, actual: &Path) -> Result<(), Error> {
+    let expected_entries = relative_entries(expected)?;
+    let actual_entries = relative_entries(actual)?;
+    assert_eq!(expected_entries, actual_entries);
+
+    for relative in expected_entries {
+        let expected_path = expected.join(&relative);
+        let actual_path = actual.join(&relative);
+        let expected_type = std::fs::symlink_metadata(&expected_path)?.file_type();
+        let actual_type = std::fs::symlink_metadata(&actual_path)?.file_type();
+        assert_eq!(expected_type.is_dir(), actual_type.is_dir(), "{relative:?}");
+        assert_eq!(
+            expected_type.is_file(),
+            actual_type.is_file(),
+            "{relative:?}"
+        );
+        assert_eq!(
+            expected_type.is_symlink(),
+            actual_type.is_symlink(),
+            "{relative:?}"
+        );
+
+        if expected_type.is_symlink() {
+            assert_eq!(
+                std::fs::read_link(&expected_path)?,
+                std::fs::read_link(&actual_path)?,
+                "{relative:?}"
+            );
+        } else if expected_type.is_file() {
+            assert_eq!(
+                std::fs::read(&expected_path)?,
+                std::fs::read(&actual_path)?,
+                "{relative:?}"
+            );
+        }
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+
+            assert_eq!(
+                std::fs::symlink_metadata(expected_path)?
+                    .permissions()
+                    .mode()
+                    & 0o777,
+                std::fs::symlink_metadata(actual_path)?.permissions().mode() & 0o777,
+                "{relative:?} mode"
+            );
+        }
+    }
+    Ok(())
+}
+
 fn unique_builder_name() -> String {
     let suffix = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .expect("system clock is before the Unix epoch")
         .as_nanos();
-    format!("bollard_llb_gate_e_{suffix}")
+    format!("bollard_llb_gate_f_{suffix}")
+}
+
+async fn capture_builder_identity(docker: &Docker, driver_name: &str) -> Result<(), Error> {
+    let container = docker.inspect_container(driver_name, None).await?;
+    let image_ref = container
+        .config
+        .as_ref()
+        .and_then(|config| config.image.clone())
+        .ok_or_else(|| Error::IOError {
+            err: std::io::Error::other("BuildKit container has no configured image"),
+        })?;
+    let container_id = container.id.clone().ok_or_else(|| Error::IOError {
+        err: std::io::Error::other("BuildKit container has no resolved image ID"),
+    })?;
+    let image_id = container.image.clone().ok_or_else(|| Error::IOError {
+        err: std::io::Error::other("BuildKit container has no image ID"),
+    })?;
+    let image = docker.inspect_image(&image_ref).await?;
+    let repo_digests = image.repo_digests.unwrap_or_default();
+
+    let exec = docker
+        .create_exec(
+            driver_name,
+            CreateExecOptions {
+                attach_stdout: Some(true),
+                cmd: Some(vec![String::from("buildkitd"), String::from("--version")]),
+                ..Default::default()
+            },
+        )
+        .await?;
+    let results = docker
+        .start_exec(&exec.id, None::<StartExecOptions>)
+        .await?;
+    let version_output = match results {
+        StartExecResults::Attached { output, .. } => {
+            let output: Vec<LogOutput> = output.try_collect().await?;
+            output
+                .into_iter()
+                .filter_map(|entry| match entry {
+                    LogOutput::StdOut { message } => Some(message),
+                    LogOutput::StdErr { .. } => None,
+                    _ => None,
+                })
+                .flatten()
+                .collect::<Vec<_>>()
+        }
+        StartExecResults::Detached => Vec::new(),
+    };
+    let version_output = String::from_utf8_lossy(&version_output).trim().to_string();
+    let engine_version = docker.version().await?;
+    let daemon_info = docker.info().await?;
+
+    assert!(
+        !version_output.is_empty(),
+        "buildkitd --version returned no output"
+    );
+    assert!(
+        !repo_digests.is_empty(),
+        "BuildKit image has no repository digest"
+    );
+    println!(
+        "phase-f identity: image_ref={image_ref} image_id={image_id} container_id={container_id} image_digests={repo_digests:?} buildkitd_version={version_output:?} docker_version={:?} docker_api_version={:?} docker_daemon_id={:?}",
+        engine_version.version,
+        engine_version.api_version,
+        daemon_info.id
+    );
+    Ok(())
 }
 
 async fn direct_definition_solve_test(docker: Docker) -> Result<(), Error> {
@@ -154,15 +450,220 @@ async fn direct_definition_solve_test(docker: Docker) -> Result<(), Error> {
     result
 }
 
-async fn local_source_filesync_test(docker: Docker) -> Result<(), Error> {
-    let name = format!("bollard_llb_gate_f_{}", unique_builder_name());
+async fn local_source_application_mvp_test(docker: Docker) -> Result<(), Error> {
+    let name = unique_builder_name();
     let volume_name = format!("{name}_state");
-    let source = tempfile::tempdir()?;
+    let source = create_application_fixture()?;
+    let direct_output = tempfile::tempdir()?;
+    let app_output = tempfile::tempdir()?;
+    let exec_output = tempfile::tempdir()?;
+    let (image_ref, image_registry) = alpine_image_reference();
+
+    let result = async {
+        let mut builder = DockerContainerBuilder::new(&docker);
+        builder.name(&name);
+        let driver = builder.bootstrap().await.map_err(|error| Error::IOError {
+            err: std::io::Error::other(format!("BuildKit bootstrap failed: {error}")),
+        })?;
+        capture_builder_identity(&docker, driver.name()).await?;
+
+        let request = DefinitionSolveRequest::new(
+            local_source_copy_definition("context", "/"),
+            DefinitionExporter::Local(direct_output.path().to_path_buf()),
+        )
+        .with_options(local_source_options("context", source.path(), None)?);
+        SolveDefinition::solve_definition(&driver, request)
+            .await
+            .map_err(|error| Error::IOError {
+                err: std::io::Error::other(format!("local source export failed: {error}")),
+            })?;
+        assert_tree_equal(source.path(), direct_output.path())?;
+
+        let request = DefinitionSolveRequest::new(
+            local_source_copy_definition("context", "/app"),
+            DefinitionExporter::Local(app_output.path().to_path_buf()),
+        )
+        .with_options(local_source_options("context", source.path(), None)?);
+        SolveDefinition::solve_definition(&driver, request)
+            .await
+            .map_err(|error| Error::IOError {
+                err: std::io::Error::other(format!("local source copy failed: {error}")),
+            })?;
+        assert_tree_equal(source.path(), &app_output.path().join("app"))?;
+
+        let request = DefinitionSolveRequest::new(
+            local_source_exec_definition(&format!("docker-image://{image_ref}"), "context"),
+            DefinitionExporter::Local(exec_output.path().to_path_buf()),
+        )
+        .with_options(local_source_options(
+            "context",
+            source.path(),
+            image_registry.as_deref(),
+        )?);
+        SolveDefinition::solve_definition(&driver, request)
+            .await
+            .map_err(|error| Error::IOError {
+                err: std::io::Error::other(format!("local source exec failed: {error}")),
+            })?;
+        assert_eq!(
+            std::fs::read(exec_output.path().join("result.txt"))?,
+            b"local source"
+        );
+        assert!(
+            !std::fs::read_to_string(exec_output.path().join("cache-proof"))?
+                .trim()
+                .is_empty()
+        );
+
+        let container = docker.inspect_container(driver.name(), None).await?;
+        assert_eq!(container.name.as_deref(), Some(format!("/{name}").as_str()));
+        assert_eq!(docker.inspect_volume(&volume_name).await?.name, volume_name);
+        Ok::<(), Error>(())
+    }
+    .await;
+
+    let _ = driver_cleanup(&docker, &name, &volume_name).await;
+    result
+}
+
+async fn local_source_filter_and_metadata_test(docker: Docker) -> Result<(), Error> {
+    let name = unique_builder_name();
+    let volume_name = format!("{name}_state");
+    let source = create_application_fixture()?;
     let output = tempfile::tempdir()?;
-    std::fs::create_dir(source.path().join("nested"))?;
-    std::fs::write(source.path().join("nested/input.txt"), b"local source")?;
-    #[cfg(unix)]
-    std::os::unix::fs::symlink("nested/input.txt", source.path().join("link"))?;
+    let encoded_output = tempfile::tempdir()?;
+
+    let result = async {
+        let mut builder = DockerContainerBuilder::new(&docker);
+        builder.name(&name);
+        let driver = builder.bootstrap().await.map_err(|error| Error::IOError {
+            err: std::io::Error::other(format!("BuildKit bootstrap failed: {error}")),
+        })?;
+        let request = DefinitionSolveRequest::new(
+            local_source_copy_definition_with_patterns(
+                "context",
+                "/",
+                &["**/*.txt"],
+                &["nested/input.txt"],
+            ),
+            DefinitionExporter::Local(output.path().to_path_buf()),
+        )
+        .with_options(local_source_options("context", source.path(), None)?);
+        SolveDefinition::solve_definition(&driver, request)
+            .await
+            .map_err(|error| Error::IOError {
+                err: std::io::Error::other(format!("filtered local source solve failed: {error}")),
+            })?;
+
+        let entries = relative_entries(output.path())?;
+        let expected = BTreeSet::from([
+            PathBuf::from("café.txt"),
+            PathBuf::from("empty.txt"),
+            PathBuf::from("mode.txt"),
+        ]);
+        assert_eq!(entries, expected);
+        assert_eq!(std::fs::read(output.path().join("café.txt"))?, b"unicode");
+
+        let request = DefinitionSolveRequest::new(
+            local_source_copy_definition_with_patterns("context", "/", &["café.txt"], &[]),
+            DefinitionExporter::Local(encoded_output.path().to_path_buf()),
+        )
+        .with_options(local_source_options("context", source.path(), None)?);
+        SolveDefinition::solve_definition(&driver, request)
+            .await
+            .map_err(|error| Error::IOError {
+                err: std::io::Error::other(format!("encoded local source solve failed: {error}")),
+            })?;
+        assert_eq!(
+            relative_entries(encoded_output.path())?,
+            BTreeSet::from([PathBuf::from("café.txt")])
+        );
+        Ok::<(), Error>(())
+    }
+    .await;
+
+    let _ = driver_cleanup(&docker, &name, &volume_name).await;
+    result
+}
+
+async fn local_source_cache_repeatability_test(docker: Docker) -> Result<(), Error> {
+    let name = unique_builder_name();
+    let volume_name = format!("{name}_state");
+    let source = create_application_fixture()?;
+    let first_output = tempfile::tempdir()?;
+    let second_output = tempfile::tempdir()?;
+    let (image_ref, image_registry) = alpine_image_reference();
+
+    let result = async {
+        let mut builder = DockerContainerBuilder::new(&docker);
+        builder.name(&name);
+        let driver = builder.bootstrap().await.map_err(|error| Error::IOError {
+            err: std::io::Error::other(format!("BuildKit bootstrap failed: {error}")),
+        })?;
+        let first_id = docker
+            .inspect_container(driver.name(), None)
+            .await?
+            .id
+            .ok_or_else(|| Error::IOError {
+                err: std::io::Error::other("first BuildKit container has no ID"),
+            })?;
+        let definition =
+            local_source_exec_definition(&format!("docker-image://{image_ref}"), "context");
+
+        for (output, label) in [(&first_output, "first"), (&second_output, "second")] {
+            let request = DefinitionSolveRequest::new(
+                definition.clone(),
+                DefinitionExporter::Local(output.path().to_path_buf()),
+            )
+            .with_options(local_source_options(
+                "context",
+                source.path(),
+                image_registry.as_deref(),
+            )?);
+            SolveDefinition::solve_definition(&driver, request)
+                .await
+                .map_err(|error| Error::IOError {
+                    err: std::io::Error::other(format!("{label} cached solve failed: {error}")),
+                })?;
+            assert_eq!(
+                std::fs::read(output.path().join("result.txt"))?,
+                b"local source"
+            );
+            if label == "first" {
+                tokio::time::sleep(Duration::from_secs(2)).await;
+            }
+        }
+
+        assert_eq!(
+            std::fs::read_to_string(first_output.path().join("cache-proof"))?,
+            std::fs::read_to_string(second_output.path().join("cache-proof"))?
+        );
+        let second_id = docker
+            .inspect_container(driver.name(), None)
+            .await?
+            .id
+            .ok_or_else(|| Error::IOError {
+                err: std::io::Error::other("second BuildKit container has no ID"),
+            })?;
+        assert_eq!(first_id, second_id);
+        assert_eq!(docker.inspect_volume(&volume_name).await?.name, volume_name);
+        Ok::<(), Error>(())
+    }
+    .await;
+
+    let _ = driver_cleanup(&docker, &name, &volume_name).await;
+    result
+}
+
+async fn local_source_unknown_name_test(docker: Docker) -> Result<(), Error> {
+    let name = unique_builder_name();
+    let volume_name = format!("{name}_state");
+    let context = create_application_fixture()?;
+    let other = create_application_fixture()?;
+    std::fs::write(context.path().join("context-only.txt"), b"context")?;
+    std::fs::write(other.path().join("other-only.txt"), b"other")?;
+    let failed_output = tempfile::tempdir()?;
+    let successful_output = tempfile::tempdir()?;
 
     let result = async {
         let mut builder = DockerContainerBuilder::new(&docker);
@@ -171,31 +672,43 @@ async fn local_source_filesync_test(docker: Docker) -> Result<(), Error> {
             err: std::io::Error::other(format!("BuildKit bootstrap failed: {error}")),
         })?;
         let options = DefinitionSolveOptionsBuilder::new()
-            .local_mount("context", source.path())
+            .local_mount("context", context.path())
             .map_err(|error| Error::IOError {
-                err: std::io::Error::other(format!("local mount setup failed: {error}")),
+                err: std::io::Error::other(format!("context mount setup failed: {error}")),
+            })?
+            .local_mount("other", other.path())
+            .map_err(|error| Error::IOError {
+                err: std::io::Error::other(format!("other mount setup failed: {error}")),
             })?
             .build();
         let request = DefinitionSolveRequest::new(
-            local_source_fixture_definition(),
-            DefinitionExporter::Local(output.path().to_path_buf()),
+            local_source_copy_definition("missing", "/"),
+            DefinitionExporter::Local(failed_output.path().to_path_buf()),
+        )
+        .with_options(options.clone());
+        let error = SolveDefinition::solve_definition(&driver, request)
+            .await
+            .expect_err("unknown local source should fail");
+        match error {
+            bollard::grpc::error::GrpcError::TonicStatus { err } => {
+                assert_eq!(err.code(), tonic::Code::NotFound)
+            }
+            error => panic!("unknown local source returned an unexpected error: {error:?}"),
+        }
+        assert!(relative_entries(failed_output.path())?.is_empty());
+
+        let request = DefinitionSolveRequest::new(
+            local_source_copy_definition("context", "/"),
+            DefinitionExporter::Local(successful_output.path().to_path_buf()),
         )
         .with_options(options);
         SolveDefinition::solve_definition(&driver, request)
             .await
             .map_err(|error| Error::IOError {
-                err: std::io::Error::other(format!("local source solve failed: {error}")),
+                err: std::io::Error::other(format!("registered local source failed: {error}")),
             })?;
-        assert_eq!(
-            std::fs::read(output.path().join("nested/input.txt"))?,
-            b"local source"
-        );
-        assert!(output.path().join("nested").is_dir());
-        #[cfg(unix)]
-        assert_eq!(
-            std::fs::read_link(output.path().join("link"))?,
-            std::path::Path::new("nested/input.txt")
-        );
+        assert_tree_equal(context.path(), successful_output.path())?;
+        assert!(!successful_output.path().join("other-only.txt").exists());
         Ok::<(), Error>(())
     }
     .await;
@@ -231,7 +744,25 @@ fn integration_test_direct_definition_solve() {
 #[test]
 #[cfg(feature = "buildkit_providerless")]
 fn integration_test_local_source_filesync() {
-    connect_to_docker_and_run!(local_source_filesync_test);
+    connect_to_docker_and_run!(local_source_application_mvp_test);
+}
+
+#[test]
+#[cfg(feature = "buildkit_providerless")]
+fn integration_test_local_source_cache_repeatability() {
+    connect_to_docker_and_run!(local_source_cache_repeatability_test);
+}
+
+#[test]
+#[cfg(feature = "buildkit_providerless")]
+fn integration_test_local_source_filter_and_metadata() {
+    connect_to_docker_and_run!(local_source_filter_and_metadata_test);
+}
+
+#[test]
+#[cfg(feature = "buildkit_providerless")]
+fn integration_test_unknown_local_source_isolated() {
+    connect_to_docker_and_run!(local_source_unknown_name_test);
 }
 
 #[test]

--- a/tests/llb_solve_test.rs
+++ b/tests/llb_solve_test.rs
@@ -2,10 +2,13 @@
 
 use bollard::errors::Error;
 use bollard::grpc::driver::docker_container::DockerContainerBuilder;
-use bollard::grpc::driver::{DefinitionExporter, DefinitionSolveRequest, SolveDefinition};
+use bollard::grpc::driver::{
+    DefinitionExporter, DefinitionSolveOptionsBuilder, DefinitionSolveRequest, SolveDefinition,
+};
 use bollard::Docker;
 use bollard_buildkit_proto::pb;
 use prost::Message;
+use sha2::{Digest, Sha256};
 use std::time::{SystemTime, UNIX_EPOCH};
 use tokio::runtime::Runtime;
 
@@ -39,6 +42,65 @@ fn minimal_mkfile_definition() -> pb::Definition {
         })
         .collect::<Vec<_>>();
     pb::Definition::decode(bytes.as_slice()).expect("minimal definition is valid protobuf")
+}
+
+fn local_source_fixture_definition() -> pb::Definition {
+    let source_operation = pb::Op {
+        op: Some(pb::op::Op::Source(pb::SourceOp {
+            identifier: String::from("local://context"),
+            attrs: Default::default(),
+        })),
+        ..Default::default()
+    };
+    let source_bytes = source_operation.encode_to_vec();
+    let source_digest = format!("sha256:{:x}", Sha256::digest(&source_bytes));
+    let copy = pb::FileActionCopy {
+        src: String::from("/"),
+        dest: String::from("/"),
+        owner: None,
+        mode: -1,
+        follow_symlink: false,
+        dir_copy_contents: true,
+        attempt_unpack_docker_compatibility: false,
+        create_dest_path: true,
+        allow_wildcard: false,
+        allow_empty_wildcard: false,
+        timestamp: -1,
+        include_patterns: Vec::new(),
+        exclude_patterns: Vec::new(),
+        always_replace_existing_dest_paths: false,
+        mode_str: String::new(),
+        required_paths: Vec::new(),
+    };
+    let root_operation = pb::Op {
+        inputs: vec![pb::Input {
+            digest: source_digest,
+            index: 0,
+        }],
+        op: Some(pb::op::Op::File(pb::FileOp {
+            actions: vec![pb::FileAction {
+                input: -1,
+                secondary_input: 0,
+                output: 0,
+                action: Some(pb::file_action::Action::Copy(copy)),
+            }],
+        })),
+        ..Default::default()
+    };
+    let root_bytes = root_operation.encode_to_vec();
+    let wrapper_operation = pb::Op {
+        inputs: vec![pb::Input {
+            digest: format!("sha256:{:x}", Sha256::digest(&root_bytes)),
+            index: 0,
+        }],
+        ..Default::default()
+    };
+
+    pb::Definition {
+        def: vec![source_bytes, root_bytes, wrapper_operation.encode_to_vec()],
+        metadata: Default::default(),
+        source: None,
+    }
 }
 
 fn unique_builder_name() -> String {
@@ -92,6 +154,56 @@ async fn direct_definition_solve_test(docker: Docker) -> Result<(), Error> {
     result
 }
 
+async fn local_source_filesync_test(docker: Docker) -> Result<(), Error> {
+    let name = format!("bollard_llb_gate_f_{}", unique_builder_name());
+    let volume_name = format!("{name}_state");
+    let source = tempfile::tempdir()?;
+    let output = tempfile::tempdir()?;
+    std::fs::create_dir(source.path().join("nested"))?;
+    std::fs::write(source.path().join("nested/input.txt"), b"local source")?;
+    #[cfg(unix)]
+    std::os::unix::fs::symlink("nested/input.txt", source.path().join("link"))?;
+
+    let result = async {
+        let mut builder = DockerContainerBuilder::new(&docker);
+        builder.name(&name);
+        let driver = builder.bootstrap().await.map_err(|error| Error::IOError {
+            err: std::io::Error::other(format!("BuildKit bootstrap failed: {error}")),
+        })?;
+        let options = DefinitionSolveOptionsBuilder::new()
+            .local_mount("context", source.path())
+            .map_err(|error| Error::IOError {
+                err: std::io::Error::other(format!("local mount setup failed: {error}")),
+            })?
+            .build();
+        let request = DefinitionSolveRequest::new(
+            local_source_fixture_definition(),
+            DefinitionExporter::Local(output.path().to_path_buf()),
+        )
+        .with_options(options);
+        SolveDefinition::solve_definition(&driver, request)
+            .await
+            .map_err(|error| Error::IOError {
+                err: std::io::Error::other(format!("local source solve failed: {error}")),
+            })?;
+        assert_eq!(
+            std::fs::read(output.path().join("nested/input.txt"))?,
+            b"local source"
+        );
+        assert!(output.path().join("nested").is_dir());
+        #[cfg(unix)]
+        assert_eq!(
+            std::fs::read_link(output.path().join("link"))?,
+            std::path::Path::new("nested/input.txt")
+        );
+        Ok::<(), Error>(())
+    }
+    .await;
+
+    let _ = driver_cleanup(&docker, &name, &volume_name).await;
+    result
+}
+
 async fn driver_cleanup(docker: &Docker, name: &str, volume_name: &str) -> Result<(), Error> {
     use bollard::query_parameters::{RemoveContainerOptionsBuilder, RemoveVolumeOptionsBuilder};
 
@@ -114,6 +226,12 @@ async fn driver_cleanup(docker: &Docker, name: &str, volume_name: &str) -> Resul
 #[cfg(feature = "buildkit_providerless")]
 fn integration_test_direct_definition_solve() {
     connect_to_docker_and_run!(direct_definition_solve_test);
+}
+
+#[test]
+#[cfg(feature = "buildkit_providerless")]
+fn integration_test_local_source_filesync() {
+    connect_to_docker_and_run!(local_source_filesync_test);
 }
 
 #[test]

--- a/tests/llb_solve_test.rs
+++ b/tests/llb_solve_test.rs
@@ -313,8 +313,8 @@ fn assert_tree_equal(expected: &Path, actual: &Path) -> Result<(), Error> {
     assert_eq!(expected_entries, actual_entries);
 
     for relative in &expected_entries {
-        let expected_path = expected.join(&relative);
-        let actual_path = actual.join(&relative);
+        let expected_path = expected.join(relative);
+        let actual_path = actual.join(relative);
         let expected_type = std::fs::symlink_metadata(&expected_path)?.file_type();
         let actual_type = std::fs::symlink_metadata(&actual_path)?.file_type();
         assert_eq!(expected_type.is_dir(), actual_type.is_dir(), "{relative:?}");

--- a/tests/llb_solve_test.rs
+++ b/tests/llb_solve_test.rs
@@ -234,6 +234,11 @@ fn create_application_fixture() -> Result<tempfile::TempDir, Error> {
     let source = tempfile::tempdir()?;
     std::fs::create_dir(source.path().join("nested"))?;
     std::fs::write(source.path().join("nested/input.txt"), b"local source")?;
+    #[cfg(unix)]
+    std::fs::hard_link(
+        source.path().join("nested/input.txt"),
+        source.path().join("nested/input.hard"),
+    )?;
     std::fs::write(source.path().join("empty.txt"), [])?;
     std::fs::write(source.path().join("mode.txt"), b"mode")?;
     std::fs::write(source.path().join("café.txt"), b"unicode")?;
@@ -307,7 +312,7 @@ fn assert_tree_equal(expected: &Path, actual: &Path) -> Result<(), Error> {
     let actual_entries = relative_entries(actual)?;
     assert_eq!(expected_entries, actual_entries);
 
-    for relative in expected_entries {
+    for relative in &expected_entries {
         let expected_path = expected.join(&relative);
         let actual_path = actual.join(&relative);
         let expected_type = std::fs::symlink_metadata(&expected_path)?.file_type();
@@ -360,6 +365,38 @@ fn assert_tree_equal(expected: &Path, actual: &Path) -> Result<(), Error> {
                 "{relative:?} mode"
             );
         }
+    }
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::MetadataExt;
+
+        fn hardlink_groups(
+            root: &Path,
+            entries: &BTreeSet<PathBuf>,
+        ) -> Result<BTreeSet<BTreeSet<PathBuf>>, Error> {
+            let mut groups = BTreeMap::<(u64, u64), BTreeSet<PathBuf>>::new();
+            for relative in entries {
+                let path = root.join(relative);
+                let metadata = std::fs::symlink_metadata(&path)?;
+                if metadata.file_type().is_file() && metadata.nlink() > 1 {
+                    groups
+                        .entry((metadata.dev(), metadata.ino()))
+                        .or_default()
+                        .insert(relative.clone());
+                }
+            }
+            Ok(groups
+                .into_values()
+                .filter(|paths| paths.len() > 1)
+                .collect::<BTreeSet<_>>())
+        }
+
+        assert_eq!(
+            hardlink_groups(expected, &expected_entries)?,
+            hardlink_groups(actual, &actual_entries)?,
+            "hardlink topology"
+        );
     }
     Ok(())
 }


### PR DESCRIPTION
## Summary

Transplant Phase F local-source FileSync onto the corrected registry-backed Phase E line.

This is intentionally stacked on `feat/llb-gate-E-registry` so the review diff contains only Phase F.

## Included

- Capability-backed `local_mount` support for direct-definition solves.
- FileSync `DiffCopy` protocol implementation with bounded scanning and workers.
- Include/exclude filters, followpaths, hardlinks, xattrs, cancellation, and traversal limits.
- FileSend staging/publication cleanup hardening and Windows coverage.
- Live local-source and export integration tests.
- Appveyor providerless BuildKit library coverage.
- Registry-backed `bollard-buildkit-proto 0.9.0` dependency and regenerated lockfile.

## Transplant notes

- Historical source range: `b774d46..4d47368`.
- E's redacted solve diagnostics, runtime-independent teardown, named-agent support, transfer limits, and staging corrections are retained.
- Historical duplicate driver redaction was not replayed; only its FileSync scanner-cancellation change was incorporated.
- Historical path-pinned lockfile state was discarded.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --features buildkit,chrono --all-targets -- -D warnings`
- `cargo check --features buildkit,chrono`
- `cargo test --features buildkit_providerless,chrono --lib` (216 passed)
- `cargo test --features buildkit,chrono --test llb_solve_test -- --test-threads 1` (6 passed)
- `cargo test --features buildkit,chrono --test export_test -- --test-threads 1` (5 passed)
- `cargo xtask buildkit check`
- xtask and proto tests
- `cargo semver-checks check-release --all-features`
- `cargo package --locked --allow-dirty`

The focused integration tests were run with the local registry on `127.0.0.1:5000`.
