### PR TITLE
feat(buildkit): add direct definition solve support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -205,6 +205,7 @@ dependencies = [
  "once_cell",
  "openssh",
  "pin-project-lite",
+ "prost",
  "rand",
  "rustls",
  "rustls-native-certs",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -183,7 +183,7 @@ dependencies = [
  "async-stream",
  "base64 0.23.1",
  "bitflags",
- "bollard-buildkit-proto 0.9.0",
+ "bollard-buildkit-proto 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "bollard-stubs 1.53.1-rc.29.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes",
  "cap-std",
@@ -244,12 +244,9 @@ dependencies = [
 
 [[package]]
 name = "bollard-buildkit-proto"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dde1c1fa6e91b511b1a00293b6add7bba4e97a81c3b50499728a2de30d440a4b"
+version = "0.9.1"
 dependencies = [
  "prost",
- "prost-types",
  "tonic",
  "tonic-prost",
 ]
@@ -257,6 +254,8 @@ dependencies = [
 [[package]]
 name = "bollard-buildkit-proto"
 version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520619af2416f16aa42df3053233632891db4fd70c193db7e86cd2f9ee4ab814"
 dependencies = [
  "prost",
  "tonic",
@@ -268,7 +267,7 @@ name = "bollard-stubs"
 version = "1.53.1-rc.29.3.1"
 dependencies = [
  "base64 0.23.1",
- "bollard-buildkit-proto 0.9.0",
+ "bollard-buildkit-proto 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes",
  "chrono",
  "prost",
@@ -1605,7 +1604,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1936,7 +1935,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,6 +104,7 @@ cap-std = { version = "4.0", optional = true }
 
 [dev-dependencies]
 flate2 = "1.0"
+prost = "0.14"
 tar = "0.4"
 tokio = { version = "1.38", features = ["fs", "rt-multi-thread", "macros"] }
 tokio-util = { version = "0.7", features = ["io"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,7 +64,7 @@ test_websocket = ["websocket"]
 [dependencies]
 base64 = "0.23"
 bollard-stubs = { version = "=1.53.1-rc.29.3.1", default-features = false }
-bollard-buildkit-proto = { version = "0.9.0", optional = true }
+bollard-buildkit-proto = { version = "0.9.1", optional = true }
 bytes = "1"
 chrono = { version = "0.4", default-features = false, features = ["std", "clock", "serde"], optional = true }
 futures-core = "0.3"

--- a/codegen/swagger/Cargo.toml
+++ b/codegen/swagger/Cargo.toml
@@ -11,7 +11,7 @@ buildkit = ["base64", "bytes", "bollard-buildkit-proto", "prost"]
 
 [dependencies]
 base64 = { version = "0.23", optional = true }
-bollard-buildkit-proto = { version = "0.9.0", optional = true }
+bollard-buildkit-proto = { version = "0.9.1", optional = true }
 bytes = { version = "1", optional = true }
 chrono = { version = "0.4", default-features = false, features = ["std", "clock", "serde"], optional = true }
 serde = { version = "1.0", features = ["derive"] }

--- a/src/grpc/driver/buildkitd.rs
+++ b/src/grpc/driver/buildkitd.rs
@@ -140,3 +140,12 @@ impl super::Image for BuildkitDaemon {
         .await
     }
 }
+
+impl super::SolveDefinition for BuildkitDaemon {
+    async fn solve_definition(
+        &self,
+        request: super::DefinitionSolveRequest,
+    ) -> Result<(), GrpcError> {
+        super::solve_definition(self, request).await
+    }
+}

--- a/src/grpc/driver/docker_container.rs
+++ b/src/grpc/driver/docker_container.rs
@@ -1604,6 +1604,15 @@ impl super::Image for DockerContainer {
     }
 }
 
+impl super::SolveDefinition for DockerContainer {
+    async fn solve_definition(
+        &self,
+        request: super::DefinitionSolveRequest,
+    ) -> Result<(), GrpcError> {
+        super::solve_definition(self, request).await
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/grpc/driver/mod.rs
+++ b/src/grpc/driver/mod.rs
@@ -47,6 +47,7 @@ pub(crate) const DEFAULT_MAX_SEND_MSG_SIZE: usize = 16 << 20;
 /// Used by buildkit [here](https://github.com/moby/buildkit/blob/082e8d8cf3267ddd3a28de1e258eaec20ebe3bbe/cmd/buildkitd/main.go#L309)
 pub(crate) const DEFAULT_MAX_RECV_MSG_SIZE: usize = 16 << 20;
 const TEAR_DOWN_TIMEOUT: Duration = Duration::from_secs(30);
+const DEFAULT_DEFINITION_SOLVE_TIMEOUT: Duration = Duration::from_secs(10 * 60);
 
 /// The Buildkit Daemon driver opens a GRPC connection by connecting to a Buildkit Daemon over a TCP connection.
 pub mod buildkitd;
@@ -217,7 +218,7 @@ pub enum DefinitionExporter {
 }
 
 /// Options for a direct LLB definition solve.
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone)]
 pub struct DefinitionSolveOptions {
     cache_to: Vec<bollard_buildkit_proto::moby::buildkit::v1::CacheOptionsEntry>,
     cache_from: Vec<bollard_buildkit_proto::moby::buildkit::v1::CacheOptionsEntry>,
@@ -226,6 +227,20 @@ pub struct DefinitionSolveOptions {
     ssh: bool,
     timeout: Option<Duration>,
     file_transfer_limits: FileTransferLimits,
+}
+
+impl Default for DefinitionSolveOptions {
+    fn default() -> Self {
+        Self {
+            cache_to: Vec::new(),
+            cache_from: Vec::new(),
+            credentials: HashMap::new(),
+            secrets: HashMap::new(),
+            ssh: false,
+            timeout: Some(DEFAULT_DEFINITION_SOLVE_TIMEOUT),
+            file_transfer_limits: FileTransferLimits::default(),
+        }
+    }
 }
 
 /// Builder for direct LLB definition solve options.
@@ -277,6 +292,8 @@ impl DefinitionSolveOptionsBuilder {
     }
 
     /// Set one wall-clock deadline for setup and the active solve.
+    ///
+    /// The default is ten minutes. Teardown has a separate bounded timeout.
     pub fn timeout(mut self, timeout: Duration) -> Self {
         self.options.timeout = Some(timeout);
         self
@@ -551,7 +568,14 @@ pub(crate) async fn solve_definition(
     let deadline = request
         .options
         .timeout
-        .map(|timeout| Instant::now() + timeout);
+        .map(|timeout| {
+            Instant::now().checked_add(timeout).ok_or_else(|| {
+                GrpcError::from(tonic::Status::invalid_argument(
+                    "direct solve timeout is too large",
+                ))
+            })
+        })
+        .transpose()?;
 
     let DefinitionSolveRequest {
         definition,
@@ -615,14 +639,12 @@ fn build_definition_solve_request(
     normalize_empty_source_locations(&mut definition);
 
     let (exporter_type, exporter_attrs, exporters) = match exporter {
-        DefinitionExporter::Local(path) => {
-            let mut attrs = HashMap::new();
-            attrs.insert(String::from("dest"), path.to_string_lossy().to_string());
+        DefinitionExporter::Local(_) => {
             let exporters = vec![Exporter {
                 r#type: String::from("local"),
-                attrs: attrs.clone(),
+                attrs: HashMap::new(),
             }];
-            (String::from("local"), attrs, exporters)
+            (String::from("local"), HashMap::new(), exporters)
         }
     };
 
@@ -1109,12 +1131,11 @@ mod tests {
         assert!(request.frontend_attrs.is_empty());
         assert!(request.frontend_inputs.is_empty());
         assert_eq!(request.exporter_deprecated, "local");
+        assert!(request.exporter_attrs_deprecated.is_empty());
         assert_eq!(request.exporters.len(), 1);
         assert_eq!(request.exporters[0].r#type, "local");
-        assert_eq!(
-            request.exporters[0].attrs.get("dest"),
-            Some(&String::from("/out"))
-        );
+        assert!(request.exporters[0].attrs.is_empty());
+        assert!(!format!("{request:?}").contains("/out"));
         assert_eq!(request.session, "session-id");
     }
 
@@ -1171,6 +1192,35 @@ mod tests {
         assert!(options.ssh);
         assert_eq!(options.timeout, Some(Duration::from_secs(3)));
         assert_eq!(options.file_transfer_limits.max_files, Some(2));
+    }
+
+    #[test]
+    fn definition_options_have_a_bounded_default_timeout() {
+        assert_eq!(
+            DefinitionSolveOptions::default().timeout,
+            Some(DEFAULT_DEFINITION_SOLVE_TIMEOUT)
+        );
+    }
+
+    #[tokio::test]
+    async fn definition_solve_rejects_an_overflowing_timeout() {
+        let request = DefinitionSolveRequest::new(
+            bollard_buildkit_proto::pb::Definition::default(),
+            DefinitionExporter::Local(PathBuf::from("/out")),
+        )
+        .with_options(
+            DefinitionSolveOptionsBuilder::new()
+                .timeout(Duration::MAX)
+                .build(),
+        );
+
+        let error = solve_definition(&failing_test_driver(), request)
+            .await
+            .expect_err("an overflowing timeout must be rejected");
+        assert!(matches!(
+            error,
+            GrpcError::TonicStatus { err } if err.code() == tonic::Code::InvalidArgument
+        ));
     }
 
     #[tokio::test]

--- a/src/grpc/driver/mod.rs
+++ b/src/grpc/driver/mod.rs
@@ -322,9 +322,15 @@ impl DefinitionSolveOptionsBuilder {
         self
     }
 
-    /// Set aggregate packet-export transfer limits.
-    pub fn file_transfer_limits(mut self, limits: FileTransferLimits) -> Self {
-        self.options.file_transfer_limits = limits;
+    /// Reject a packet export once it reaches this many filesystem entries.
+    pub fn max_files(mut self, max_files: u64) -> Self {
+        self.options.file_transfer_limits.max_files = Some(max_files);
+        self
+    }
+
+    /// Reject a packet export once its declared entry sizes exceed this total.
+    pub fn max_bytes(mut self, max_bytes: u64) -> Self {
+        self.options.file_transfer_limits.max_bytes = Some(max_bytes);
         self
     }
 
@@ -1158,6 +1164,30 @@ mod tests {
         }
     }
 
+    async fn assert_teardown_timeout_case(
+        driver: &TestDriver,
+        deadline: Option<Instant>,
+        expected_code: tonic::Code,
+    ) {
+        let calls = Arc::new(AtomicUsize::new(0));
+        let started = Arc::new(Notify::new());
+        let cancelled = Arc::new(AtomicBool::new(false));
+        let result = execute_solve_with_teardown_timeout(
+            driver,
+            "session",
+            SolveRequest::default(),
+            Vec::new(),
+            blocking_teardown(calls.clone(), started, cancelled.clone()),
+            deadline,
+            Duration::from_millis(5),
+        )
+        .await;
+
+        assert_eq!(status_code(result), expected_code);
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+        assert!(cancelled.load(Ordering::SeqCst));
+    }
+
     #[test]
     fn definition_solve_request_has_definition_and_empty_frontend() {
         let request = build_definition_solve_request(
@@ -1274,10 +1304,8 @@ mod tests {
             .secret("token", SecretSource::Env(String::from("TOKEN")))
             .enable_ssh(true)
             .timeout(Duration::from_secs(3))
-            .file_transfer_limits(FileTransferLimits {
-                max_files: Some(2),
-                max_bytes: Some(8),
-            })
+            .max_files(2)
+            .max_bytes(8)
             .build();
 
         assert_eq!(options.cache_to.len(), 1);
@@ -1417,7 +1445,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn solve_reuses_a_driver_with_fresh_session_ids() {
+    async fn solve_entry_points_use_fresh_session_ids() {
         let (address, shutdown_sender, handle) = start_test_server(None).await;
         let driver = test_driver(address);
         let session_ids = Arc::clone(&driver.session_ids);
@@ -1437,21 +1465,6 @@ mod tests {
             .unwrap();
         }
 
-        stop_test_server(shutdown_sender, handle).await;
-
-        let session_ids = session_ids
-            .lock()
-            .expect("session IDs mutex is not poisoned");
-        assert_eq!(session_ids.len(), 2);
-        assert_ne!(session_ids[0], session_ids[1]);
-    }
-
-    #[tokio::test]
-    async fn solve_definition_reuses_a_driver_with_fresh_session_ids() {
-        let (address, shutdown_sender, handle) = start_test_server(None).await;
-        let driver = test_driver(address);
-        let session_ids = Arc::clone(&driver.session_ids);
-
         for _ in 0..2 {
             let request = DefinitionSolveRequest::new(
                 bollard_buildkit_proto::pb::Definition::default(),
@@ -1461,9 +1474,16 @@ mod tests {
         }
 
         stop_test_server(shutdown_sender, handle).await;
-        let session_ids = session_ids.lock().unwrap();
-        assert_eq!(session_ids.len(), 2);
+
+        let session_ids = session_ids
+            .lock()
+            .expect("session IDs mutex is not poisoned");
+        assert_eq!(session_ids.len(), 4);
         assert_ne!(session_ids[0], session_ids[1]);
+        assert_ne!(session_ids[2], session_ids[3]);
+        assert!(session_ids[..2]
+            .iter()
+            .all(|session_id| !session_ids[2..].contains(session_id)));
     }
 
     #[tokio::test]
@@ -1495,70 +1515,35 @@ mod tests {
 
     #[tokio::test]
     async fn execute_solve_awaits_teardown_after_setup_timeout() {
-        let calls = Arc::new(AtomicUsize::new(0));
-        let started = Arc::new(Notify::new());
-        let cancelled = Arc::new(AtomicBool::new(false));
-        let result = execute_solve_with_teardown_timeout(
-            &pending_test_driver(),
-            "session",
-            SolveRequest::default(),
-            Vec::new(),
-            blocking_teardown(calls.clone(), started, cancelled.clone()),
+        let driver = pending_test_driver();
+        assert_teardown_timeout_case(
+            &driver,
             Some(Instant::now() + Duration::from_millis(1)),
-            Duration::from_millis(5),
+            tonic::Code::DeadlineExceeded,
         )
         .await;
-
-        assert_eq!(status_code(result), tonic::Code::DeadlineExceeded);
-        assert_eq!(calls.load(Ordering::SeqCst), 1);
-        assert!(cancelled.load(Ordering::SeqCst));
     }
 
     #[tokio::test]
     async fn execute_solve_awaits_teardown_after_solve_timeout() {
         let (address, shutdown_sender, handle) = start_pending_solve_server().await;
-        let calls = Arc::new(AtomicUsize::new(0));
-        let started = Arc::new(Notify::new());
-        let cancelled = Arc::new(AtomicBool::new(false));
-        let result = execute_solve_with_teardown_timeout(
-            &test_driver(address),
-            "session",
-            SolveRequest::default(),
-            Vec::new(),
-            blocking_teardown(calls.clone(), started, cancelled.clone()),
+        let driver = test_driver(address);
+        assert_teardown_timeout_case(
+            &driver,
             Some(Instant::now() + Duration::from_millis(25)),
-            Duration::from_millis(5),
+            tonic::Code::DeadlineExceeded,
         )
         .await;
         stop_test_server(shutdown_sender, handle).await;
-
-        assert_eq!(status_code(result), tonic::Code::DeadlineExceeded);
-        assert_eq!(calls.load(Ordering::SeqCst), 1);
-        assert!(cancelled.load(Ordering::SeqCst));
     }
 
     #[tokio::test]
     async fn execute_solve_preserves_solve_error_over_teardown_timeout() {
         let (address, shutdown_sender, handle) =
             start_test_server(Some(Status::not_found("solve failed"))).await;
-        let calls = Arc::new(AtomicUsize::new(0));
-        let started = Arc::new(Notify::new());
-        let cancelled = Arc::new(AtomicBool::new(false));
-        let result = execute_solve_with_teardown_timeout(
-            &test_driver(address),
-            "session",
-            SolveRequest::default(),
-            Vec::new(),
-            blocking_teardown(calls.clone(), started, cancelled.clone()),
-            None,
-            Duration::from_millis(5),
-        )
-        .await;
+        let driver = test_driver(address);
+        assert_teardown_timeout_case(&driver, None, tonic::Code::NotFound).await;
         stop_test_server(shutdown_sender, handle).await;
-
-        assert_eq!(status_code(result), tonic::Code::NotFound);
-        assert_eq!(calls.load(Ordering::SeqCst), 1);
-        assert!(cancelled.load(Ordering::SeqCst));
     }
 
     #[tokio::test]

--- a/src/grpc/driver/mod.rs
+++ b/src/grpc/driver/mod.rs
@@ -596,9 +596,12 @@ pub(crate) async fn solve_definition(
     let mut services = vec![GrpcServer::Auth(auth), GrpcServer::Secrets(secret)];
 
     if options.ssh {
-        let ssh = SshServer::new(super::SshProvider::new())
-            .max_decoding_message_size(DEFAULT_MAX_RECV_MSG_SIZE)
-            .max_encoding_message_size(DEFAULT_MAX_SEND_MSG_SIZE);
+        let ssh = SshServer::new(super::SshProvider::new(HashMap::from([(
+            String::from(super::DEFAULT_SSH_AGENT_ID),
+            super::SshAgentSource::DefaultAgentSocket,
+        )])))
+        .max_decoding_message_size(DEFAULT_MAX_RECV_MSG_SIZE)
+        .max_encoding_message_size(DEFAULT_MAX_SEND_MSG_SIZE);
         services.push(GrpcServer::Ssh(ssh));
     }
 

--- a/src/grpc/driver/mod.rs
+++ b/src/grpc/driver/mod.rs
@@ -78,16 +78,22 @@ struct TearDownGuard {
     handler: Arc<dyn DriverTearDownHandler>,
     runtime: tokio::runtime::Handle,
     task: Option<tokio::task::JoinHandle<Result<(), GrpcError>>>,
+    timeout: Duration,
     armed: bool,
     started: bool,
 }
 
 impl TearDownGuard {
     fn new(handler: Box<dyn DriverTearDownHandler>) -> Self {
+        Self::with_timeout(handler, TEAR_DOWN_TIMEOUT)
+    }
+
+    fn with_timeout(handler: Box<dyn DriverTearDownHandler>, timeout: Duration) -> Self {
         Self {
             handler: Arc::from(handler),
             runtime: tokio::runtime::Handle::current(),
             task: None,
+            timeout,
             armed: true,
             started: false,
         }
@@ -104,43 +110,62 @@ impl TearDownGuard {
 
         self.started = true;
         let handler = Arc::clone(&self.handler);
-        self.task = Some(self.runtime.spawn(run_tear_down(handler)));
+        self.task = Some(self.runtime.spawn(run_tear_down(handler, self.timeout)));
     }
 
     async fn tear_down(&mut self) -> Result<(), GrpcError> {
         self.start();
-        self.task
-            .take()
-            .ok_or_else(|| GrpcError::TearDownTaskUnavailable)?
-            .await
-            .map_err(|error| tonic::Status::internal(format!("teardown task failed: {error}")))?
+        let result = {
+            let task = self
+                .task
+                .as_mut()
+                .ok_or_else(|| GrpcError::TearDownTaskUnavailable)?;
+            task.await
+        };
+        self.task.take();
+        result.map_err(|error| tonic::Status::internal(format!("teardown task failed: {error}")))?
     }
 }
 
-async fn run_tear_down(handler: Arc<dyn DriverTearDownHandler>) -> Result<(), GrpcError> {
-    tokio::time::timeout(TEAR_DOWN_TIMEOUT, handler.tear_down())
-        .await
-        .map_err(|_| {
-            GrpcError::from(tonic::Status::deadline_exceeded(
+async fn run_tear_down(
+    handler: Arc<dyn DriverTearDownHandler>,
+    timeout: Duration,
+) -> Result<(), GrpcError> {
+    let mut task = tokio::spawn(async move { handler.tear_down().await });
+    match tokio::time::timeout(timeout, &mut task).await {
+        Ok(result) => result
+            .map_err(|error| tonic::Status::internal(format!("teardown task failed: {error}")))?,
+        Err(_) => {
+            task.abort();
+            let _ = task.await;
+            Err(GrpcError::from(tonic::Status::deadline_exceeded(
                 "driver teardown exceeded its timeout",
-            ))
-        })?
+            )))
+        }
+    }
 }
 
 impl Drop for TearDownGuard {
     fn drop(&mut self) {
-        if !self.armed || self.started {
-            // Dropping a JoinHandle detaches the task, allowing cleanup to finish after the
-            // solve future is cancelled or unwinds due to a panic.
+        if !self.armed {
             return;
         }
 
-        let handler = Arc::clone(&self.handler);
-        self.runtime.spawn(async move {
-            if let Err(error) = run_tear_down(handler).await {
-                warn!("failed to tear down BuildKit driver after cancellation: {error}");
-            }
-        });
+        if let Some(task) = self.task.take() {
+            self.runtime.spawn(async move {
+                if let Err(error) = task.await {
+                    warn!("failed to join BuildKit driver teardown after cancellation: {error}");
+                }
+            });
+        } else if !self.started {
+            let handler = Arc::clone(&self.handler);
+            let timeout = self.timeout;
+            self.runtime.spawn(async move {
+                if let Err(error) = run_tear_down(handler, timeout).await {
+                    warn!("failed to tear down BuildKit driver after cancellation: {error}");
+                }
+            });
+        }
     }
 }
 
@@ -278,6 +303,54 @@ pub struct DefinitionSolveRequest {
     pub exporter: DefinitionExporter,
     options: DefinitionSolveOptions,
     build_ref: Option<BuildRef>,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct SolveRequestSummary {
+    has_ref: bool,
+    has_session: bool,
+    has_definition: bool,
+    definition_ops: usize,
+    frontend_attrs: usize,
+    frontend_inputs: usize,
+    entitlements: usize,
+    exporters: usize,
+    cache_exports: usize,
+    cache_imports: usize,
+    has_source_policy: bool,
+    has_source_policy_session: bool,
+    internal: bool,
+    enable_session_exporter: bool,
+}
+
+impl From<&SolveRequest> for SolveRequestSummary {
+    fn from(request: &SolveRequest) -> Self {
+        Self {
+            has_ref: !request.r#ref.is_empty(),
+            has_session: !request.session.is_empty(),
+            has_definition: request.definition.is_some(),
+            definition_ops: request
+                .definition
+                .as_ref()
+                .map_or(0, |definition| definition.def.len()),
+            frontend_attrs: request.frontend_attrs.len(),
+            frontend_inputs: request.frontend_inputs.len(),
+            entitlements: request.entitlements.len(),
+            exporters: request.exporters.len(),
+            cache_exports: request
+                .cache
+                .as_ref()
+                .map_or(0, |cache| cache.exports.len()),
+            cache_imports: request
+                .cache
+                .as_ref()
+                .map_or(0, |cache| cache.imports.len()),
+            has_source_policy: request.source_policy.is_some(),
+            has_source_policy_session: !request.source_policy_session.is_empty(),
+            internal: request.internal,
+            enable_session_exporter: request.enable_session_exporter,
+        }
+    }
 }
 
 impl DefinitionSolveRequest {
@@ -594,17 +667,34 @@ async fn execute_solve<D: Driver>(
     tear_down_handler: Box<dyn DriverTearDownHandler>,
     deadline: Option<Instant>,
 ) -> Result<(), GrpcError> {
-    let mut tear_down_guard = TearDownGuard::new(tear_down_handler);
+    execute_solve_with_teardown_timeout(
+        driver,
+        session_id,
+        request,
+        services,
+        tear_down_handler,
+        deadline,
+        TEAR_DOWN_TIMEOUT,
+    )
+    .await
+}
+
+async fn execute_solve_with_teardown_timeout<D: Driver>(
+    driver: &D,
+    session_id: &str,
+    request: SolveRequest,
+    services: Vec<GrpcServer>,
+    tear_down_handler: Box<dyn DriverTearDownHandler>,
+    deadline: Option<Instant>,
+    teardown_timeout: Duration,
+) -> Result<(), GrpcError> {
+    let mut tear_down_guard = TearDownGuard::with_timeout(tear_down_handler, teardown_timeout);
     let mut control_client = match run_until(deadline, driver.grpc_handle(session_id, services))
         .await
     {
         Ok(client) => client
             .max_decoding_message_size(DEFAULT_MAX_RECV_MSG_SIZE)
             .max_encoding_message_size(DEFAULT_MAX_SEND_MSG_SIZE),
-        Err(error) if is_deadline_exceeded(&error) => {
-            drop(tear_down_guard);
-            return Err(error);
-        }
         Err(error) => {
             // A driver may have created resources before gRPC setup failed.
             if let Err(teardown_error) = tear_down_guard.tear_down().await {
@@ -614,7 +704,10 @@ async fn execute_solve<D: Driver>(
         }
     };
 
-    debug!("sending solve request: {:#?}", request);
+    debug!(
+        "sending solve request: {:?}",
+        SolveRequestSummary::from(&request)
+    );
     let solve_result = match run_until(
         deadline,
         control_client.solve(request).map_err(GrpcError::from),
@@ -622,13 +715,9 @@ async fn execute_solve<D: Driver>(
     .await
     {
         Ok(_) => Ok(()),
-        Err(error) if is_deadline_exceeded(&error) => {
-            drop(tear_down_guard);
-            return Err(error);
-        }
         Err(error) => Err(error),
     };
-    debug!("solve res: {:#?}", solve_result);
+    debug!("solve completed: success={}", solve_result.is_ok());
 
     let tear_down_result = tear_down_guard.tear_down().await;
 
@@ -659,20 +748,13 @@ where
     }
 }
 
-fn is_deadline_exceeded(error: &GrpcError) -> bool {
-    matches!(
-        error,
-        GrpcError::TonicStatus { err } if err.code() == tonic::Code::DeadlineExceeded
-    )
-}
-
 #[cfg(test)]
 mod tests {
     use std::{
         net::SocketAddr,
         pin::Pin,
         sync::{
-            atomic::{AtomicUsize, Ordering},
+            atomic::{AtomicBool, AtomicUsize, Ordering},
             Arc, Mutex,
         },
     };
@@ -685,7 +767,10 @@ mod tests {
         UpdateBuildHistoryResponse, UsageRecord,
     };
     use futures_util::{stream::Empty, FutureExt};
-    use tokio::{net::TcpListener, sync::oneshot};
+    use tokio::{
+        net::TcpListener,
+        sync::{oneshot, Notify},
+    };
     use tokio_stream::wrappers::TcpListenerStream;
     use tonic::{
         transport::{Channel, Endpoint, Server},
@@ -747,6 +832,7 @@ mod tests {
     struct TestTearDown {
         calls: Arc<AtomicUsize>,
         error: Option<Status>,
+        started: Option<Arc<Notify>>,
     }
 
     impl DriverTearDownHandler for TestTearDown {
@@ -755,6 +841,9 @@ mod tests {
         ) -> Pin<Box<dyn futures_core::Future<Output = Result<(), GrpcError>> + Send + 'static>>
         {
             self.calls.fetch_add(1, Ordering::SeqCst);
+            if let Some(started) = &self.started {
+                started.notify_one();
+            }
             let result = self
                 .error
                 .clone()
@@ -763,8 +852,41 @@ mod tests {
         }
     }
 
+    struct BlockingTearDown {
+        calls: Arc<AtomicUsize>,
+        started: Arc<Notify>,
+        cancelled: Arc<AtomicBool>,
+    }
+
+    impl DriverTearDownHandler for BlockingTearDown {
+        fn tear_down(
+            &self,
+        ) -> Pin<Box<dyn futures_core::Future<Output = Result<(), GrpcError>> + Send + 'static>>
+        {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            self.started.notify_one();
+            let cancelled = Arc::clone(&self.cancelled);
+
+            struct CancellationFlag(Arc<AtomicBool>);
+
+            impl Drop for CancellationFlag {
+                fn drop(&mut self) {
+                    self.0.store(true, Ordering::SeqCst);
+                }
+            }
+
+            Box::pin(async move {
+                let _cancellation_flag = CancellationFlag(cancelled);
+                std::future::pending::<()>().await;
+                #[allow(unreachable_code)]
+                Ok(())
+            })
+        }
+    }
+
     struct TestControl {
         solve_error: Option<Status>,
+        solve_pending: bool,
     }
 
     type EmptyUsageRecords = Empty<Result<UsageRecord, Status>>;
@@ -797,6 +919,9 @@ mod tests {
             &self,
             _request: Request<SolveRequest>,
         ) -> Result<Response<SolveResponse>, Status> {
+            if self.solve_pending {
+                std::future::pending::<()>().await;
+            }
             match &self.solve_error {
                 Some(error) => Err(error.clone()),
                 None => Ok(Response::new(SolveResponse::default())),
@@ -849,11 +974,26 @@ mod tests {
     async fn start_test_server(
         solve_error: Option<Status>,
     ) -> (SocketAddr, oneshot::Sender<()>, tokio::task::JoinHandle<()>) {
+        start_test_server_with_pending(solve_error, false).await
+    }
+
+    async fn start_pending_solve_server(
+    ) -> (SocketAddr, oneshot::Sender<()>, tokio::task::JoinHandle<()>) {
+        start_test_server_with_pending(None, true).await
+    }
+
+    async fn start_test_server_with_pending(
+        solve_error: Option<Status>,
+        solve_pending: bool,
+    ) -> (SocketAddr, oneshot::Sender<()>, tokio::task::JoinHandle<()>) {
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let address = listener.local_addr().unwrap();
         let (shutdown_sender, shutdown_receiver) = oneshot::channel();
         let server = Server::builder()
-            .add_service(ControlServer::new(TestControl { solve_error }))
+            .add_service(ControlServer::new(TestControl {
+                solve_error,
+                solve_pending,
+            }))
             .serve_with_incoming_shutdown(TcpListenerStream::new(listener), async move {
                 let _ = shutdown_receiver.await;
             });
@@ -917,7 +1057,34 @@ mod tests {
     }
 
     fn teardown(calls: Arc<AtomicUsize>, error: Option<Status>) -> Box<dyn DriverTearDownHandler> {
-        Box::new(TestTearDown { calls, error })
+        Box::new(TestTearDown {
+            calls,
+            error,
+            started: None,
+        })
+    }
+
+    fn teardown_with_started(
+        calls: Arc<AtomicUsize>,
+        started: Arc<Notify>,
+    ) -> Box<dyn DriverTearDownHandler> {
+        Box::new(TestTearDown {
+            calls,
+            error: None,
+            started: Some(started),
+        })
+    }
+
+    fn blocking_teardown(
+        calls: Arc<AtomicUsize>,
+        started: Arc<Notify>,
+        cancelled: Arc<AtomicBool>,
+    ) -> Box<dyn DriverTearDownHandler> {
+        Box::new(BlockingTearDown {
+            calls,
+            started,
+            cancelled,
+        })
     }
 
     fn status_code(result: Result<(), GrpcError>) -> tonic::Code {
@@ -949,6 +1116,33 @@ mod tests {
             Some(&String::from("/out"))
         );
         assert_eq!(request.session, "session-id");
+    }
+
+    #[test]
+    fn solve_request_summary_redacts_request_values() {
+        let mut request = SolveRequest {
+            r#ref: String::from("sensitive-build-reference"),
+            session: String::from("sensitive-session-id"),
+            definition: Some(bollard_buildkit_proto::pb::Definition {
+                def: vec![b"sensitive-definition-bytes".to_vec()],
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        request
+            .frontend_attrs
+            .insert(String::from("secret-path"), String::from("/private"));
+
+        let summary = SolveRequestSummary::from(&request);
+        let rendered = format!("{summary:?}");
+
+        assert_eq!(summary.definition_ops, 1);
+        assert_eq!(summary.frontend_attrs, 1);
+        assert!(!rendered.contains("sensitive-build-reference"));
+        assert!(!rendered.contains("sensitive-session-id"));
+        assert!(!rendered.contains("sensitive-definition-bytes"));
+        assert!(!rendered.contains("secret-path"));
+        assert!(!rendered.contains("/private"));
     }
 
     #[test]
@@ -1130,6 +1324,8 @@ mod tests {
     #[tokio::test]
     async fn execute_solve_tears_down_after_cancellation() {
         let calls = Arc::new(AtomicUsize::new(0));
+        let started = Arc::new(Notify::new());
+        let notification = started.notified();
         let driver = pending_test_driver();
         let result = tokio::time::timeout(
             Duration::from_millis(10),
@@ -1138,59 +1334,108 @@ mod tests {
                 "session",
                 SolveRequest::default(),
                 Vec::new(),
-                teardown(calls.clone(), None),
+                teardown_with_started(calls.clone(), started.clone()),
                 None,
             ),
         )
         .await;
 
         assert!(result.is_err());
-        for _ in 0..10 {
-            tokio::task::yield_now().await;
-        }
+        tokio::time::timeout(Duration::from_secs(1), notification)
+            .await
+            .expect("cancelled solve starts teardown");
 
         assert_eq!(calls.load(Ordering::SeqCst), 1);
     }
 
     #[tokio::test]
-    async fn execute_solve_returns_deadline_and_detaches_teardown() {
+    async fn execute_solve_awaits_teardown_after_setup_timeout() {
         let calls = Arc::new(AtomicUsize::new(0));
-        let result = execute_solve(
+        let started = Arc::new(Notify::new());
+        let cancelled = Arc::new(AtomicBool::new(false));
+        let result = execute_solve_with_teardown_timeout(
             &pending_test_driver(),
             "session",
             SolveRequest::default(),
             Vec::new(),
-            teardown(calls.clone(), None),
+            blocking_teardown(calls.clone(), started, cancelled.clone()),
             Some(Instant::now() + Duration::from_millis(1)),
+            Duration::from_millis(5),
         )
         .await;
 
         assert_eq!(status_code(result), tonic::Code::DeadlineExceeded);
-        for _ in 0..10 {
-            tokio::task::yield_now().await;
-        }
         assert_eq!(calls.load(Ordering::SeqCst), 1);
+        assert!(cancelled.load(Ordering::SeqCst));
+    }
+
+    #[tokio::test]
+    async fn execute_solve_awaits_teardown_after_solve_timeout() {
+        let (address, shutdown_sender, handle) = start_pending_solve_server().await;
+        let calls = Arc::new(AtomicUsize::new(0));
+        let started = Arc::new(Notify::new());
+        let cancelled = Arc::new(AtomicBool::new(false));
+        let result = execute_solve_with_teardown_timeout(
+            &test_driver(address),
+            "session",
+            SolveRequest::default(),
+            Vec::new(),
+            blocking_teardown(calls.clone(), started, cancelled.clone()),
+            Some(Instant::now() + Duration::from_millis(25)),
+            Duration::from_millis(5),
+        )
+        .await;
+        stop_test_server(shutdown_sender, handle).await;
+
+        assert_eq!(status_code(result), tonic::Code::DeadlineExceeded);
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+        assert!(cancelled.load(Ordering::SeqCst));
+    }
+
+    #[tokio::test]
+    async fn execute_solve_preserves_solve_error_over_teardown_timeout() {
+        let (address, shutdown_sender, handle) =
+            start_test_server(Some(Status::not_found("solve failed"))).await;
+        let calls = Arc::new(AtomicUsize::new(0));
+        let started = Arc::new(Notify::new());
+        let cancelled = Arc::new(AtomicBool::new(false));
+        let result = execute_solve_with_teardown_timeout(
+            &test_driver(address),
+            "session",
+            SolveRequest::default(),
+            Vec::new(),
+            blocking_teardown(calls.clone(), started, cancelled.clone()),
+            None,
+            Duration::from_millis(5),
+        )
+        .await;
+        stop_test_server(shutdown_sender, handle).await;
+
+        assert_eq!(status_code(result), tonic::Code::NotFound);
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+        assert!(cancelled.load(Ordering::SeqCst));
     }
 
     #[tokio::test]
     async fn execute_solve_tears_down_after_panic() {
         let calls = Arc::new(AtomicUsize::new(0));
+        let started = Arc::new(Notify::new());
+        let notification = started.notified();
         let result = std::panic::AssertUnwindSafe(execute_solve(
             &panicking_test_driver(),
             "session",
             SolveRequest::default(),
             Vec::new(),
-            teardown(calls.clone(), None),
+            teardown_with_started(calls.clone(), started.clone()),
             None,
         ))
         .catch_unwind()
         .await;
 
         assert!(result.is_err());
-        for _ in 0..10 {
-            tokio::task::yield_now().await;
-        }
-
+        tokio::time::timeout(Duration::from_secs(1), notification)
+            .await
+            .expect("panicked solve starts teardown");
         assert_eq!(calls.load(Ordering::SeqCst), 1);
     }
 }

--- a/src/grpc/driver/mod.rs
+++ b/src/grpc/driver/mod.rs
@@ -1,5 +1,5 @@
 use std::time::Duration;
-use std::{collections::HashMap, path::PathBuf, sync::Arc, time::Instant};
+use std::{collections::HashMap, fmt, path::PathBuf, sync::Arc, time::Instant};
 
 use bollard_buildkit_proto::moby::{
     buildkit::{
@@ -154,8 +154,16 @@ impl Drop for TearDownGuard {
 
         if let Some(task) = self.task.take() {
             self.runtime.spawn(async move {
-                if let Err(error) = task.await {
-                    warn!("failed to join BuildKit driver teardown after cancellation: {error}");
+                match task.await {
+                    Ok(Ok(())) => {}
+                    Ok(Err(error)) => {
+                        warn!("failed to tear down BuildKit driver after cancellation: {error}");
+                    }
+                    Err(error) => {
+                        warn!(
+                            "failed to join BuildKit driver teardown after cancellation: {error}"
+                        );
+                    }
                 }
             });
         } else if !self.started {
@@ -218,7 +226,7 @@ pub enum DefinitionExporter {
 }
 
 /// Options for a direct LLB definition solve.
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct DefinitionSolveOptions {
     cache_to: Vec<bollard_buildkit_proto::moby::buildkit::v1::CacheOptionsEntry>,
     cache_from: Vec<bollard_buildkit_proto::moby::buildkit::v1::CacheOptionsEntry>,
@@ -227,6 +235,21 @@ pub struct DefinitionSolveOptions {
     ssh: bool,
     timeout: Option<Duration>,
     file_transfer_limits: FileTransferLimits,
+}
+
+impl fmt::Debug for DefinitionSolveOptions {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("DefinitionSolveOptions")
+            .field("cache_to", &self.cache_to.len())
+            .field("cache_from", &self.cache_from.len())
+            .field("credentials", &self.credentials.len())
+            .field("secrets", &self.secrets.len())
+            .field("ssh", &self.ssh)
+            .field("timeout", &self.timeout)
+            .field("file_transfer_limits", &self.file_transfer_limits)
+            .finish()
+    }
 }
 
 impl Default for DefinitionSolveOptions {
@@ -312,7 +335,7 @@ impl DefinitionSolveOptionsBuilder {
 }
 
 /// A direct-definition solve request.
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct DefinitionSolveRequest {
     /// The pre-built LLB definition to solve.
     pub definition: bollard_buildkit_proto::pb::Definition,
@@ -320,6 +343,22 @@ pub struct DefinitionSolveRequest {
     pub exporter: DefinitionExporter,
     options: DefinitionSolveOptions,
     build_ref: Option<BuildRef>,
+}
+
+impl fmt::Debug for DefinitionSolveRequest {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let exporter = match &self.exporter {
+            DefinitionExporter::Local(_) => "local",
+        };
+
+        formatter
+            .debug_struct("DefinitionSolveRequest")
+            .field("definition_ops", &self.definition.def.len())
+            .field("exporter", &exporter)
+            .field("options", &self.options)
+            .field("has_build_ref", &self.build_ref.is_some())
+            .finish()
+    }
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -1167,6 +1206,59 @@ mod tests {
         assert!(!rendered.contains("sensitive-definition-bytes"));
         assert!(!rendered.contains("secret-path"));
         assert!(!rendered.contains("/private"));
+    }
+
+    #[test]
+    fn definition_solve_debug_output_redacts_sensitive_values() {
+        let builder = DefinitionSolveOptionsBuilder::new()
+            .credential(
+                "sensitive-registry.example",
+                DockerCredentials {
+                    username: Some(String::from("sensitive-username")),
+                    password: Some(String::from("sensitive-password")),
+                    auth: Some(String::from("sensitive-auth")),
+                    identitytoken: Some(String::from("sensitive-identity-token")),
+                    registrytoken: Some(String::from("sensitive-registry-token")),
+                    ..Default::default()
+                },
+            )
+            .secret(
+                "sensitive-secret-id",
+                SecretSource::Env(String::from("sensitive-secret-source")),
+            );
+        let builder_debug = format!("{builder:?}");
+        let options = builder.clone().build();
+        let options_debug = format!("{options:?}");
+        let request = DefinitionSolveRequest::new(
+            bollard_buildkit_proto::pb::Definition {
+                def: vec![b"sensitive-definition-bytes".to_vec()],
+                ..Default::default()
+            },
+            DefinitionExporter::Local(PathBuf::from("/sensitive-export-path")),
+        )
+        .with_options(options);
+        let request_debug = format!("{request:?}");
+
+        for rendered in [&builder_debug, &options_debug, &request_debug] {
+            assert!(!rendered.contains("sensitive-registry.example"));
+            assert!(!rendered.contains("sensitive-username"));
+            assert!(!rendered.contains("sensitive-password"));
+            assert!(!rendered.contains("sensitive-auth"));
+            assert!(!rendered.contains("sensitive-identity-token"));
+            assert!(!rendered.contains("sensitive-registry-token"));
+            assert!(!rendered.contains("sensitive-secret-id"));
+            assert!(!rendered.contains("sensitive-secret-source"));
+            assert!(!rendered.contains("sensitive-definition-bytes"));
+            assert!(!rendered.contains("/sensitive-export-path"));
+        }
+
+        assert!(builder_debug.contains("credentials: 1"));
+        assert!(builder_debug.contains("secrets: 1"));
+        assert!(options_debug.contains("credentials: 1"));
+        assert!(options_debug.contains("secrets: 1"));
+        assert!(request_debug.contains("definition_ops: 1"));
+        assert!(request_debug.contains("exporter: \"local\""));
+        assert!(request_debug.contains("has_build_ref: false"));
     }
 
     #[test]

--- a/src/grpc/driver/mod.rs
+++ b/src/grpc/driver/mod.rs
@@ -1,15 +1,19 @@
 use std::time::Duration;
-use std::{collections::HashMap, path::PathBuf, sync::Arc};
+use std::{collections::HashMap, path::PathBuf, sync::Arc, time::Instant};
 
 use bollard_buildkit_proto::moby::{
     buildkit::{
         secrets::v1::secrets_server::SecretsServer,
-        v1::{control_client::ControlClient, CacheOptions, SolveRequest},
+        v1::{control_client::ControlClient, CacheOptions, Exporter, SolveRequest},
     },
-    filesync::v1::{auth_server::AuthServer, file_send_server::FileSendServer},
+    filesync::{
+        packet::file_send_server::FileSendServer as FileSendPacketServer,
+        v1::{auth_server::AuthServer, file_send_server::FileSendServer},
+    },
     sshforward::v1::ssh_server::SshServer,
     upload::v1::upload_server::UploadServer,
 };
+use futures_util::TryFutureExt;
 use log::{debug, warn};
 // use tonic::service::Interceptor;
 use tonic::{
@@ -18,7 +22,10 @@ use tonic::{
 
 use crate::{
     auth::DockerCredentials,
-    grpc::{build::ImageBuildFrontendOptionsIngest, BuildRef},
+    grpc::{
+        build::{ImageBuildFrontendOptionsIngest, SecretSource},
+        BuildRef, FileTransferLimits,
+    },
 };
 
 use super::{
@@ -176,6 +183,136 @@ pub enum ImageExporterEnum {
     Docker(ImageExporterRequest),
 }
 
+/// Exporter selection for a direct LLB definition solve.
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub enum DefinitionExporter {
+    /// Export the solved filesystem into a local directory.
+    Local(PathBuf),
+}
+
+/// Options for a direct LLB definition solve.
+#[derive(Debug, Clone, Default)]
+pub struct DefinitionSolveOptions {
+    cache_to: Vec<bollard_buildkit_proto::moby::buildkit::v1::CacheOptionsEntry>,
+    cache_from: Vec<bollard_buildkit_proto::moby::buildkit::v1::CacheOptionsEntry>,
+    credentials: HashMap<String, DockerCredentials>,
+    secrets: HashMap<String, SecretSource>,
+    ssh: bool,
+    timeout: Option<Duration>,
+    file_transfer_limits: FileTransferLimits,
+}
+
+/// Builder for direct LLB definition solve options.
+#[derive(Debug, Clone, Default)]
+pub struct DefinitionSolveOptionsBuilder {
+    options: DefinitionSolveOptions,
+}
+
+impl DefinitionSolveOptionsBuilder {
+    /// Construct empty direct-definition solve options.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Add a cache export configuration.
+    pub fn cache_to(
+        mut self,
+        cache: &bollard_buildkit_proto::moby::buildkit::v1::CacheOptionsEntry,
+    ) -> Self {
+        self.options.cache_to.push(cache.clone());
+        self
+    }
+
+    /// Add a cache import configuration.
+    pub fn cache_from(
+        mut self,
+        cache: &bollard_buildkit_proto::moby::buildkit::v1::CacheOptionsEntry,
+    ) -> Self {
+        self.options.cache_from.push(cache.clone());
+        self
+    }
+
+    /// Configure credentials for a registry host.
+    pub fn credential(mut self, host: impl Into<String>, credentials: DockerCredentials) -> Self {
+        self.options.credentials.insert(host.into(), credentials);
+        self
+    }
+
+    /// Expose a secret source under the given BuildKit secret ID.
+    pub fn secret(mut self, id: impl Into<String>, source: SecretSource) -> Self {
+        self.options.secrets.insert(id.into(), source);
+        self
+    }
+
+    /// Enable SSH agent forwarding for the solve.
+    pub fn enable_ssh(mut self, enable: bool) -> Self {
+        self.options.ssh = enable;
+        self
+    }
+
+    /// Set one wall-clock deadline for setup and the active solve.
+    pub fn timeout(mut self, timeout: Duration) -> Self {
+        self.options.timeout = Some(timeout);
+        self
+    }
+
+    /// Set aggregate packet-export transfer limits.
+    pub fn file_transfer_limits(mut self, limits: FileTransferLimits) -> Self {
+        self.options.file_transfer_limits = limits;
+        self
+    }
+
+    /// Consume the builder and return immutable solve options.
+    pub fn build(self) -> DefinitionSolveOptions {
+        self.options
+    }
+}
+
+/// A direct-definition solve request.
+#[derive(Debug, Clone)]
+pub struct DefinitionSolveRequest {
+    /// The pre-built LLB definition to solve.
+    pub definition: bollard_buildkit_proto::pb::Definition,
+    /// Where to export the result.
+    pub exporter: DefinitionExporter,
+    options: DefinitionSolveOptions,
+    build_ref: Option<BuildRef>,
+}
+
+impl DefinitionSolveRequest {
+    /// Construct a request for a definition and exporter.
+    pub fn new(
+        definition: bollard_buildkit_proto::pb::Definition,
+        exporter: DefinitionExporter,
+    ) -> Self {
+        Self {
+            definition,
+            exporter,
+            options: DefinitionSolveOptions::default(),
+            build_ref: None,
+        }
+    }
+
+    /// Set immutable solve options.
+    pub fn with_options(mut self, options: DefinitionSolveOptions) -> Self {
+        self.options = options;
+        self
+    }
+
+    /// Set the BuildKit build reference.
+    pub fn with_build_ref(mut self, build_ref: BuildRef) -> Self {
+        self.build_ref = Some(build_ref);
+        self
+    }
+}
+
+/// Trait for solving a pre-built LLB definition without a frontend.
+pub trait SolveDefinition {
+    /// Solve a direct LLB definition and export its result.
+    async fn solve_definition(&self, request: DefinitionSolveRequest) -> Result<(), GrpcError>;
+}
+
 /// Trait enabling container exports.
 pub trait Export {
     /// Export the container to a tar
@@ -328,8 +465,125 @@ pub(crate) async fn solve(
         solve_request,
         services,
         tear_down_handler,
+        None,
     )
     .await
+}
+
+pub(crate) async fn solve_definition(
+    driver: &impl Driver,
+    request: DefinitionSolveRequest,
+) -> Result<(), GrpcError> {
+    let session_id = crate::grpc::new_id();
+    let deadline = request
+        .options
+        .timeout
+        .map(|timeout| Instant::now() + timeout);
+
+    let DefinitionSolveRequest {
+        definition,
+        exporter,
+        options,
+        build_ref,
+    } = request;
+
+    let mut auth_provider = super::AuthProvider::new();
+    for (host, credentials) in options.credentials.clone() {
+        auth_provider.set_docker_credentials(&host, credentials);
+    }
+
+    let auth = AuthServer::new(auth_provider);
+    let secret = SecretsServer::new(super::SecretProvider::new(options.secrets.clone()))
+        .max_decoding_message_size(DEFAULT_MAX_RECV_MSG_SIZE)
+        .max_encoding_message_size(DEFAULT_MAX_SEND_MSG_SIZE);
+    let mut services = vec![GrpcServer::Auth(auth), GrpcServer::Secrets(secret)];
+
+    if options.ssh {
+        let ssh = SshServer::new(super::SshProvider::new())
+            .max_decoding_message_size(DEFAULT_MAX_RECV_MSG_SIZE)
+            .max_encoding_message_size(DEFAULT_MAX_SEND_MSG_SIZE);
+        services.push(GrpcServer::Ssh(ssh));
+    }
+
+    match &exporter {
+        DefinitionExporter::Local(path) => {
+            let filesend = FileSendPacketServer::new(super::FileSendPacketImpl::with_limits(
+                path,
+                options.file_transfer_limits,
+            ))
+            .max_decoding_message_size(DEFAULT_MAX_RECV_MSG_SIZE)
+            .max_encoding_message_size(DEFAULT_MAX_SEND_MSG_SIZE);
+            services.push(GrpcServer::FileSendPacket(filesend));
+        }
+    }
+
+    let tear_down_handler = driver.begin_solve()?;
+    let solve_request =
+        build_definition_solve_request(definition, &exporter, &options, &session_id, build_ref);
+
+    execute_solve(
+        driver,
+        &session_id,
+        solve_request,
+        services,
+        tear_down_handler,
+        deadline,
+    )
+    .await
+}
+
+fn build_definition_solve_request(
+    mut definition: bollard_buildkit_proto::pb::Definition,
+    exporter: &DefinitionExporter,
+    options: &DefinitionSolveOptions,
+    session_id: &str,
+    build_ref: Option<BuildRef>,
+) -> SolveRequest {
+    normalize_empty_source_locations(&mut definition);
+
+    let (exporter_type, exporter_attrs, exporters) = match exporter {
+        DefinitionExporter::Local(path) => {
+            let mut attrs = HashMap::new();
+            attrs.insert(String::from("dest"), path.to_string_lossy().to_string());
+            let exporters = vec![Exporter {
+                r#type: String::from("local"),
+                attrs: attrs.clone(),
+            }];
+            (String::from("local"), attrs, exporters)
+        }
+    };
+
+    SolveRequest {
+        r#ref: build_ref.unwrap_or_default().into(),
+        cache: Some(CacheOptions {
+            export_ref_deprecated: String::new(),
+            import_refs_deprecated: Vec::new(),
+            export_attrs_deprecated: HashMap::new(),
+            exports: options.cache_to.clone(),
+            imports: options.cache_from.clone(),
+        }),
+        definition: Some(definition),
+        entitlements: vec![],
+        exporter_deprecated: exporter_type,
+        exporter_attrs_deprecated: exporter_attrs,
+        frontend: String::new(),
+        frontend_attrs: HashMap::new(),
+        frontend_inputs: HashMap::new(),
+        session: String::from(session_id),
+        exporters,
+        internal: false,
+        source_policy: None,
+        enable_session_exporter: false,
+        source_policy_session: String::new(),
+    }
+}
+
+fn normalize_empty_source_locations(definition: &mut bollard_buildkit_proto::pb::Definition) {
+    if let Some(source) = definition.source.as_mut() {
+        source
+            .locations
+            .retain(|_, locations| !locations.locations.is_empty());
+    }
 }
 
 async fn execute_solve<D: Driver>(
@@ -338,12 +592,19 @@ async fn execute_solve<D: Driver>(
     request: SolveRequest,
     services: Vec<GrpcServer>,
     tear_down_handler: Box<dyn DriverTearDownHandler>,
+    deadline: Option<Instant>,
 ) -> Result<(), GrpcError> {
     let mut tear_down_guard = TearDownGuard::new(tear_down_handler);
-    let mut control_client = match driver.grpc_handle(session_id, services).await {
+    let mut control_client = match run_until(deadline, driver.grpc_handle(session_id, services))
+        .await
+    {
         Ok(client) => client
             .max_decoding_message_size(DEFAULT_MAX_RECV_MSG_SIZE)
             .max_encoding_message_size(DEFAULT_MAX_SEND_MSG_SIZE),
+        Err(error) if is_deadline_exceeded(&error) => {
+            drop(tear_down_guard);
+            return Err(error);
+        }
         Err(error) => {
             // A driver may have created resources before gRPC setup failed.
             if let Err(teardown_error) = tear_down_guard.tear_down().await {
@@ -354,7 +615,19 @@ async fn execute_solve<D: Driver>(
     };
 
     debug!("sending solve request: {:#?}", request);
-    let solve_result = control_client.solve(request).await.map_err(GrpcError::from);
+    let solve_result = match run_until(
+        deadline,
+        control_client.solve(request).map_err(GrpcError::from),
+    )
+    .await
+    {
+        Ok(_) => Ok(()),
+        Err(error) if is_deadline_exceeded(&error) => {
+            drop(tear_down_guard);
+            return Err(error);
+        }
+        Err(error) => Err(error),
+    };
     debug!("solve res: {:#?}", solve_result);
 
     let tear_down_result = tear_down_guard.tear_down().await;
@@ -369,6 +642,28 @@ async fn execute_solve<D: Driver>(
         }
         Ok(_) => tear_down_result,
     }
+}
+
+async fn run_until<F, T>(deadline: Option<Instant>, future: F) -> Result<T, GrpcError>
+where
+    F: std::future::Future<Output = Result<T, GrpcError>>,
+{
+    match deadline {
+        Some(deadline) => {
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            tokio::time::timeout(remaining, future)
+                .await
+                .map_err(|_| GrpcError::from(tonic::Status::deadline_exceeded("solve timed out")))?
+        }
+        None => future.await,
+    }
+}
+
+fn is_deadline_exceeded(error: &GrpcError) -> bool {
+    matches!(
+        error,
+        GrpcError::TonicStatus { err } if err.code() == tonic::Code::DeadlineExceeded
+    )
 }
 
 #[cfg(test)]
@@ -405,6 +700,7 @@ mod tests {
         setup_pending: bool,
         setup_panic: bool,
         session_ids: Arc<Mutex<Vec<String>>>,
+        service_names: Arc<Mutex<Vec<String>>>,
     }
 
     impl Driver for TestDriver {
@@ -418,6 +714,10 @@ mod tests {
                 .lock()
                 .expect("session IDs mutex is not poisoned")
                 .push(String::from(session_id));
+            self.service_names
+                .lock()
+                .expect("service names mutex is not poisoned")
+                .extend(_services.iter().flat_map(GrpcServer::names));
 
             if let Some(error) = &self.setup_error {
                 return Err(error.clone().into());
@@ -579,6 +879,7 @@ mod tests {
             setup_pending: false,
             setup_panic: false,
             session_ids: Arc::new(Mutex::new(Vec::new())),
+            service_names: Arc::new(Mutex::new(Vec::new())),
         }
     }
 
@@ -589,6 +890,7 @@ mod tests {
             setup_pending: false,
             setup_panic: false,
             session_ids: Arc::new(Mutex::new(Vec::new())),
+            service_names: Arc::new(Mutex::new(Vec::new())),
         }
     }
 
@@ -599,6 +901,7 @@ mod tests {
             setup_pending: true,
             setup_panic: false,
             session_ids: Arc::new(Mutex::new(Vec::new())),
+            service_names: Arc::new(Mutex::new(Vec::new())),
         }
     }
 
@@ -609,6 +912,7 @@ mod tests {
             setup_pending: false,
             setup_panic: true,
             session_ids: Arc::new(Mutex::new(Vec::new())),
+            service_names: Arc::new(Mutex::new(Vec::new())),
         }
     }
 
@@ -623,6 +927,81 @@ mod tests {
         }
     }
 
+    #[test]
+    fn definition_solve_request_has_definition_and_empty_frontend() {
+        let request = build_definition_solve_request(
+            bollard_buildkit_proto::pb::Definition::default(),
+            &DefinitionExporter::Local(PathBuf::from("/out")),
+            &DefinitionSolveOptions::default(),
+            "session-id",
+            None,
+        );
+
+        assert!(request.definition.is_some());
+        assert!(request.frontend.is_empty());
+        assert!(request.frontend_attrs.is_empty());
+        assert!(request.frontend_inputs.is_empty());
+        assert_eq!(request.exporter_deprecated, "local");
+        assert_eq!(request.exporters.len(), 1);
+        assert_eq!(request.exporters[0].r#type, "local");
+        assert_eq!(
+            request.exporters[0].attrs.get("dest"),
+            Some(&String::from("/out"))
+        );
+        assert_eq!(request.session, "session-id");
+    }
+
+    #[test]
+    fn definition_options_are_configured_through_builder() {
+        let cache = bollard_buildkit_proto::moby::buildkit::v1::CacheOptionsEntry {
+            r#type: String::from("local"),
+            attrs: HashMap::new(),
+        };
+        let options = DefinitionSolveOptionsBuilder::new()
+            .cache_to(&cache)
+            .cache_from(&cache)
+            .credential("registry.example", DockerCredentials::default())
+            .secret("token", SecretSource::Env(String::from("TOKEN")))
+            .enable_ssh(true)
+            .timeout(Duration::from_secs(3))
+            .file_transfer_limits(FileTransferLimits {
+                max_files: Some(2),
+                max_bytes: Some(8),
+            })
+            .build();
+
+        assert_eq!(options.cache_to.len(), 1);
+        assert_eq!(options.cache_from.len(), 1);
+        assert!(options.credentials.contains_key("registry.example"));
+        assert!(options.secrets.contains_key("token"));
+        assert!(options.ssh);
+        assert_eq!(options.timeout, Some(Duration::from_secs(3)));
+        assert_eq!(options.file_transfer_limits.max_files, Some(2));
+    }
+
+    #[tokio::test]
+    async fn definition_solve_registers_shared_services_without_upload() {
+        let driver = failing_test_driver();
+        let service_names = Arc::clone(&driver.service_names);
+        let request = DefinitionSolveRequest::new(
+            bollard_buildkit_proto::pb::Definition::default(),
+            DefinitionExporter::Local(PathBuf::from("/out")),
+        )
+        .with_options(
+            DefinitionSolveOptionsBuilder::new()
+                .enable_ssh(true)
+                .build(),
+        );
+
+        assert!(solve_definition(&driver, request).await.is_err());
+        let names = service_names.lock().unwrap();
+        assert!(names.iter().any(|name| name.contains("credentials")));
+        assert!(names.iter().any(|name| name.contains("GetSecret")));
+        assert!(names.iter().any(|name| name.contains("ForwardAgent")));
+        assert!(names.iter().any(|name| name.contains("diffcopy")));
+        assert!(!names.iter().any(|name| name.contains("upload")));
+    }
+
     #[tokio::test]
     async fn execute_solve_tears_down_after_setup_failure() {
         let calls = Arc::new(AtomicUsize::new(0));
@@ -632,6 +1011,7 @@ mod tests {
             SolveRequest::default(),
             Vec::new(),
             teardown(calls.clone(), Some(Status::aborted("teardown failed"))),
+            None,
         )
         .await;
 
@@ -650,6 +1030,7 @@ mod tests {
             SolveRequest::default(),
             Vec::new(),
             teardown(calls.clone(), Some(Status::aborted("teardown failed"))),
+            None,
         )
         .await;
         stop_test_server(shutdown_sender, handle).await;
@@ -668,6 +1049,7 @@ mod tests {
             SolveRequest::default(),
             Vec::new(),
             teardown(calls.clone(), Some(Status::aborted("teardown failed"))),
+            None,
         )
         .await;
         stop_test_server(shutdown_sender, handle).await;
@@ -686,6 +1068,7 @@ mod tests {
             SolveRequest::default(),
             Vec::new(),
             teardown(calls.clone(), None),
+            None,
         )
         .await;
         stop_test_server(shutdown_sender, handle).await;
@@ -725,6 +1108,26 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn solve_definition_reuses_a_driver_with_fresh_session_ids() {
+        let (address, shutdown_sender, handle) = start_test_server(None).await;
+        let driver = test_driver(address);
+        let session_ids = Arc::clone(&driver.session_ids);
+
+        for _ in 0..2 {
+            let request = DefinitionSolveRequest::new(
+                bollard_buildkit_proto::pb::Definition::default(),
+                DefinitionExporter::Local(PathBuf::from("/out")),
+            );
+            solve_definition(&driver, request).await.unwrap();
+        }
+
+        stop_test_server(shutdown_sender, handle).await;
+        let session_ids = session_ids.lock().unwrap();
+        assert_eq!(session_ids.len(), 2);
+        assert_ne!(session_ids[0], session_ids[1]);
+    }
+
+    #[tokio::test]
     async fn execute_solve_tears_down_after_cancellation() {
         let calls = Arc::new(AtomicUsize::new(0));
         let driver = pending_test_driver();
@@ -736,6 +1139,7 @@ mod tests {
                 SolveRequest::default(),
                 Vec::new(),
                 teardown(calls.clone(), None),
+                None,
             ),
         )
         .await;
@@ -749,6 +1153,26 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn execute_solve_returns_deadline_and_detaches_teardown() {
+        let calls = Arc::new(AtomicUsize::new(0));
+        let result = execute_solve(
+            &pending_test_driver(),
+            "session",
+            SolveRequest::default(),
+            Vec::new(),
+            teardown(calls.clone(), None),
+            Some(Instant::now() + Duration::from_millis(1)),
+        )
+        .await;
+
+        assert_eq!(status_code(result), tonic::Code::DeadlineExceeded);
+        for _ in 0..10 {
+            tokio::task::yield_now().await;
+        }
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
     async fn execute_solve_tears_down_after_panic() {
         let calls = Arc::new(AtomicUsize::new(0));
         let result = std::panic::AssertUnwindSafe(execute_solve(
@@ -757,6 +1181,7 @@ mod tests {
             SolveRequest::default(),
             Vec::new(),
             teardown(calls.clone(), None),
+            None,
         ))
         .catch_unwind()
         .await;

--- a/src/grpc/driver/mod.rs
+++ b/src/grpc/driver/mod.rs
@@ -1164,11 +1164,7 @@ mod tests {
         }
     }
 
-    async fn assert_teardown_timeout_case(
-        driver: &TestDriver,
-        deadline: Option<Instant>,
-        expected_code: tonic::Code,
-    ) {
+    async fn assert_teardown_timeout_case(driver: &TestDriver, deadline: Option<Instant>) {
         let calls = Arc::new(AtomicUsize::new(0));
         let started = Arc::new(Notify::new());
         let cancelled = Arc::new(AtomicBool::new(false));
@@ -1183,7 +1179,7 @@ mod tests {
         )
         .await;
 
-        assert_eq!(status_code(result), expected_code);
+        assert_eq!(status_code(result), tonic::Code::DeadlineExceeded);
         assert_eq!(calls.load(Ordering::SeqCst), 1);
         assert!(cancelled.load(Ordering::SeqCst));
     }
@@ -1207,7 +1203,6 @@ mod tests {
         assert_eq!(request.exporters.len(), 1);
         assert_eq!(request.exporters[0].r#type, "local");
         assert!(request.exporters[0].attrs.is_empty());
-        assert!(!format!("{request:?}").contains("/out"));
         assert_eq!(request.session, "session-id");
     }
 
@@ -1315,6 +1310,7 @@ mod tests {
         assert!(options.ssh);
         assert_eq!(options.timeout, Some(Duration::from_secs(3)));
         assert_eq!(options.file_transfer_limits.max_files, Some(2));
+        assert_eq!(options.file_transfer_limits.max_bytes, Some(8));
     }
 
     #[test]
@@ -1516,33 +1512,16 @@ mod tests {
     #[tokio::test]
     async fn execute_solve_awaits_teardown_after_setup_timeout() {
         let driver = pending_test_driver();
-        assert_teardown_timeout_case(
-            &driver,
-            Some(Instant::now() + Duration::from_millis(1)),
-            tonic::Code::DeadlineExceeded,
-        )
-        .await;
+        assert_teardown_timeout_case(&driver, Some(Instant::now() + Duration::from_millis(1)))
+            .await;
     }
 
     #[tokio::test]
     async fn execute_solve_awaits_teardown_after_solve_timeout() {
         let (address, shutdown_sender, handle) = start_pending_solve_server().await;
         let driver = test_driver(address);
-        assert_teardown_timeout_case(
-            &driver,
-            Some(Instant::now() + Duration::from_millis(25)),
-            tonic::Code::DeadlineExceeded,
-        )
-        .await;
-        stop_test_server(shutdown_sender, handle).await;
-    }
-
-    #[tokio::test]
-    async fn execute_solve_preserves_solve_error_over_teardown_timeout() {
-        let (address, shutdown_sender, handle) =
-            start_test_server(Some(Status::not_found("solve failed"))).await;
-        let driver = test_driver(address);
-        assert_teardown_timeout_case(&driver, None, tonic::Code::NotFound).await;
+        assert_teardown_timeout_case(&driver, Some(Instant::now() + Duration::from_millis(25)))
+            .await;
         stop_test_server(shutdown_sender, handle).await;
     }
 

--- a/src/grpc/mod.rs
+++ b/src/grpc/mod.rs
@@ -358,11 +358,9 @@ impl FileSendPacketImpl {
 
 /// Aggregate limits for one packet-based local export.
 #[derive(Clone, Copy, Debug, Default)]
-pub struct FileTransferLimits {
-    /// Maximum number of filesystem entries accepted in one transfer.
-    pub max_files: Option<u64>,
-    /// Maximum sum of declared entry sizes accepted in one transfer.
-    pub max_bytes: Option<u64>,
+pub(crate) struct FileTransferLimits {
+    max_files: Option<u64>,
+    max_bytes: Option<u64>,
 }
 
 const MAX_PATH_LENGTH: usize = 4096;
@@ -570,23 +568,30 @@ impl FileReceiveState {
     async fn receive_stat(&mut self, request_id: u32, stat: &Stat) -> Result<bool, Status> {
         let declared_size = u64::try_from(stat.size)
             .map_err(|_| Status::invalid_argument("file stat has a negative size"))?;
-        if let Some(max_files) = self.limits.max_files {
-            if self.file_count as u64 >= max_files {
-                return Err(Status::resource_exhausted(
-                    "file transfer exceeds the maximum entry count",
-                ));
-            }
+        if self
+            .limits
+            .max_files
+            .is_some_and(|max_files| self.file_count as u64 >= max_files)
+        {
+            return Err(Status::resource_exhausted(
+                "file transfer exceeds the maximum entry count",
+            ));
         }
-        if let Some(max_bytes) = self.limits.max_bytes {
-            let total = self
-                .total_size
-                .checked_add(declared_size)
-                .ok_or_else(|| Status::resource_exhausted("file transfer byte count overflow"))?;
-            if total > max_bytes {
-                return Err(Status::resource_exhausted(
-                    "file transfer exceeds the maximum byte count",
-                ));
-            }
+        let total = self.total_size.checked_add(declared_size).ok_or_else(|| {
+            Status::resource_exhausted(if self.limits.max_bytes.is_some() {
+                "file transfer byte count overflow"
+            } else {
+                "export size overflow"
+            })
+        })?;
+        if self
+            .limits
+            .max_bytes
+            .is_some_and(|max_bytes| total > max_bytes)
+        {
+            return Err(Status::resource_exhausted(
+                "file transfer exceeds the maximum byte count",
+            ));
         }
         if self.file_count >= MAX_FILE_COUNT {
             return Err(Status::resource_exhausted("too many files in export"));
@@ -599,10 +604,7 @@ impl FileReceiveState {
             )));
         }
 
-        self.total_size = self
-            .total_size
-            .checked_add(declared_size)
-            .ok_or_else(|| Status::resource_exhausted("export size overflow"))?;
+        self.total_size = total;
         if self.total_size > MAX_TOTAL_SIZE {
             return Err(Status::resource_exhausted(
                 "export exceeds the maximum size",
@@ -851,15 +853,15 @@ impl StagingGuard {
             .expect("staging guard owns a path before publication")
     }
 
-    async fn cleanup(&mut self) -> Result<(), Status> {
-        if let Some(staging) = self.staging.take() {
-            remove_path(&staging).await
-        } else {
-            Ok(())
-        }
+    async fn cleanup(mut self) -> Result<(), Status> {
+        let staging = self
+            .staging
+            .take()
+            .expect("staging guard owns a path before cleanup");
+        remove_path(&staging).await
     }
 
-    async fn publish(&mut self, destination: &Path) -> Result<(), Status> {
+    async fn publish(mut self, destination: &Path) -> Result<(), Status> {
         let staging = self
             .staging
             .take()
@@ -880,6 +882,31 @@ impl Drop for StagingGuard {
                 warn!("failed to clean up cancelled FileSend staging directory: {error}");
             }
         });
+    }
+}
+
+async fn prepare_file_receive_state(
+    destination: &Path,
+    limits: FileTransferLimits,
+) -> Result<(StagingGuard, FileReceiveState), Status> {
+    let staging_guard = StagingGuard::new(destination).await?;
+    let staging = staging_guard.path().to_owned();
+    match FileReceiveState::with_limits(staging, limits).await {
+        Ok(state) => Ok((staging_guard, state)),
+        Err(error) => {
+            if let Err(cleanup_error) = staging_guard.cleanup().await {
+                warn!("failed to clean up staging directory: {cleanup_error}");
+            }
+            Err(error)
+        }
+    }
+}
+
+async fn cleanup_staging_guard(guard: &mut Option<StagingGuard>, context: &str) {
+    if let Some(guard) = guard.take() {
+        if let Err(error) = guard.cleanup().await {
+            warn!("failed to clean up {context}: {error}");
+        }
     }
 }
 
@@ -985,32 +1012,13 @@ impl FileSendPacket for FileSendPacketImpl {
         // protocol reference: https://github.com/tonistiigi/fsutil/blob/91a3fc46842c58b62dd4630b688662842364da49/receive.go#L1-L15
         let out_stream = async_stream::try_stream! {
             debug!("starting FileSend packet export");
-            let mut staging_guard = StagingGuard::new(&destination).await?;
-            let staging = staging_guard.path().to_owned();
-            let mut state = Some(match FileReceiveState::with_limits(staging.clone(), limits).await {
-                Ok(state) => state,
-                Err(error) => {
-                    if let Err(cleanup_error) = staging_guard.cleanup().await {
-                        warn!("failed to clean up staging directory: {cleanup_error}");
-                    }
-                    Err::<FileReceiveState, Status>(error)?;
-                    unreachable!();
-                }
-            });
+            let (staging_guard, state) = prepare_file_receive_state(&destination, limits).await?;
+            let mut staging_guard = Some(staging_guard);
+            let mut state = Some(state);
 
-            let mut receiver_sent_fin = false;
             loop {
                 match in_stream.next().await {
                     Some(Ok(packet)) => {
-                        if receiver_sent_fin {
-                            if packet.r#type != PacketType::PacketFin as i32 {
-                                Err::<(), Status>(Status::failed_precondition(
-                                    "packet received after PACKET_FIN",
-                                    ))?;
-                            }
-                            break;
-                        }
-
                         let packet_result = state
                             .as_mut()
                             .expect("receiver state is present before PACKET_FIN")
@@ -1023,65 +1031,57 @@ impl FileSendPacket for FileSendPacketImpl {
                                         .take()
                                         .expect("receiver state is present before finalization");
                                     if let Err(error) = completed_state.finalize().await {
-                                        if let Err(cleanup_error) = staging_guard.cleanup().await {
-                                            warn!("failed to clean up unfinalized export: {cleanup_error}");
-                                        }
+                                        cleanup_staging_guard(&mut staging_guard, "unfinalized export")
+                                            .await;
                                         Err::<(), Status>(error)?;
                                     }
 
-                                    if let Err(error) = staging_guard.publish(&destination).await {
-                                        Err::<(), Status>(error)?;
-                                    }
-
-                                    receiver_sent_fin = true;
+                                    staging_guard
+                                        .take()
+                                        .expect("staging guard is armed before publication")
+                                        .publish(&destination)
+                                        .await?;
                                     yield out;
+
+                                    match in_stream.next().await {
+                                        Some(Ok(packet)) if packet.r#type == PacketType::PacketFin as i32 => {}
+                                        Some(Ok(_)) => {
+                                            Err::<(), Status>(Status::failed_precondition(
+                                                "packet received after PACKET_FIN",
+                                            ))?;
+                                        }
+                                        Some(Err(error)) => {
+                                            warn!("packet stream ended after export publish: {error}");
+                                        }
+                                        None => {
+                                            warn!("packet stream ended after export publish");
+                                        }
+                                    }
+                                    break;
                                 } else {
                                     yield out;
                                 }
                             }
                             Ok(None) => {}
                             Err(error) => {
-                                if let Err(cleanup_error) = staging_guard.cleanup().await {
-                                    warn!("failed to clean up failed export: {cleanup_error}");
-                                }
+                                cleanup_staging_guard(&mut staging_guard, "failed export").await;
                                 Err::<(), Status>(error)?;
                             }
                         }
                     }
                     Some(Err(error)) => {
-                        if receiver_sent_fin {
-                            warn!("packet stream ended after export publish: {error}");
-                            break;
-                        }
-                        if let Err(cleanup_error) = staging_guard.cleanup().await {
-                            warn!("failed to clean up failed export: {cleanup_error}");
-                        }
+                        cleanup_staging_guard(&mut staging_guard, "failed export").await;
                         Err::<(), Status>(Status::internal(format!("packet stream error: {error}")))?;
                     }
                     None => {
-                        if receiver_sent_fin {
-                            warn!("packet stream ended after export publish");
-                        } else {
-                            if let Err(cleanup_error) = staging_guard.cleanup().await {
-                                warn!("failed to clean up incomplete export: {cleanup_error}");
-                            }
-                            Err::<(), Status>(Status::failed_precondition(
-                                "file packet stream ended before PACKET_FIN",
-                            ))?;
-                        }
-                        break;
+                        cleanup_staging_guard(&mut staging_guard, "incomplete export").await;
+                        Err::<(), Status>(Status::failed_precondition(
+                            "file packet stream ended before PACKET_FIN",
+                        ))?;
                     }
                 }
             }
 
-            if !receiver_sent_fin {
-                if let Err(cleanup_error) = staging_guard.cleanup().await {
-                    warn!("failed to clean up incomplete export: {cleanup_error}");
-                }
-                Err::<(), Status>(Status::failed_precondition(
-                    "file packet stream ended before PACKET_FIN",
-                ))?;
-            }
             info!("published FileSend packet export");
         };
 
@@ -2139,37 +2139,6 @@ mod tests {
 
     #[tokio::test]
     async fn test_file_send_packet_grpc_cleans_staging_after_stream_cancellation() {
-        let root = tempfile::tempdir().unwrap();
-        let destination = root.path().join("output");
-        let (address, server_task) = start_file_send_server(destination).await;
-        let mut client = FileSendClient::connect(format!("http://{address}"))
-            .await
-            .unwrap();
-        let (sender, receiver) = mpsc::channel(1);
-        let response = client
-            .diff_copy(tokio_stream::wrappers::ReceiverStream::new(receiver))
-            .await
-            .unwrap();
-        let mut response_stream = response.into_inner();
-        let response_task =
-            tokio::spawn(async move { while response_stream.message().await.is_ok() {} });
-
-        sender
-            .send(packet_stat(Some(stat("partial", 0o600, 5, ""))))
-            .await
-            .unwrap();
-        wait_for_staging_siblings(root.path(), true).await;
-        response_task.abort();
-        let _ = response_task.await;
-        drop(sender);
-        wait_for_staging_siblings(root.path(), false).await;
-
-        server_task.abort();
-        let _ = server_task.await;
-    }
-
-    #[tokio::test]
-    async fn test_file_send_packet_grpc_cleans_partial_staging_after_stream_cancellation() {
         let root = tempfile::tempdir().unwrap();
         let destination = root.path().join("output");
         let (address, server_task) = start_file_send_server(destination).await;

--- a/src/grpc/mod.rs
+++ b/src/grpc/mod.rs
@@ -832,8 +832,59 @@ async fn prepare_staging_directory(destination: &Path) -> Result<PathBuf, Status
     Ok(staging)
 }
 
-async fn remove_path(path: &Path) -> Result<(), Status> {
-    let metadata = match fs::symlink_metadata(path).await {
+struct StagingGuard {
+    staging: Option<PathBuf>,
+    runtime: tokio::runtime::Handle,
+}
+
+impl StagingGuard {
+    async fn new(destination: &Path) -> Result<Self, Status> {
+        Ok(Self {
+            staging: Some(prepare_staging_directory(destination).await?),
+            runtime: tokio::runtime::Handle::current(),
+        })
+    }
+
+    fn path(&self) -> &Path {
+        self.staging
+            .as_deref()
+            .expect("staging guard owns a path before publication")
+    }
+
+    async fn cleanup(&mut self) -> Result<(), Status> {
+        if let Some(staging) = self.staging.take() {
+            remove_path(&staging).await
+        } else {
+            Ok(())
+        }
+    }
+
+    async fn publish(&mut self, destination: &Path) -> Result<(), Status> {
+        let staging = self
+            .staging
+            .take()
+            .expect("staging guard owns a path before publication");
+        publish_staging_directory(&staging, destination).await
+    }
+}
+
+impl Drop for StagingGuard {
+    fn drop(&mut self) {
+        let Some(staging) = self.staging.take() else {
+            return;
+        };
+
+        let runtime = self.runtime.clone();
+        runtime.spawn(async move {
+            if let Err(error) = remove_path(&staging).await {
+                warn!("failed to clean up cancelled FileSend staging directory: {error}");
+            }
+        });
+    }
+}
+
+fn remove_path_blocking(path: &Path) -> Result<(), Status> {
+    let metadata = match std::fs::symlink_metadata(path) {
         Ok(metadata) => metadata,
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
         Err(error) => {
@@ -843,55 +894,81 @@ async fn remove_path(path: &Path) -> Result<(), Status> {
         }
     };
     let result = if metadata.is_dir() && !metadata.file_type().is_symlink() {
-        fs::remove_dir_all(path).await
+        std::fs::remove_dir_all(path)
     } else {
-        fs::remove_file(path).await
+        std::fs::remove_file(path)
     };
     result.map_err(|error| Status::internal(format!("failed to clean up export path: {error}")))
 }
 
-async fn publish_staging_directory(staging: &Path, destination: &Path) -> Result<(), Status> {
-    let parent = destination.parent().unwrap_or_else(|| Path::new("."));
-    let name = destination
-        .file_name()
-        .ok_or_else(|| Status::invalid_argument("export destination has no filename"))?
-        .to_string_lossy();
-    let backup = parent.join(format!(".{name}.bollard-backup-{}", crate::grpc::new_id()));
-    let destination_exists = match fs::symlink_metadata(destination).await {
-        Ok(_) => true,
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => false,
-        Err(error) => {
-            return Err(Status::internal(format!(
-                "failed to inspect export destination: {error}"
-            )))
-        }
-    };
+async fn remove_path(path: &Path) -> Result<(), Status> {
+    let path = path.to_owned();
+    tokio::task::spawn_blocking(move || remove_path_blocking(&path))
+        .await
+        .map_err(|error| Status::internal(format!("filesystem cleanup worker failed: {error}")))?
+}
 
-    if destination_exists {
-        fs::rename(destination, &backup).await.map_err(|error| {
-            Status::internal(format!("failed to stage existing export: {error}"))
-        })?;
-    }
+fn publish_staging_directory_blocking(staging: &Path, destination: &Path) -> Result<(), Status> {
+    let result = (|| {
+        let parent = destination.parent().unwrap_or_else(|| Path::new("."));
+        let name = destination
+            .file_name()
+            .ok_or_else(|| Status::invalid_argument("export destination has no filename"))?
+            .to_string_lossy();
+        let backup = parent.join(format!(".{name}.bollard-backup-{}", crate::grpc::new_id()));
+        let destination_exists = match std::fs::symlink_metadata(destination) {
+            Ok(_) => true,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => false,
+            Err(error) => {
+                return Err(Status::internal(format!(
+                    "failed to inspect export destination: {error}"
+                )))
+            }
+        };
 
-    if let Err(error) = fs::rename(staging, destination).await {
         if destination_exists {
-            if let Err(rollback_error) = fs::rename(&backup, destination).await {
-                error!(
-                    "failed to publish export and roll back destination: publish={error}; rollback={rollback_error}"
-                );
+            std::fs::rename(destination, &backup).map_err(|error| {
+                Status::internal(format!("failed to stage existing export: {error}"))
+            })?;
+        }
+
+        if let Err(error) = std::fs::rename(staging, destination) {
+            if destination_exists {
+                if let Err(rollback_error) = std::fs::rename(&backup, destination) {
+                    error!(
+                        "failed to publish export and roll back destination: publish={error}; rollback={rollback_error}"
+                    );
+                }
+            }
+            return Err(Status::internal(format!(
+                "failed to publish export: {error}"
+            )));
+        }
+
+        if destination_exists {
+            if let Err(error) = remove_path_blocking(&backup) {
+                warn!("published export but failed to remove backup: {error}");
             }
         }
-        return Err(Status::internal(format!(
-            "failed to publish export: {error}"
-        )));
-    }
+        Ok(())
+    })();
 
-    if destination_exists {
-        if let Err(error) = remove_path(&backup).await {
-            warn!("published export but failed to remove backup: {error}");
+    if result.is_err() {
+        if let Err(cleanup_error) = remove_path_blocking(staging) {
+            warn!("failed to clean up unpublished export: {cleanup_error}");
         }
     }
-    Ok(())
+    result
+}
+
+async fn publish_staging_directory(staging: &Path, destination: &Path) -> Result<(), Status> {
+    let staging = staging.to_owned();
+    let destination = destination.to_owned();
+    tokio::task::spawn_blocking(move || publish_staging_directory_blocking(&staging, &destination))
+        .await
+        .map_err(|error| {
+            Status::internal(format!("filesystem publication worker failed: {error}"))
+        })?
 }
 
 #[tonic::async_trait]
@@ -908,11 +985,12 @@ impl FileSendPacket for FileSendPacketImpl {
         // protocol reference: https://github.com/tonistiigi/fsutil/blob/91a3fc46842c58b62dd4630b688662842364da49/receive.go#L1-L15
         let out_stream = async_stream::try_stream! {
             debug!("starting FileSend packet export");
-            let staging = prepare_staging_directory(&destination).await?;
+            let mut staging_guard = StagingGuard::new(&destination).await?;
+            let staging = staging_guard.path().to_owned();
             let mut state = Some(match FileReceiveState::with_limits(staging.clone(), limits).await {
                 Ok(state) => state,
                 Err(error) => {
-                    if let Err(cleanup_error) = remove_path(&staging).await {
+                    if let Err(cleanup_error) = staging_guard.cleanup().await {
                         warn!("failed to clean up staging directory: {cleanup_error}");
                     }
                     Err::<FileReceiveState, Status>(error)?;
@@ -945,16 +1023,13 @@ impl FileSendPacket for FileSendPacketImpl {
                                         .take()
                                         .expect("receiver state is present before finalization");
                                     if let Err(error) = completed_state.finalize().await {
-                                        if let Err(cleanup_error) = remove_path(&staging).await {
+                                        if let Err(cleanup_error) = staging_guard.cleanup().await {
                                             warn!("failed to clean up unfinalized export: {cleanup_error}");
                                         }
                                         Err::<(), Status>(error)?;
                                     }
 
-                                    if let Err(error) = publish_staging_directory(&staging, &destination).await {
-                                        if let Err(cleanup_error) = remove_path(&staging).await {
-                                            warn!("failed to clean up unpublished export: {cleanup_error}");
-                                        }
+                                    if let Err(error) = staging_guard.publish(&destination).await {
                                         Err::<(), Status>(error)?;
                                     }
 
@@ -966,7 +1041,7 @@ impl FileSendPacket for FileSendPacketImpl {
                             }
                             Ok(None) => {}
                             Err(error) => {
-                                if let Err(cleanup_error) = remove_path(&staging).await {
+                                if let Err(cleanup_error) = staging_guard.cleanup().await {
                                     warn!("failed to clean up failed export: {cleanup_error}");
                                 }
                                 Err::<(), Status>(error)?;
@@ -978,7 +1053,7 @@ impl FileSendPacket for FileSendPacketImpl {
                             warn!("packet stream ended after export publish: {error}");
                             break;
                         }
-                        if let Err(cleanup_error) = remove_path(&staging).await {
+                        if let Err(cleanup_error) = staging_guard.cleanup().await {
                             warn!("failed to clean up failed export: {cleanup_error}");
                         }
                         Err::<(), Status>(Status::internal(format!("packet stream error: {error}")))?;
@@ -987,7 +1062,7 @@ impl FileSendPacket for FileSendPacketImpl {
                         if receiver_sent_fin {
                             warn!("packet stream ended after export publish");
                         } else {
-                            if let Err(cleanup_error) = remove_path(&staging).await {
+                            if let Err(cleanup_error) = staging_guard.cleanup().await {
                                 warn!("failed to clean up incomplete export: {cleanup_error}");
                             }
                             Err::<(), Status>(Status::failed_precondition(
@@ -1000,7 +1075,7 @@ impl FileSendPacket for FileSendPacketImpl {
             }
 
             if !receiver_sent_fin {
-                if let Err(cleanup_error) = remove_path(&staging).await {
+                if let Err(cleanup_error) = staging_guard.cleanup().await {
                     warn!("failed to clean up incomplete export: {cleanup_error}");
                 }
                 Err::<(), Status>(Status::failed_precondition(
@@ -1751,13 +1826,14 @@ mod tests {
     #[cfg(unix)]
     use std::os::unix::fs::MetadataExt;
     use std::path::{Path, PathBuf};
+    use std::time::Duration;
 
     use bollard_buildkit_proto::fsutil::types::packet::PacketType;
     use bollard_buildkit_proto::fsutil::types::{Packet, Stat};
     use bollard_buildkit_proto::moby::filesync::packet::file_send_client::FileSendClient;
     use bollard_buildkit_proto::moby::sshforward::v1::ssh_server::Ssh;
     use bollard_buildkit_proto::moby::sshforward::v1::CheckAgentRequest;
-    use tokio::net::TcpListener;
+    use tokio::{net::TcpListener, sync::mpsc};
     use tokio_stream::wrappers::TcpListenerStream;
     use tonic::metadata::MetadataMap;
     use tonic::transport::Server;
@@ -1838,6 +1914,19 @@ mod tests {
             .map(|entry| entry.unwrap().file_name().to_string_lossy().into_owned())
             .filter(|name| name.contains(".bollard-staging-") || name.contains(".bollard-backup-"))
             .collect()
+    }
+
+    async fn wait_for_staging_siblings(root: &Path, expected: bool) {
+        tokio::time::timeout(Duration::from_secs(1), async {
+            loop {
+                if !transfer_sibling_names(root).is_empty() == expected {
+                    break;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("FileSend staging state became observable");
     }
 
     #[test]
@@ -2046,6 +2135,69 @@ mod tests {
             b"old"
         );
         assert!(transfer_sibling_names(root.path()).is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_file_send_packet_grpc_cleans_staging_after_stream_cancellation() {
+        let root = tempfile::tempdir().unwrap();
+        let destination = root.path().join("output");
+        let (address, server_task) = start_file_send_server(destination).await;
+        let mut client = FileSendClient::connect(format!("http://{address}"))
+            .await
+            .unwrap();
+        let (sender, receiver) = mpsc::channel(1);
+        let response = client
+            .diff_copy(tokio_stream::wrappers::ReceiverStream::new(receiver))
+            .await
+            .unwrap();
+        let mut response_stream = response.into_inner();
+        let response_task =
+            tokio::spawn(async move { while response_stream.message().await.is_ok() {} });
+
+        sender
+            .send(packet_stat(Some(stat("partial", 0o600, 5, ""))))
+            .await
+            .unwrap();
+        wait_for_staging_siblings(root.path(), true).await;
+        response_task.abort();
+        let _ = response_task.await;
+        drop(sender);
+        wait_for_staging_siblings(root.path(), false).await;
+
+        server_task.abort();
+        let _ = server_task.await;
+    }
+
+    #[tokio::test]
+    async fn test_file_send_packet_grpc_cleans_partial_staging_after_stream_cancellation() {
+        let root = tempfile::tempdir().unwrap();
+        let destination = root.path().join("output");
+        let (address, server_task) = start_file_send_server(destination).await;
+        let mut client = FileSendClient::connect(format!("http://{address}"))
+            .await
+            .unwrap();
+        let (sender, receiver) = mpsc::channel(1);
+        let response = client
+            .diff_copy(tokio_stream::wrappers::ReceiverStream::new(receiver))
+            .await
+            .unwrap();
+        let mut response_stream = response.into_inner();
+        let response_task =
+            tokio::spawn(async move { while response_stream.message().await.is_ok() {} });
+
+        sender
+            .send(packet_stat(Some(stat("partial", 0o600, 5, ""))))
+            .await
+            .unwrap();
+        sender.send(packet_data(0, b"hi")).await.unwrap();
+        wait_for_staging_siblings(root.path(), true).await;
+        response_task.abort();
+        let _ = response_task.await;
+        drop(sender);
+        wait_for_staging_siblings(root.path(), false).await;
+
+        server_task.abort();
+        let _ = server_task.await;
     }
 
     #[tokio::test]

--- a/src/grpc/mod.rs
+++ b/src/grpc/mod.rs
@@ -284,12 +284,18 @@ impl FileSend for FileSendImpl {
 #[derive(Clone, Debug)]
 pub(crate) struct FileSendPacketImpl {
     pub(crate) dest: PathBuf,
+    pub(crate) limits: FileTransferLimits,
 }
 
 impl FileSendPacketImpl {
     pub fn new(dest: &Path) -> Self {
+        Self::with_limits(dest, FileTransferLimits::default())
+    }
+
+    pub(crate) fn with_limits(dest: &Path, limits: FileTransferLimits) -> Self {
         Self {
             dest: dest.to_owned(),
+            limits,
         }
     }
 
@@ -350,6 +356,15 @@ impl FileSendPacketImpl {
     }
 }
 
+/// Aggregate limits for one packet-based local export.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct FileTransferLimits {
+    /// Maximum number of filesystem entries accepted in one transfer.
+    pub max_files: Option<u64>,
+    /// Maximum sum of declared entry sizes accepted in one transfer.
+    pub max_bytes: Option<u64>,
+}
+
 const MAX_PATH_LENGTH: usize = 4096;
 const MAX_LINKNAME_LENGTH: usize = 4096;
 const MAX_FILE_COUNT: usize = 100_000;
@@ -367,6 +382,7 @@ struct FileReceiveState {
     next_stat_id: u32,
     file_count: usize,
     total_size: u64,
+    limits: FileTransferLimits,
 }
 
 struct PendingFile {
@@ -377,6 +393,10 @@ struct PendingFile {
 
 impl FileReceiveState {
     async fn new(base: PathBuf) -> Result<Self, Status> {
+        Self::with_limits(base, FileTransferLimits::default()).await
+    }
+
+    async fn with_limits(base: PathBuf, limits: FileTransferLimits) -> Result<Self, Status> {
         let root = tokio::task::spawn_blocking(move || {
             cap_std::fs::Dir::open_ambient_dir(&base, cap_std::ambient_authority())
         })
@@ -400,6 +420,7 @@ impl FileReceiveState {
             next_stat_id: 0,
             file_count: 0,
             total_size: 0,
+            limits,
         })
     }
 
@@ -547,6 +568,26 @@ impl FileReceiveState {
     }
 
     async fn receive_stat(&mut self, request_id: u32, stat: &Stat) -> Result<bool, Status> {
+        let declared_size = u64::try_from(stat.size)
+            .map_err(|_| Status::invalid_argument("file stat has a negative size"))?;
+        if let Some(max_files) = self.limits.max_files {
+            if self.file_count as u64 >= max_files {
+                return Err(Status::resource_exhausted(
+                    "file transfer exceeds the maximum entry count",
+                ));
+            }
+        }
+        if let Some(max_bytes) = self.limits.max_bytes {
+            let total = self
+                .total_size
+                .checked_add(declared_size)
+                .ok_or_else(|| Status::resource_exhausted("file transfer byte count overflow"))?;
+            if total > max_bytes {
+                return Err(Status::resource_exhausted(
+                    "file transfer exceeds the maximum byte count",
+                ));
+            }
+        }
         if self.file_count >= MAX_FILE_COUNT {
             return Err(Status::resource_exhausted("too many files in export"));
         }
@@ -558,11 +599,9 @@ impl FileReceiveState {
             )));
         }
 
-        let size = u64::try_from(stat.size)
-            .map_err(|_| Status::invalid_argument("file stat has a negative size"))?;
         self.total_size = self
             .total_size
-            .checked_add(size)
+            .checked_add(declared_size)
             .ok_or_else(|| Status::resource_exhausted("export size overflow"))?;
         if self.total_size > MAX_TOTAL_SIZE {
             return Err(Status::resource_exhausted(
@@ -863,13 +902,14 @@ impl FileSendPacket for FileSendPacketImpl {
         request: Request<Streaming<Packet>>,
     ) -> Result<Response<Self::DiffCopyStream>, Status> {
         let destination = self.dest.clone();
+        let limits = self.limits;
         let mut in_stream = request.into_inner();
 
         // protocol reference: https://github.com/tonistiigi/fsutil/blob/91a3fc46842c58b62dd4630b688662842364da49/receive.go#L1-L15
         let out_stream = async_stream::try_stream! {
             debug!("starting FileSend packet export");
             let staging = prepare_staging_directory(&destination).await?;
-            let mut state = Some(match FileReceiveState::new(staging.clone()).await {
+            let mut state = Some(match FileReceiveState::with_limits(staging.clone(), limits).await {
                 Ok(state) => state,
                 Err(error) => {
                     if let Err(cleanup_error) = remove_path(&staging).await {
@@ -1726,7 +1766,8 @@ mod tests {
     use super::build::ImageBuildSessionProviders;
     use super::{
         fs, fsutil, prepare_staging_directory, publish_staging_directory, FileReceiveState,
-        FileSendPacketImpl, FileSendPacketServer, SshAgentSource, SshProvider, MAX_FILE_SIZE,
+        FileSendPacketImpl, FileSendPacketServer, FileTransferLimits, SshAgentSource, SshProvider,
+        MAX_FILE_SIZE,
     };
 
     fn packet_stat(stat: Option<Stat>) -> Packet {
@@ -1810,6 +1851,45 @@ mod tests {
         for path in ["", ".", "..", "../escape", "/absolute", "foo/../bar"] {
             assert!(FileSendPacketImpl::validate_path(path).is_err(), "{path:?}");
         }
+    }
+
+    #[tokio::test]
+    async fn test_file_receive_state_enforces_transfer_limits() {
+        let root = tempfile::tempdir().unwrap();
+        let mut state = FileReceiveState::with_limits(
+            root.path().to_path_buf(),
+            FileTransferLimits {
+                max_files: Some(1),
+                max_bytes: Some(4),
+            },
+        )
+        .await
+        .unwrap();
+
+        state
+            .handle_packet(packet_stat(Some(stat("first", 0o644, 4, ""))))
+            .await
+            .unwrap();
+        let error = state
+            .handle_packet(packet_stat(Some(stat("second", 0o644, 0, ""))))
+            .await
+            .unwrap_err();
+        assert!(error.message().contains("maximum entry count"));
+
+        let mut state = FileReceiveState::with_limits(
+            root.path().to_path_buf(),
+            FileTransferLimits {
+                max_files: None,
+                max_bytes: Some(3),
+            },
+        )
+        .await
+        .unwrap();
+        let error = state
+            .handle_packet(packet_stat(Some(stat("too-large", 0o644, 4, ""))))
+            .await
+            .unwrap_err();
+        assert!(error.message().contains("maximum byte count"));
     }
 
     #[cfg(unix)]

--- a/tests/image_test.rs
+++ b/tests/image_test.rs
@@ -996,22 +996,27 @@ async fn build_buildkit_named_context_test(docker: Docker) -> Result<(), Error> 
 }
 
 #[cfg(all(feature = "buildkit", feature = "test_sshforward"))]
-async fn build_buildkit_ssh_test(docker: Docker) -> Result<(), Error> {
-    let git_host = std::env::var("GIT_HTTP_HOST").unwrap_or_else(|_| "localhost".to_string());
-    let git_port = std::env::var("GIT_HTTP_PORT").unwrap_or_else(|_| "2222".to_string());
-    let dockerfile = format!(
+fn buildkit_ssh_dockerfile(git_host: &str, git_port: &str, agent_id: Option<&str>) -> String {
+    let mount = agent_id.map_or("--mount=type=ssh".to_string(), |id| {
+        format!("--mount=type=ssh,id={id}")
+    });
+    format!(
         "FROM {}alpine as builder1
 RUN apk add --no-cache openssh-client git netcat-openbsd
 RUN mkdir -p -m 0600 ~/.ssh && ssh-keyscan -t rsa -p {} {} >> ~/.ssh/known_hosts
-RUN --mount=type=ssh git clone ssh://git@{}:{}/srv/git/config.git /config
+RUN {} git clone ssh://git@{}:{}/srv/git/config.git /config
 ",
-        &registry_http_addr(),
-        &git_port,
-        &git_host,
-        &git_host,
-        &git_port,
-    );
+        registry_http_addr(),
+        git_port,
+        git_host,
+        mount,
+        git_host,
+        git_port,
+    )
+}
 
+#[cfg(all(feature = "buildkit", feature = "test_sshforward"))]
+fn compressed_dockerfile(dockerfile: &str) -> bytes::Bytes {
     let mut header = tar::Header::new_gnu();
     header.set_path("Dockerfile").unwrap();
     header.set_size(dockerfile.len() as u64);
@@ -1021,9 +1026,64 @@ RUN --mount=type=ssh git clone ssh://git@{}:{}/srv/git/config.git /config
     tar.append(&header, dockerfile.as_bytes()).unwrap();
 
     let uncompressed = tar.into_inner().unwrap();
-    let mut c = flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::default());
-    c.write_all(&uncompressed).unwrap();
-    let compressed = c.finish().unwrap();
+    let mut encoder = flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::default());
+    encoder.write_all(&uncompressed).unwrap();
+    bytes::Bytes::from(encoder.finish().unwrap())
+}
+
+#[cfg(all(feature = "buildkit", feature = "test_sshforward"))]
+fn ssh_registry_credentials() -> bollard::auth::DockerCredentials {
+    bollard::auth::DockerCredentials {
+        username: Some("bollard".to_string()),
+        password: std::env::var("REGISTRY_PASSWORD").ok(),
+        ..Default::default()
+    }
+}
+
+#[cfg(all(feature = "buildkit", feature = "test_sshforward"))]
+async fn assert_buildkit_ssh_image(docker: &Docker, name: &str) -> Result<(), Error> {
+    let _ = &docker
+        .create_container(
+            Some(CreateContainerOptions {
+                name: Some(name.to_string()),
+                ..Default::default()
+            }),
+            ContainerCreateBody {
+                image: Some(name.to_string()),
+                cmd: Some(["ls", "/config"].iter().map(|s| s.to_string()).collect()),
+                ..Default::default()
+            },
+        )
+        .await?;
+
+    let _ = &docker
+        .start_container(name, None::<StartContainerOptions>)
+        .await?;
+    let results = &docker
+        .wait_container(name, None::<WaitContainerOptions>)
+        .try_collect::<Vec<_>>()
+        .await?;
+    let first = results.first().unwrap();
+    if let Some(error) = &first.error {
+        println!("{}", error.message.as_ref().unwrap());
+    }
+    assert_eq!(first.status_code, 0);
+
+    let _ = &docker
+        .remove_container(name, None::<RemoveContainerOptions>)
+        .await?;
+    let _ = &docker
+        .remove_image(name, None::<RemoveImageOptions>, None)
+        .await?;
+
+    Ok(())
+}
+
+#[cfg(all(feature = "buildkit", feature = "test_sshforward"))]
+async fn build_buildkit_ssh_test(docker: Docker) -> Result<(), Error> {
+    let git_host = std::env::var("GIT_HTTP_HOST").unwrap_or_else(|_| "localhost".to_string());
+    let git_port = std::env::var("GIT_HTTP_PORT").unwrap_or_else(|_| "2222".to_string());
+    let compressed = compressed_dockerfile(&buildkit_ssh_dockerfile(&git_host, &git_port, None));
 
     let name = "integration_test_build_buildkit_ssh";
 
@@ -1038,78 +1098,68 @@ RUN --mount=type=ssh git clone ssh://git@{}:{}/srv/git/config.git /config
 
     let driver = bollard::grpc::driver::moby::Moby::new(&docker);
 
-    let load_input =
-        bollard::grpc::build::ImageBuildLoadInput::Upload(bytes::Bytes::from(compressed));
-
-    let credentials = bollard::auth::DockerCredentials {
-        username: Some("bollard".to_string()),
-        password: std::env::var("REGISTRY_PASSWORD").ok(),
-        ..Default::default()
-    };
-    let mut creds_hsh = std::collections::HashMap::new();
-    creds_hsh.insert("localhost:5000", credentials);
+    let load_input = bollard::grpc::build::ImageBuildLoadInput::Upload(compressed);
 
     let res = bollard::grpc::driver::Build::docker_build(
         &driver,
         name,
         frontend_opts,
         load_input,
-        Some(creds_hsh),
+        Some(HashMap::from([(
+            "localhost:5000",
+            ssh_registry_credentials(),
+        )])),
         None,
     )
     .await;
 
     assert!(res.is_ok());
+    assert_buildkit_ssh_image(&docker, name).await?;
 
-    let _ = &docker
-        .create_container(
-            Some(CreateContainerOptions {
-                name: Some("integration_test_build_buildkit_ssh".to_string()),
-                ..Default::default()
-            }),
-            ContainerCreateBody {
-                image: Some("integration_test_build_buildkit_ssh".to_string()),
-                cmd: Some(["ls", "/config"].iter().map(|s| s.to_string()).collect()),
-                ..Default::default()
-            },
+    Ok(())
+}
+
+#[cfg(all(feature = "buildkit", feature = "test_sshforward"))]
+async fn build_buildkit_named_ssh_test(docker: Docker) -> Result<(), Error> {
+    use bollard::grpc::build::ImageBuildSessionProviders;
+    use bollard::grpc::SshAgentSource;
+
+    let git_host = std::env::var("GIT_HTTP_HOST").unwrap_or_else(|_| "localhost".to_string());
+    let git_port = std::env::var("GIT_HTTP_PORT").unwrap_or_else(|_| "2222".to_string());
+    let name = "integration_test_build_buildkit_ssh_named";
+    let session = "integration_test_build_buildkit_ssh_named_session";
+    let compressed = compressed_dockerfile(&buildkit_ssh_dockerfile(
+        &git_host,
+        &git_port,
+        Some("deploy"),
+    ));
+    let socket =
+        std::env::var_os("SSH_AUTH_SOCK").expect("SSH_AUTH_SOCK is set by test_sshforward");
+    let providers = ImageBuildSessionProviders::default()
+        .set_ssh_agent("deploy", &SshAgentSource::Socket(socket.into()));
+    let options = BuildImageOptionsBuilder::default()
+        .dockerfile("Dockerfile")
+        .t(name)
+        .pull("true")
+        .version(BuilderVersion::BuilderBuildKit)
+        .rm(true)
+        .session(session)
+        .build();
+
+    let result = docker
+        .build_image_with_session_providers(
+            options,
+            Some(HashMap::from([(
+                String::from("localhost:5000"),
+                ssh_registry_credentials(),
+            )])),
+            Some(body_full(compressed)),
+            providers,
         )
-        .await?;
-
-    let _ = &docker
-        .start_container(
-            "integration_test_build_buildkit_ssh",
-            None::<StartContainerOptions>,
-        )
-        .await?;
-
-    let vec = &docker
-        .wait_container(
-            "integration_test_build_buildkit_ssh",
-            None::<WaitContainerOptions>,
-        )
-        .try_collect::<Vec<_>>()
-        .await?;
-
-    let first = vec.first().unwrap();
-    if let Some(error) = &first.error {
-        println!("{}", error.message.as_ref().unwrap());
-    }
-    assert_eq!(first.status_code, 0);
-
-    let _ = &docker
-        .remove_container(
-            "integration_test_build_buildkit_ssh",
-            None::<RemoveContainerOptions>,
-        )
-        .await?;
-
-    let _ = &docker
-        .remove_image(
-            "integration_test_build_buildkit_ssh",
-            None::<RemoveImageOptions>,
-            None,
-        )
-        .await?;
+        .try_collect::<Vec<bollard::models::BuildInfo>>()
+        .await;
+    assert!(result.is_ok());
+    assert_buildkit_ssh_image(&docker, name).await?;
 
     Ok(())
 }
@@ -1901,6 +1951,12 @@ fn integration_test_build_buildkit_named_context() {
 #[cfg(all(feature = "buildkit", feature = "test_sshforward"))]
 fn integration_test_build_buildkit_ssh() {
     connect_to_docker_and_run!(build_buildkit_ssh_test);
+}
+
+#[test]
+#[cfg(all(feature = "buildkit", feature = "test_sshforward"))]
+fn integration_test_build_buildkit_ssh_named() {
+    connect_to_docker_and_run!(build_buildkit_named_ssh_test);
 }
 
 #[test]

--- a/tests/llb_solve_test.rs
+++ b/tests/llb_solve_test.rs
@@ -1,0 +1,126 @@
+#![cfg(feature = "buildkit")]
+
+use bollard::errors::Error;
+use bollard::grpc::driver::docker_container::DockerContainerBuilder;
+use bollard::grpc::driver::{DefinitionExporter, DefinitionSolveRequest, SolveDefinition};
+use bollard::Docker;
+use bollard_buildkit_proto::pb;
+use prost::Message;
+use std::time::{SystemTime, UNIX_EPOCH};
+use tokio::runtime::Runtime;
+
+#[macro_use]
+pub mod common;
+use crate::common::*;
+
+const MINIMAL_MKFILE_DEFINITION_HEX: &str = concat!(
+    "0a3b5a002237123508ffffffffffffffffff0110ffffffffffffffffff01",
+    "2a1d0a062f68656c6c6f10a4031a05776f726c6428ffffffffffffffffff",
+    "010a4b0a490a477368613235363a63636433313636376132333330393365",
+    "333431633432393437336261316264393635653433353535343361663630",
+    "613932343562303535363163656265623066126a0a477368613235363a62",
+    "323437643630373064333566646134303730616535343261653235656633",
+    "626637313835326264633163653635613431366133653764393334363834",
+    "623361121f2a0c0a08706c6174666f726d10012a0f0a0b636f6e73747261",
+    "696e74731001125a0a477368613235363a63636433313636376132333330",
+    "393365333431633432393437336261316264393635653433353535343361",
+    "663630613932343562303535363163656265623066120f2a0d0a0966696c",
+    "652e6261736510011a4d0a4b0a477368613235363a636364333136363761",
+    "323333303933653334316334323934373362613162643936356534333535",
+    "353433616636306139323435623035353631636562656230661200"
+);
+
+fn minimal_mkfile_definition() -> pb::Definition {
+    let bytes = (0..MINIMAL_MKFILE_DEFINITION_HEX.len())
+        .step_by(2)
+        .map(|index| {
+            u8::from_str_radix(&MINIMAL_MKFILE_DEFINITION_HEX[index..index + 2], 16)
+                .expect("minimal definition hex is valid")
+        })
+        .collect::<Vec<_>>();
+    pb::Definition::decode(bytes.as_slice()).expect("minimal definition is valid protobuf")
+}
+
+fn unique_builder_name() -> String {
+    let suffix = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system clock is before the Unix epoch")
+        .as_nanos();
+    format!("bollard_llb_gate_e_{suffix}")
+}
+
+async fn direct_definition_solve_test(docker: Docker) -> Result<(), Error> {
+    let name = unique_builder_name();
+    let volume_name = format!("{name}_state");
+    let first_output = tempfile::tempdir()?;
+    let second_output = tempfile::tempdir()?;
+
+    let result = async {
+        let mut builder = DockerContainerBuilder::new(&docker);
+        builder.name(&name);
+        let driver = builder.bootstrap().await.map_err(|error| Error::IOError {
+            err: std::io::Error::other(format!("BuildKit bootstrap failed: {error}")),
+        })?;
+
+        let definition = minimal_mkfile_definition();
+        for output in [first_output.path(), second_output.path()] {
+            let request = DefinitionSolveRequest::new(
+                definition.clone(),
+                DefinitionExporter::Local(output.to_path_buf()),
+            );
+            SolveDefinition::solve_definition(&driver, request)
+                .await
+                .map_err(|error| Error::IOError {
+                    err: std::io::Error::other(format!("direct definition solve failed: {error}")),
+                })?;
+
+            assert_eq!(std::fs::read(output.join("hello"))?, b"world");
+        }
+
+        let container = docker.inspect_container(driver.name(), None).await?;
+        let expected_container_name = format!("/{name}");
+        assert_eq!(
+            container.name.as_deref(),
+            Some(expected_container_name.as_str())
+        );
+        assert_eq!(docker.inspect_volume(&volume_name).await?.name, volume_name);
+        Ok::<(), Error>(())
+    }
+    .await;
+
+    let _ = driver_cleanup(&docker, &name, &volume_name).await;
+    result
+}
+
+async fn driver_cleanup(docker: &Docker, name: &str, volume_name: &str) -> Result<(), Error> {
+    use bollard::query_parameters::{RemoveContainerOptionsBuilder, RemoveVolumeOptionsBuilder};
+
+    let _ = docker
+        .remove_container(
+            name,
+            Some(RemoveContainerOptionsBuilder::default().force(true).build()),
+        )
+        .await;
+    let _ = docker
+        .remove_volume(
+            volume_name,
+            Some(RemoveVolumeOptionsBuilder::default().build()),
+        )
+        .await;
+    Ok(())
+}
+
+#[test]
+#[cfg(feature = "buildkit_providerless")]
+fn integration_test_direct_definition_solve() {
+    connect_to_docker_and_run!(direct_definition_solve_test);
+}
+
+#[test]
+fn direct_definition_request_accepts_known_valid_protobuf() {
+    let request = DefinitionSolveRequest::new(
+        minimal_mkfile_definition(),
+        DefinitionExporter::Local(std::path::PathBuf::from("/tmp/output")),
+    );
+    assert_eq!(request.definition.def.len(), 2);
+}

--- a/tests/llb_solve_test.rs
+++ b/tests/llb_solve_test.rs
@@ -115,12 +115,3 @@ async fn driver_cleanup(docker: &Docker, name: &str, volume_name: &str) -> Resul
 fn integration_test_direct_definition_solve() {
     connect_to_docker_and_run!(direct_definition_solve_test);
 }
-
-#[test]
-fn direct_definition_request_accepts_known_valid_protobuf() {
-    let request = DefinitionSolveRequest::new(
-        minimal_mkfile_definition(),
-        DefinitionExporter::Local(std::path::PathBuf::from("/tmp/output")),
-    );
-    assert_eq!(request.definition.def.len(), 2);
-}


### PR DESCRIPTION
## Summary

- Add an API to solve a `pb::Definition` without a frontend.
- Support `BuildkitDaemon` and `DockerContainer`.
- Support local export, cache, credentials, secrets, SSH, build references, timeouts, and transfer limits.
- Use the existing session lifecycle with bounded cleanup.
- Redact sensitive data from debug output.
- Add unit and integration tests.

## Scope

This change adds direct solve support. It does not add local-source FileSync or LLB graph construction.