### PR TITLE
fix(buildkit): refresh Cargo.lock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -183,7 +183,7 @@ dependencies = [
  "async-stream",
  "base64 0.23.1",
  "bitflags",
- "bollard-buildkit-proto 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bollard-buildkit-proto 0.9.0",
  "bollard-stubs 1.53.1-rc.29.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes",
  "cap-std",
@@ -243,15 +243,6 @@ dependencies = [
 
 [[package]]
 name = "bollard-buildkit-proto"
-version = "0.9.1"
-dependencies = [
- "prost",
- "tonic",
- "tonic-prost",
-]
-
-[[package]]
-name = "bollard-buildkit-proto"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dde1c1fa6e91b511b1a00293b6add7bba4e97a81c3b50499728a2de30d440a4b"
@@ -263,11 +254,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "bollard-buildkit-proto"
+version = "0.9.1"
+dependencies = [
+ "prost",
+ "tonic",
+ "tonic-prost",
+]
+
+[[package]]
 name = "bollard-stubs"
 version = "1.53.1-rc.29.3.1"
 dependencies = [
  "base64 0.23.1",
- "bollard-buildkit-proto 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bollard-buildkit-proto 0.9.0",
  "bytes",
  "chrono",
  "prost",


### PR DESCRIPTION
Refresh Cargo.lock after the proto 0.9.1 merge.