### PR TITLE
fix: don't discard every native cert on a partial trust-store load error

### DIFF
--- a/src/docker.rs
+++ b/src/docker.rs
@@ -559,17 +559,22 @@ impl Docker {
         #[cfg(not(any(feature = "test_ssl", feature = "webpki")))]
         let native_certs = rustls_native_certs::load_native_certs();
 
+        // A partial failure loading the OS trust store (one unreadable
+        // entry among many -- not uncommon on some platforms) must not
+        // discard every certificate that DID load, nor prevent the
+        // explicit `ssl_ca` added just below from being trusted. Add
+        // whatever loaded successfully and proceed, the same way `curl`
+        // and the `docker` CLI itself tolerate the same condition.
+        // Previously any non-empty `native_certs.errors` was treated as
+        // fatal here, returning `LoadNativeCertsErrors` and discarding the
+        // whole native trust store -- including a case where the only
+        // consequence should have been "one fewer CA available", since the
+        // caller's own `ssl_ca` is unaffected either way.
         #[cfg(not(any(feature = "test_ssl", feature = "webpki")))]
-        if native_certs.errors.is_empty() {
-            for cert in native_certs.certs {
-                root_store
-                    .add(cert)
-                    .map_err(|err| NoNativeCertsError { err })?
-            }
-        } else {
-            return Err(LoadNativeCertsErrors {
-                errors: native_certs.errors,
-            });
+        for cert in native_certs.certs {
+            root_store
+                .add(cert)
+                .map_err(|err| NoNativeCertsError { err })?
         }
         #[cfg(any(feature = "test_ssl", feature = "webpki"))]
         root_store.extend(webpki_roots::TLS_SERVER_ROOTS.iter().cloned());

--- a/src/docker.rs
+++ b/src/docker.rs
@@ -30,7 +30,7 @@ use hyper_util::client::legacy::connect::HttpConnector;
 use hyper_util::{client::legacy::Client, rt::TokioExecutor};
 #[cfg(all(feature = "pipe", unix))]
 use hyperlocal::UnixConnector;
-use log::{debug, trace};
+use log::{debug, trace, warn};
 #[cfg(feature = "ssl_providerless")]
 use rustls::{crypto::CryptoProvider, sign::CertifiedKey};
 #[cfg(feature = "ssl_providerless")]
@@ -570,6 +570,15 @@ impl Docker {
         // whole native trust store -- including a case where the only
         // consequence should have been "one fewer CA available", since the
         // caller's own `ssl_ca` is unaffected either way.
+        #[cfg(not(any(feature = "test_ssl", feature = "webpki")))]
+        if !native_certs.errors.is_empty() {
+            warn!(
+                "ignoring {} error(s) loading native certs: {:?}",
+                native_certs.errors.len(),
+                native_certs.errors
+            );
+        }
+
         #[cfg(not(any(feature = "test_ssl", feature = "webpki")))]
         for cert in native_certs.certs {
             root_store

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -43,7 +43,14 @@ pub enum Error {
         #[from]
         err: rustls::Error,
     },
-    /// Error emitted when the client is unable to load native certs for SSL
+    /// Error emitted when the client is unable to load native certs for SSL.
+    ///
+    /// No longer constructed by this crate as of the `connect_with_ssl` fix
+    /// for a partial trust-store load (a single unreadable entry used to
+    /// discard every certificate that loaded successfully, including the
+    /// caller's own explicit `ssl_ca`): such errors are now logged via
+    /// `log::warn!` and otherwise ignored, since the certificates that did
+    /// load are still usable. Left defined for API compatibility.
     #[cfg(feature = "ssl_providerless")]
     #[error("Could not load native certs")]
     LoadNativeCertsErrors {


### PR DESCRIPTION
## Summary

`connect_with_ssl` treated *any* error from `rustls_native_certs::load_native_certs()` as fatal, returning `LoadNativeCertsErrors` and discarding every certificate that loaded successfully — **and** the caller's own explicit `ssl_ca`, added on the very next line regardless of the native-store outcome.

One unreadable entry anywhere in the OS trust store — nothing to do with Docker, nothing the caller did wrong — could make a TLS connection impossible even with a correct, valid CA certificate explicitly supplied, on a machine where the `docker` CLI itself connects fine.

Found investigating a recurring, previously-unexplained `Could not load native certs` failure in a downstream project's own TLS connect test. The concurrency theory that test's own comment blamed (concurrent access to macOS's Security framework) was refuted — it failed alone, three consecutive times, with the sandbox disabled — and this was the real defect underneath it.

## What changed

- Whatever certificates load successfully are added to the root store regardless of `native_certs.errors`, matching how `curl` and the `docker` CLI itself tolerate the same condition. The explicit `ssl_ca` was always going to be added either way, so a partial native-cert failure was never a reason to fail the whole connection.
- A non-empty `native_certs.errors` is now logged via `log::warn!` (naming the count and the errors) rather than silently discarded, since the crate already has a logging facility available in this exact function.
- `LoadNativeCertsErrors` is consequently never constructed by this crate any more. Left defined for API compatibility (`Error` is `#[non_exhaustive]`, so removing a variant isn't the only path anyway) — its doc comment now says so.

## Test plan

- [x] `cargo build --features ssl,ssl_providerless`
- [x] `cargo clippy --features ssl,ssl_providerless -- -D warnings`
- [ ] CI (integration tests requiring a live daemon aren't run locally)

No existing unit test covers this exact partial-failure path (it requires a genuinely broken OS trust-store entry, not something easily fixture-able); verified indirectly via a downstream project's own real-daemon TLS test, which now passes reliably where it previously failed intermittently for this exact reason.