### PR TITLE
fix(buildkit): isolate proto RPC dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,7 +67,7 @@ jobs:
       - checkout
       - setup_remote_docker
       - run: docker build -t bollard .
-      - run: docker run -ti --rm bollard bash -c "cargo xtask buildkit check && cargo test -p xtask && cargo test -p bollard-buildkit-proto --all-features"
+      - run: docker run -ti --rm bollard bash -c "cargo xtask buildkit check && cargo test -p xtask && cargo test -p bollard-buildkit-proto --all-features && cargo test -p bollard-buildkit-proto --no-default-features"
       - run: resources/dockerfiles/bin/run_integration_tests.sh --features buildkit,chrono --tests
       - run:
           name: Clean up Bollard BuildKit resources

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -243,10 +243,9 @@ dependencies = [
 
 [[package]]
 name = "bollard-buildkit-proto"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "prost",
- "prost-types",
  "tonic",
  "tonic-prost",
 ]

--- a/codegen/proto/Cargo.toml
+++ b/codegen/proto/Cargo.toml
@@ -1,14 +1,17 @@
 [package]
 name = "bollard-buildkit-proto"
 description = "Protobuf definitions to interact with buildkit using Bollard"
-version = "0.9.0"
+version = "0.9.1"
 authors = [ "Bollard contributors" ]
 license = "Apache-2.0"
 repository = "https://github.com/fussybeaver/bollard"
 edition = "2021"
 
+[features]
+default = ["grpc"]
+grpc = ["dep:tonic", "dep:tonic-prost"]
+
 [dependencies]
-tonic = { version = "0.14" }
 prost = { version = "0.14" }
-prost-types = "0.14"
-tonic-prost = { version = "0.14" }
+tonic = { version = "0.14", optional = true }
+tonic-prost = { version = "0.14", optional = true }

--- a/codegen/proto/README.md
+++ b/codegen/proto/README.md
@@ -44,3 +44,10 @@ maintained in [`xtask/Cargo.toml`](xtask/Cargo.toml) and
 [`xtask/src/provenance.rs`](xtask/src/provenance.rs). It records the generation
 contract in [`provenance.lock.toml`](provenance.lock.toml). Do not set `PROTOC`
 or `PROTOC_INCLUDE` while running xtask.
+
+## Features
+
+The `grpc` feature is enabled by default and exposes the generated gRPC clients
+and servers. Disable default features when only protobuf messages and
+provenance are needed; this avoids resolving the gRPC transport dependency
+stack.

--- a/codegen/proto/src/generated/grpc.health.v1.rs
+++ b/codegen/proto/src/generated/grpc.health.v1.rs
@@ -67,6 +67,7 @@ pub struct HealthListResponse {
     >,
 }
 /// Generated client implementations.
+#[cfg(feature = "grpc")]
 pub mod health_client {
     #![allow(
         unused_variables,
@@ -268,6 +269,7 @@ pub mod health_client {
     }
 }
 /// Generated server implementations.
+#[cfg(feature = "grpc")]
 pub mod health_server {
     #![allow(
         unused_variables,

--- a/codegen/proto/src/generated/moby.buildkit.secrets.v1.rs
+++ b/codegen/proto/src/generated/moby.buildkit.secrets.v1.rs
@@ -15,6 +15,7 @@ pub struct GetSecretResponse {
     pub data: ::prost::alloc::vec::Vec<u8>,
 }
 /// Generated client implementations.
+#[cfg(feature = "grpc")]
 pub mod secrets_client {
     #![allow(
         unused_variables,
@@ -134,6 +135,7 @@ pub mod secrets_client {
     }
 }
 /// Generated server implementations.
+#[cfg(feature = "grpc")]
 pub mod secrets_server {
     #![allow(
         unused_variables,

--- a/codegen/proto/src/generated/moby.buildkit.v1.rs
+++ b/codegen/proto/src/generated/moby.buildkit.v1.rs
@@ -426,6 +426,7 @@ impl BuildHistoryEventType {
     }
 }
 /// Generated client implementations.
+#[cfg(feature = "grpc")]
 pub mod control_client {
     #![allow(
         unused_variables,
@@ -733,6 +734,7 @@ pub mod control_client {
     }
 }
 /// Generated server implementations.
+#[cfg(feature = "grpc")]
 pub mod control_server {
     #![allow(
         unused_variables,

--- a/codegen/proto/src/generated/moby.filesync.packet.rs
+++ b/codegen/proto/src/generated/moby.filesync.packet.rs
@@ -6,6 +6,7 @@ pub struct BytesMessage {
     pub data: ::prost::alloc::vec::Vec<u8>,
 }
 /// Generated client implementations.
+#[cfg(feature = "grpc")]
 pub mod file_sync_client {
     #![allow(
         unused_variables,
@@ -160,6 +161,7 @@ pub mod file_sync_client {
     }
 }
 /// Generated server implementations.
+#[cfg(feature = "grpc")]
 pub mod file_sync_server {
     #![allow(
         unused_variables,
@@ -423,6 +425,7 @@ pub mod file_sync_server {
     }
 }
 /// Generated client implementations.
+#[cfg(feature = "grpc")]
 pub mod file_send_client {
     #![allow(
         unused_variables,
@@ -547,6 +550,7 @@ pub mod file_send_client {
     }
 }
 /// Generated server implementations.
+#[cfg(feature = "grpc")]
 pub mod file_send_server {
     #![allow(
         unused_variables,

--- a/codegen/proto/src/generated/moby.filesync.v1.rs
+++ b/codegen/proto/src/generated/moby.filesync.v1.rs
@@ -62,6 +62,7 @@ pub struct VerifyTokenAuthorityResponse {
     pub signed: ::prost::alloc::vec::Vec<u8>,
 }
 /// Generated client implementations.
+#[cfg(feature = "grpc")]
 pub mod auth_client {
     #![allow(
         unused_variables,
@@ -253,6 +254,7 @@ pub mod auth_client {
     }
 }
 /// Generated server implementations.
+#[cfg(feature = "grpc")]
 pub mod auth_server {
     #![allow(
         unused_variables,
@@ -593,6 +595,7 @@ pub struct BytesMessage {
     pub data: ::prost::alloc::vec::Vec<u8>,
 }
 /// Generated client implementations.
+#[cfg(feature = "grpc")]
 pub mod file_sync_client {
     #![allow(
         unused_variables,
@@ -747,6 +750,7 @@ pub mod file_sync_client {
     }
 }
 /// Generated server implementations.
+#[cfg(feature = "grpc")]
 pub mod file_sync_server {
     #![allow(
         unused_variables,
@@ -1010,6 +1014,7 @@ pub mod file_sync_server {
     }
 }
 /// Generated client implementations.
+#[cfg(feature = "grpc")]
 pub mod file_send_client {
     #![allow(
         unused_variables,
@@ -1128,6 +1133,7 @@ pub mod file_send_client {
     }
 }
 /// Generated server implementations.
+#[cfg(feature = "grpc")]
 pub mod file_send_server {
     #![allow(
         unused_variables,

--- a/codegen/proto/src/generated/moby.sshforward.v1.rs
+++ b/codegen/proto/src/generated/moby.sshforward.v1.rs
@@ -13,6 +13,7 @@ pub struct CheckAgentRequest {
 #[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct CheckAgentResponse {}
 /// Generated client implementations.
+#[cfg(feature = "grpc")]
 pub mod ssh_client {
     #![allow(
         unused_variables,
@@ -154,6 +155,7 @@ pub mod ssh_client {
     }
 }
 /// Generated server implementations.
+#[cfg(feature = "grpc")]
 pub mod ssh_server {
     #![allow(
         unused_variables,

--- a/codegen/proto/src/generated/moby.upload.v1.rs
+++ b/codegen/proto/src/generated/moby.upload.v1.rs
@@ -6,6 +6,7 @@ pub struct BytesMessage {
     pub data: ::prost::alloc::vec::Vec<u8>,
 }
 /// Generated client implementations.
+#[cfg(feature = "grpc")]
 pub mod upload_client {
     #![allow(
         unused_variables,
@@ -123,6 +124,7 @@ pub mod upload_client {
     }
 }
 /// Generated server implementations.
+#[cfg(feature = "grpc")]
 pub mod upload_server {
     #![allow(
         unused_variables,

--- a/codegen/proto/src/lib.rs
+++ b/codegen/proto/src/lib.rs
@@ -116,6 +116,8 @@ impl AsRef<[u8]> for moby::buildkit::v1::BytesMessage {
 
 #[cfg(test)]
 mod tests {
+    use prost::Message;
+
     use super::provenance;
 
     #[test]
@@ -127,5 +129,16 @@ mod tests {
         assert_eq!(provenance::BUILDKIT_COMMIT.len(), 40);
         assert_eq!(provenance::OPS_PROTO_SHA256.len(), 64);
         assert!(provenance::MOBY_TAG.starts_with("docker-v"));
+    }
+
+    #[test]
+    fn llb_definition_is_available_without_grpc() {
+        let definition = super::pb::Definition {
+            def: vec![vec![1, 2, 3]],
+            ..Default::default()
+        };
+
+        let encoded = definition.encode_to_vec();
+        assert_eq!(super::pb::Definition::decode(encoded.as_slice()), Ok(definition));
     }
 }

--- a/codegen/proto/xtask/src/buildkit.rs
+++ b/codegen/proto/xtask/src/buildkit.rs
@@ -459,7 +459,9 @@ fn compile(
     let builder = tonic_prost_build::configure()
         .out_dir(output_directory)
         .compile_well_known_types(true)
-        .btree_map(".pb");
+        .btree_map(".pb")
+        .client_mod_attribute(".", r##"#[cfg(feature = "grpc")]"##)
+        .server_mod_attribute(".", r##"#[cfg(feature = "grpc")]"##);
     builder.compile_with_config(
         config,
         proto_files,


### PR DESCRIPTION

- make `tonic` and `tonic-prost` optional behind the default `grpc` feature
- keep generated protobuf messages available with `--no-default-features`
- publish the patch as `bollard-buildkit-proto 0.9.1`
- add no-default-feature coverage and CI validation
